### PR TITLE
draft: implement Feed and cookie login through auth folder

### DIFF
--- a/aspx/wwwroot/Default.aspx
+++ b/aspx/wwwroot/Default.aspx
@@ -26,19 +26,24 @@
    
     public string getAuthenticatedUser() {
         HttpCookie authCookie = HttpContext.Current.Request.Cookies[".ASPXAUTH"];
-        if(authCookie == null ) return "";
-        FormsAuthenticationTicket authTicket = FormsAuthentication.Decrypt(authCookie.Value);
-        if(authTicket==null) {
+        if(authCookie == null || authCookie.Value == "") return "";
+        try {
+            // Decrypt may throw an exception if authCookie.Value is total gargbage
+            FormsAuthenticationTicket authTicket = FormsAuthentication.Decrypt(authCookie.Value);
+            if(authTicket==null) {
+                return "";
+            }
+            return authTicket.Name;
+        }
+        catch {
             return "";
         }
-        return authTicket.Name;
     }
 </script>
 <%
-<%
   string authUser = getAuthenticatedUser();
   if(authUser=="") {
-     Response.Redirect("auth/login.aspx?ReturnUrl=../");
+     Response.Redirect("auth/login.aspx?ReturnUrl="+Uri.EscapeUriString(HttpContext.Current.Request.Url.AbsolutePath));
   }
   else {
 %>

--- a/aspx/wwwroot/Default.aspx
+++ b/aspx/wwwroot/Default.aspx
@@ -23,8 +23,25 @@
         GetRDPvalue = theName.Replace("|", "");
         return GetRDPvalue;
     }
+   
+    public string getAuthenticatedUser() {
+        HttpCookie authCookie = HttpContext.Current.Request.Cookies[".ASPXAUTH"];
+        if(authCookie == null ) return "";
+        FormsAuthenticationTicket authTicket = FormsAuthentication.Decrypt(authCookie.Value);
+        if(authTicket==null) {
+            return "";
+        }
+        return authTicket.Name;
+    }
 </script>
-
+<%
+<%
+  string authUser = getAuthenticatedUser();
+  if(authUser=="") {
+     Response.Redirect("auth/login.aspx?ReturnUrl=../");
+  }
+  else {
+%>
 <html>
 <head>
 <title>
@@ -101,3 +118,6 @@ font-family:Arial,sans-serif;
 %>
 </body>
 </html>
+<%
+  }
+%>

--- a/aspx/wwwroot/Web.config
+++ b/aspx/wwwroot/Web.config
@@ -6,7 +6,7 @@
    </system.web>
    <system.webServer>
       <staticContent>
-        <mimeMap fileExtension=".rdp" mimeType="application/rdp" />
+        <mimeMap fileExtension=".rdp" mimeType="application/x-rdp" />
       </staticContent>
    </system.webServer>
 </configuration>

--- a/aspx/wwwroot/auth/login.aspx
+++ b/aspx/wwwroot/auth/login.aspx
@@ -1,0 +1,23 @@
+<%@ Page language="C#" %>
+<%@ Import Namespace="System.Web.Security" %>
+<script runat="server">
+//useful fields: https://learn.microsoft.com/en-us/dotnet/api/system.web.httprequest.logonuseridentity?view=netframework-4.8.1
+private void Login() {
+    FormsAuthenticationTicket tkt;
+    string cookiestr;
+    string username = Request.LogonUserIdentity.Name;
+    bool isPersistent = false;
+    HttpCookie ck;
+    tkt = new FormsAuthenticationTicket(1, username, DateTime.Now, DateTime.Now.AddMinutes(30), isPersistent , "");
+    cookiestr = FormsAuthentication.Encrypt(tkt);
+    ck = new HttpCookie(".ASPXAUTH", cookiestr);
+    ck.Path = FormsAuthentication.FormsCookiePath;
+    Response.Cookies.Add(ck);
+
+    Response.Redirect(FormsAuthentication.GetRedirectUrl(username, isPersistent));
+
+}
+</script>
+<%
+Login();
+%>

--- a/aspx/wwwroot/auth/loginfeed.aspx
+++ b/aspx/wwwroot/auth/loginfeed.aspx
@@ -1,0 +1,19 @@
+<%@ Page language="C#" %>
+<%@ Import Namespace="System.Web.Security" %>
+<script runat="server">
+//useful fields: https://learn.microsoft.com/en-us/dotnet/api/system.web.httprequest.logonuseridentity?view=netframework-4.8.1
+private string getLoginToken() {
+    FormsAuthenticationTicket tkt;
+    string token;
+    string username = Request.LogonUserIdentity.Name;
+    bool isPersistent = false;
+    HttpCookie ck;
+    tkt = new FormsAuthenticationTicket(1, username, DateTime.Now, DateTime.Now.AddMinutes(30), isPersistent , "");
+    token = FormsAuthentication.Encrypt(tkt);
+    return token;
+}
+</script>
+<%
+HttpContext.Current.Response.ContentType = "application/x-msts-webfeed-login; charset=utf-8";
+HttpContext.Current.Response.Write(getLoginToken());
+%>

--- a/aspx/wwwroot/webfeed.aspx
+++ b/aspx/wwwroot/webfeed.aspx
@@ -32,12 +32,18 @@
     }
     public string getAuthenticatedUser() {
         HttpCookie authCookie = HttpContext.Current.Request.Cookies[".ASPXAUTH"];
-        if(authCookie == null ) return "";
-        FormsAuthenticationTicket authTicket = FormsAuthentication.Decrypt(authCookie.Value);
-        if(authTicket==null) {
+        if(authCookie == null || authCookie.Value == "") return "";
+        try {
+            // Decrypt may throw an exception if authCookie.Value is total gargbage
+            FormsAuthenticationTicket authTicket = FormsAuthentication.Decrypt(authCookie.Value);
+            if(authTicket==null) {
+                return "";
+            }
+            return authTicket.Name;
+        }
+        catch {
             return "";
         }
-        return authTicket.Name;
     }
 </script>
 <%

--- a/aspx/wwwroot/webfeed.aspx
+++ b/aspx/wwwroot/webfeed.aspx
@@ -30,88 +30,104 @@
         string Root = DocPath.Substring(0, (DocPath.Length - aPath[aPath.GetUpperBound(0)].Length));
         return Root;
     }
+    public string getAuthenticatedUser() {
+        HttpCookie authCookie = HttpContext.Current.Request.Cookies[".ASPXAUTH"];
+        if(authCookie == null ) return "";
+        FormsAuthenticationTicket authTicket = FormsAuthentication.Decrypt(authCookie.Value);
+        if(authTicket==null) {
+            return "";
+        }
+        return authTicket.Name;
+    }
 </script>
 <%
-   string ServerName = System.Net.Dns.GetHostName();
-   string datetime = DateTime.Now.Year.ToString() + "-" + (DateTime.Now.Month + 100).ToString().Substring(1, 2) + "-" + (DateTime.Now.Day + 100).ToString().Substring(1, 2) + "T" + (DateTime.Now.Hour + 100).ToString().Substring(1, 2) + ":" + (DateTime.Now.Minute + 100).ToString().Substring(1, 2) + ":" + (DateTime.Now.Second + 100).ToString().Substring(1, 2) + ".0Z";
+  string authUser = getAuthenticatedUser();
+  if(authUser=="") {
+      Response.Redirect("auth/loginfeed.aspx");
+  }
+  else {
+      HttpContext.Current.Response.ContentType = "text/xml; charset=utf-8";
+      string ServerName = System.Net.Dns.GetHostName();
+      string datetime = DateTime.Now.Year.ToString() + "-" + (DateTime.Now.Month + 100).ToString().Substring(1, 2) + "-" + (DateTime.Now.Day + 100).ToString().Substring(1, 2) + "T" + (DateTime.Now.Hour + 100).ToString().Substring(1, 2) + ":" + (DateTime.Now.Minute + 100).ToString().Substring(1, 2) + ":" + (DateTime.Now.Second + 100).ToString().Substring(1, 2) + ".0Z";
 
-   HttpContext.Current.Response.Write("<ResourceCollection PubDate=\"" + datetime + "\" SchemaVersion=\"1.1\" xmlns=\"http://schemas.microsoft.com/ts/2007/05/tswf\">" + "\r\n");
-   HttpContext.Current.Response.Write("<Publisher LastUpdated=\"" + datetime + "\" Name=\"" + ServerName + "\" ID=\"" + ServerName + "\" Description=\"\">" + "\r\n");
-   HttpContext.Current.Response.Write("<Resources>" + "\r\n");
+      HttpContext.Current.Response.Write("<ResourceCollection PubDate=\"" + datetime + "\" SchemaVersion=\"1.1\" xmlns=\"http://schemas.microsoft.com/ts/2007/05/tswf\">" + "\r\n");
+      HttpContext.Current.Response.Write("<Publisher LastUpdated=\"" + datetime + "\" Name=\"" + ServerName + "\" ID=\"" + ServerName + "\" Description=\"\">" + "\r\n");
+      HttpContext.Current.Response.Write("<Resources>" + "\r\n");
 
-   string Whichfolder = HttpContext.Current.Server.MapPath("rdp\\") + "/";
-   string[] allfiles = System.IO.Directory.GetFiles(Whichfolder);
-   foreach (string eachfile in allfiles)
-   {
-       string extfile = eachfile.Substring(eachfile.Length - 4, 4);
-       if (extfile.ToLower() == ".rdp")
-       {
-           if (!(GetRDPvalue(eachfile, "full address:s:") == ""))
-           {
-            string basefilename = eachfile.Substring(Whichfolder.Length, eachfile.Length - Whichfolder.Length - 4);
-            string appalias = GetRDPvalue(eachfile, "remoteapplicationprogram:s:");
-            string apptitle = GetRDPvalue(eachfile, "remoteapplicationname:s:");
-            string appicon = basefilename + ".ico";
-            string appicon32 = basefilename + ".png";
-            string apprdpfile = basefilename + ".rdp";
-            string appresourceid = appalias;
-            string appftastring = GetRDPvalue(eachfile, "remoteapplicationfileextensions:s:");
-            string appfulladdress = GetRDPvalue(eachfile, "full address:s:");
-            string rdptype = "RemoteApp";
-            if (appalias == "")
+      string Whichfolder = HttpContext.Current.Server.MapPath("rdp\\") + "/";
+      string[] allfiles = System.IO.Directory.GetFiles(Whichfolder);
+      foreach (string eachfile in allfiles)
+      {
+         string extfile = eachfile.Substring(eachfile.Length - 4, 4);
+         if (extfile.ToLower() == ".rdp")
+         {
+            if (!(GetRDPvalue(eachfile, "full address:s:") == ""))
             {
-               rdptype = "Desktop";
-               appalias = basefilename;
-               apptitle = basefilename;
-               appresourceid = basefilename;
-            }
-            else
-            {
-               rdptype = "RemoteApp";
-            }
-            DateTime filedatetimeraw = System.IO.File.GetLastWriteTime(eachfile);
-            string filedatetime = DateTime.Now.Year.ToString() + "-" + (filedatetimeraw.Month + 100).ToString().Substring(1,2) + "-" + (filedatetimeraw.Day + 100).ToString().Substring(1,2) + "T" + (filedatetimeraw.Hour + 100).ToString().Substring(1,2) + ":" + (filedatetimeraw.Minute + 100).ToString().Substring(1,2) + ":" + (filedatetimeraw.Second + 100).ToString().Substring(1,2) + ".0Z";
-            HttpContext.Current.Response.Write("<Resource ID=\"" + appresourceid + "\" Alias=\"" + appalias + "\" Title=\"" + apptitle + "\" LastUpdated=\"" + filedatetime + "\" Type=\"" + rdptype + "\">" + "\r\n");
-            HttpContext.Current.Response.Write("<Icons>" + "\r\n");
-            HttpContext.Current.Response.Write("<IconRaw FileType=\"Ico\" FileURL=\"" + Root() + "icon/" + appicon + "\" />" + "\r\n");
-            if (System.IO.File.Exists(HttpContext.Current.Server.MapPath("icon32/" + appicon32)))
-            {
-               HttpContext.Current.Response.Write("<Icon32 Dimensions=\"32x32\" FileType=\"Png\" FileURL=\"" + Root() + "icon32/" + appicon32 + "\" />" + "\r\n");
-            }
-            HttpContext.Current.Response.Write("</Icons>" + "\r\n");
-            if (appftastring != "")
-            {
-               HttpContext.Current.Response.Write("<FileExtensions>" + "\r\n");
-               string[] appftaarray = appftastring.Split(',');
-               foreach(string filetype in appftaarray)
+               string basefilename = eachfile.Substring(Whichfolder.Length, eachfile.Length - Whichfolder.Length - 4);
+               string appalias = GetRDPvalue(eachfile, "remoteapplicationprogram:s:");
+               string apptitle = GetRDPvalue(eachfile, "remoteapplicationname:s:");
+               string appicon = basefilename + ".ico";
+               string appicon32 = basefilename + ".png";
+               string apprdpfile = basefilename + ".rdp";
+               string appresourceid = appalias;
+               string appftastring = GetRDPvalue(eachfile, "remoteapplicationfileextensions:s:");
+               string appfulladdress = GetRDPvalue(eachfile, "full address:s:");
+               string rdptype = "RemoteApp";
+               if (appalias == "")
                {
-                  string docicon = basefilename + "." + filetype + ".ico";
-                  HttpContext.Current.Response.Write("<FileExtension Name=\"" + filetype + "\" PrimaryHandler=\"True\">" + "\r\n");
-                  HttpContext.Current.Response.Write("<FileAssociationIcons>" + "\r\n");
-                  HttpContext.Current.Response.Write("<IconRaw FileType=\"Ico\" FileURL=\"" + Root() + "icon/" + docicon + "\" />" + "\r\n");
-                  HttpContext.Current.Response.Write("</FileAssociationIcons>" + "\r\n");
-                  HttpContext.Current.Response.Write("</FileExtension>" + "\r\n");
+                  rdptype = "Desktop";
+                  appalias = basefilename;
+                  apptitle = basefilename;
+                  appresourceid = basefilename;
                }
-               HttpContext.Current.Response.Write("</FileExtensions>" + "\r\n");
+               else
+               {
+                  rdptype = "RemoteApp";
+               }
+               DateTime filedatetimeraw = System.IO.File.GetLastWriteTime(eachfile);
+               string filedatetime = DateTime.Now.Year.ToString() + "-" + (filedatetimeraw.Month + 100).ToString().Substring(1,2) + "-" + (filedatetimeraw.Day + 100).ToString().Substring(1,2) + "T" + (filedatetimeraw.Hour + 100).ToString().Substring(1,2) + ":" + (filedatetimeraw.Minute + 100).ToString().Substring(1,2) + ":" + (filedatetimeraw.Second + 100).ToString().Substring(1,2) + ".0Z";
+               HttpContext.Current.Response.Write("<Resource ID=\"" + appresourceid + "\" Alias=\"" + appalias + "\" Title=\"" + apptitle + "\" LastUpdated=\"" + filedatetime + "\" Type=\"" + rdptype + "\">" + "\r\n");
+               HttpContext.Current.Response.Write("<Icons>" + "\r\n");
+               HttpContext.Current.Response.Write("<IconRaw FileType=\"Ico\" FileURL=\"" + Root() + "icon/" + appicon + "\" />" + "\r\n");
+               if (System.IO.File.Exists(HttpContext.Current.Server.MapPath("icon32/" + appicon32)))
+               {
+                  HttpContext.Current.Response.Write("<Icon32 Dimensions=\"32x32\" FileType=\"Png\" FileURL=\"" + Root() + "icon32/" + appicon32 + "\" />" + "\r\n");
+               }
+               HttpContext.Current.Response.Write("</Icons>" + "\r\n");
+               if (appftastring != "")
+               {
+                  HttpContext.Current.Response.Write("<FileExtensions>" + "\r\n");
+                  string[] appftaarray = appftastring.Split(',');
+                  foreach(string filetype in appftaarray)
+                  {
+                     string docicon = basefilename + "." + filetype + ".ico";
+                     HttpContext.Current.Response.Write("<FileExtension Name=\"" + filetype + "\" PrimaryHandler=\"True\">" + "\r\n");
+                     HttpContext.Current.Response.Write("<FileAssociationIcons>" + "\r\n");
+                     HttpContext.Current.Response.Write("<IconRaw FileType=\"Ico\" FileURL=\"" + Root() + "icon/" + docicon + "\" />" + "\r\n");
+                     HttpContext.Current.Response.Write("</FileAssociationIcons>" + "\r\n");
+                     HttpContext.Current.Response.Write("</FileExtension>" + "\r\n");
+                  }
+                  HttpContext.Current.Response.Write("</FileExtensions>" + "\r\n");
+               }
+               else
+               {
+                  HttpContext.Current.Response.Write("<FileExtensions />" + "\r\n");
+               }
+               HttpContext.Current.Response.Write("<HostingTerminalServers>" + "\r\n");
+               HttpContext.Current.Response.Write("<HostingTerminalServer>" + "\r\n");
+               HttpContext.Current.Response.Write("<ResourceFile FileExtension=\".rdp\" URL=\"" + Root() + "rdp/" + apprdpfile + "\" />" + "\r\n");
+               HttpContext.Current.Response.Write("<TerminalServerRef Ref=\"" + ServerName + "\" />" + "\r\n");
+               HttpContext.Current.Response.Write("</HostingTerminalServer>" + "\r\n");
+               HttpContext.Current.Response.Write("</HostingTerminalServers>" + "\r\n");
+               HttpContext.Current.Response.Write("</Resource>" + "\r\n");
             }
-            else
-            {
-               HttpContext.Current.Response.Write("<FileExtensions />" + "\r\n");
-            }
-            HttpContext.Current.Response.Write("<HostingTerminalServers>" + "\r\n");
-            HttpContext.Current.Response.Write("<HostingTerminalServer>" + "\r\n");
-            HttpContext.Current.Response.Write("<ResourceFile FileExtension=\".rdp\" URL=\"" + Root() + "rdp/" + apprdpfile + "\" />" + "\r\n");
-            HttpContext.Current.Response.Write("<TerminalServerRef Ref=\"" + ServerName + "\" />" + "\r\n");
-            HttpContext.Current.Response.Write("</HostingTerminalServer>" + "\r\n");
-            HttpContext.Current.Response.Write("</HostingTerminalServers>" + "\r\n");
-            HttpContext.Current.Response.Write("</Resource>" + "\r\n");
          }
       }
-   }
-   HttpContext.Current.Response.Write("</Resources>" + "\r\n");
-   HttpContext.Current.Response.Write("<TerminalServers>" + "\r\n");
-   HttpContext.Current.Response.Write("<TerminalServer ID=\"" + ServerName + "\" Name=\"" + ServerName + "\" LastUpdated=\"" + datetime + "\" />" + "\r\n");
-   HttpContext.Current.Response.Write("</TerminalServers>" + "\r\n");
-   HttpContext.Current.Response.Write("</Publisher>" + "\r\n");
-   HttpContext.Current.Response.Write("</ResourceCollection>" + "\r\n");
+      HttpContext.Current.Response.Write("</Resources>" + "\r\n");
+      HttpContext.Current.Response.Write("<TerminalServers>" + "\r\n");
+      HttpContext.Current.Response.Write("<TerminalServer ID=\"" + ServerName + "\" Name=\"" + ServerName + "\" LastUpdated=\"" + datetime + "\" />" + "\r\n");
+      HttpContext.Current.Response.Write("</TerminalServers>" + "\r\n");
+      HttpContext.Current.Response.Write("</Publisher>" + "\r\n");
+      HttpContext.Current.Response.Write("</ResourceCollection>" + "\r\n");
+  }
 %>


### PR DESCRIPTION
this is a aspx only prototype how to make the webfeed compatible with newer clients

see this issue: https://github.com/kimmknight/raweb/issues/6

the way this is supposed to work:
you copy the aspx version somewhere on your harddrive and add this folder as application in a website (or directly in wwwroot, the important thing is that it is a dedicated application)

on the auth folder (only that folder!) you should enable windows authentication and disable anonymous authentication
![image](https://github.com/user-attachments/assets/f3a9f754-6eb3-4207-a043-74ca48f38cf7)

What is not implemented is protecting the download of rdp and ico/png files, but that files should not contain sensible data and additionally you would need to know the names