### PR TITLE
multiuser by folder

### DIFF
--- a/aspx/wwwroot/auth/login.aspx
+++ b/aspx/wwwroot/auth/login.aspx
@@ -6,16 +6,25 @@ private void Login() {
     FormsAuthenticationTicket tkt;
     string cookiestr;
     string username = Request.LogonUserIdentity.Name;
+    if(username.IndexOf("\\")>0) {
+        string authDomain = username.Substring(0,username.IndexOf("\\"));
+        if(HttpContext.Current.Server.MachineName == authDomain)
+            username = username.Substring(authDomain.Length+1);
+    }
     bool isPersistent = false;
     HttpCookie ck;
-    tkt = new FormsAuthenticationTicket(1, username, DateTime.Now, DateTime.Now.AddMinutes(30), isPersistent , "");
+    string groupSids = "";
+    System.Security.Principal.IdentityReferenceCollection groups = Request.LogonUserIdentity.Groups;
+    foreach(System.Security.Principal.IdentityReference sid in groups) {
+        groupSids+=(groupSids.Length>0?",":"")+sid.ToString();
+    }
+    tkt = new FormsAuthenticationTicket(1, username, DateTime.Now, DateTime.Now.AddMinutes(30), isPersistent , groupSids);
     cookiestr = FormsAuthentication.Encrypt(tkt);
     ck = new HttpCookie(".ASPXAUTH", cookiestr);
     ck.Path = FormsAuthentication.FormsCookiePath;
     Response.Cookies.Add(ck);
 
     Response.Redirect(FormsAuthentication.GetRedirectUrl(username, isPersistent));
-
 }
 </script>
 <%

--- a/aspx/wwwroot/auth/loginfeed.aspx
+++ b/aspx/wwwroot/auth/loginfeed.aspx
@@ -6,9 +6,19 @@ private string getLoginToken() {
     FormsAuthenticationTicket tkt;
     string token;
     string username = Request.LogonUserIdentity.Name;
+    if(username.IndexOf("\\")>0) {
+        string authDomain = username.Substring(0,username.IndexOf("\\"));
+        if(HttpContext.Current.Server.MachineName == authDomain)
+            username = username.Substring(authDomain.Length+1);
+    }
     bool isPersistent = false;
     HttpCookie ck;
-    tkt = new FormsAuthenticationTicket(1, username, DateTime.Now, DateTime.Now.AddMinutes(30), isPersistent , "");
+    string groupSids = "";
+    System.Security.Principal.IdentityReferenceCollection groups = Request.LogonUserIdentity.Groups;
+    foreach(System.Security.Principal.IdentityReference sid in groups) {
+        groupSids+=(groupSids.Length>0?",":"")+sid.ToString();
+    }
+    tkt = new FormsAuthenticationTicket(1, username, DateTime.Now, DateTime.Now.AddMinutes(30), isPersistent , groupSids);
     token = FormsAuthentication.Encrypt(tkt);
     return token;
 }

--- a/aspx/wwwroot/rdp/group/Users/Desktop-For-All-Users.rdp
+++ b/aspx/wwwroot/rdp/group/Users/Desktop-For-All-Users.rdp
@@ -1,0 +1,46 @@
+﻿redirectclipboard:i:1
+redirectposdevices:i:0
+redirectprinters:i:1
+redirectcomports:i:1
+redirectsmartcards:i:1
+devicestoredirect:s:*
+drivestoredirect:s:*
+redirectdrives:i:1
+session bpp:i:32
+prompt for credentials on client:i:1
+span monitors:i:1
+use multimon:i:1
+remoteapplicationmode:i:1
+server port:i:3389
+allow font smoothing:i:1
+promptcredentialonce:i:0
+authentication level:i:2
+full address:s:win7testbox
+alternate full address:s:win7testbox
+disableremoteappcapscheck:i:1
+screen mode id:i:2
+winposstr:s:0,3,0,0,800,600
+compression:i:1
+keyboardhook:i:2
+audiocapturemode:i:0
+videoplaybackmode:i:1
+connection type:i:2
+disable wallpaper:i:1
+allow desktop composition:i:1
+disable full window drag:i:1
+disable menu anims:i:1
+disable themes:i:0
+disable cursor setting:i:0
+bitmapcachepersistenable:i:1
+audiomode:i:0
+redirectdirectx:i:1
+autoreconnection enabled:i:1
+prompt for credentials:i:0
+negotiate security layer:i:1
+remoteapplicationicon:s:
+shell working directory:s:
+gatewayhostname:s:
+gatewayusagemethod:i:4
+gatewaycredentialssource:i:4
+gatewayprofileusagemethod:i:0
+use redirection server name:i:0

--- a/aspx/wwwroot/rdp/user/Administrator/test-admin-app.rdp
+++ b/aspx/wwwroot/rdp/user/Administrator/test-admin-app.rdp
@@ -1,0 +1,50 @@
+﻿redirectclipboard:i:1
+redirectposdevices:i:0
+redirectprinters:i:1
+redirectcomports:i:1
+redirectsmartcards:i:1
+devicestoredirect:s:*
+drivestoredirect:s:*
+redirectdrives:i:1
+session bpp:i:32
+prompt for credentials on client:i:1
+span monitors:i:1
+use multimon:i:1
+remoteapplicationmode:i:1
+server port:i:3389
+allow font smoothing:i:1
+promptcredentialonce:i:0
+authentication level:i:2
+full address:s:win7testbox
+remoteapplicationprogram:s:||testappadmin
+remoteapplicationname:s:Test Application for Adminstrator only
+remoteapplicationcmdline:s:
+alternate full address:s:win7testbox
+disableremoteappcapscheck:i:1
+alternate shell:s:rdpinit.exe
+screen mode id:i:2
+winposstr:s:0,3,0,0,800,600
+compression:i:1
+keyboardhook:i:2
+audiocapturemode:i:0
+videoplaybackmode:i:1
+connection type:i:2
+disable wallpaper:i:1
+allow desktop composition:i:1
+disable full window drag:i:1
+disable menu anims:i:1
+disable themes:i:0
+disable cursor setting:i:0
+bitmapcachepersistenable:i:1
+audiomode:i:0
+redirectdirectx:i:1
+autoreconnection enabled:i:1
+prompt for credentials:i:0
+negotiate security layer:i:1
+remoteapplicationicon:s:
+shell working directory:s:
+gatewayhostname:s:
+gatewayusagemethod:i:4
+gatewaycredentialssource:i:4
+gatewayprofileusagemethod:i:0
+use redirection server name:i:0

--- a/aspx/wwwroot/webfeed.aspx
+++ b/aspx/wwwroot/webfeed.aspx
@@ -45,6 +45,33 @@
             return "";
         }
     }
+
+    public string[] getAuthenticatedUserGroups() {
+        HttpCookie authCookie = HttpContext.Current.Request.Cookies[".ASPXAUTH"];
+        if(authCookie == null || authCookie.Value == "") return new string[0];
+        try {
+            // Decrypt may throw an exception if authCookie.Value is total gargbage
+            FormsAuthenticationTicket authTicket = FormsAuthentication.Decrypt(authCookie.Value);
+            if(authTicket==null) {
+                return new string[0];
+            }
+            string [] sids = authTicket.UserData.Split(',');
+            string [] groups = new string[sids.Length];
+            for(int pos=0;pos<sids.Length;pos++) {
+                string group = new System.Security.Principal.SecurityIdentifier(sids[pos].ToString()).Translate(typeof(System.Security.Principal.NTAccount)).ToString();
+                if(group.IndexOf("\\")>0) {
+                    string authDomain = group.Substring(0,group.IndexOf("\\"));
+                    if(HttpContext.Current.Server.MachineName == authDomain || authDomain == "BUILTIN")
+                        group = group.Substring(authDomain.Length+1);
+                }
+                groups.SetValue(group,pos);
+            }
+            return groups;
+        }
+        catch {
+            return new string[0];
+        }
+    }
 </script>
 <%
   string authUser = getAuthenticatedUser();
@@ -52,6 +79,7 @@
       Response.Redirect("auth/loginfeed.aspx");
   }
   else {
+      string [] authUserGroups = getAuthenticatedUserGroups();
       HttpContext.Current.Response.ContentType = "text/xml; charset=utf-8";
       string ServerName = System.Net.Dns.GetHostName();
       string datetime = DateTime.Now.Year.ToString() + "-" + (DateTime.Now.Month + 100).ToString().Substring(1, 2) + "-" + (DateTime.Now.Day + 100).ToString().Substring(1, 2) + "T" + (DateTime.Now.Hour + 100).ToString().Substring(1, 2) + ":" + (DateTime.Now.Minute + 100).ToString().Substring(1, 2) + ":" + (DateTime.Now.Second + 100).ToString().Substring(1, 2) + ".0Z";
@@ -60,8 +88,26 @@
       HttpContext.Current.Response.Write("<Publisher LastUpdated=\"" + datetime + "\" Name=\"" + ServerName + "\" ID=\"" + ServerName + "\" Description=\"\">" + "\r\n");
       HttpContext.Current.Response.Write("<Resources>" + "\r\n");
 
-      string Whichfolder = HttpContext.Current.Server.MapPath("rdp\\") + "/";
-      string[] allfiles = System.IO.Directory.GetFiles(Whichfolder);
+      string Whichfolder = HttpContext.Current.Server.MapPath("rdp\\");
+      string UserFolder = HttpContext.Current.Server.MapPath("rdp\\user\\")+authUser;
+      string[] alluserfiles = System.IO.Directory.GetFiles(Whichfolder);
+      string[] userfiles = new string[0];
+      if(System.IO.Directory.Exists(UserFolder))
+          userfiles = System.IO.Directory.GetFiles(UserFolder);
+
+      string[] allfiles = new string[alluserfiles.Length + userfiles.Length];
+      Array.Copy(alluserfiles,allfiles,alluserfiles.Length);
+      Array.Copy(userfiles,0,allfiles,alluserfiles.Length,userfiles.Length);
+
+      foreach(string group in authUserGroups) {
+          string groupdir = HttpContext.Current.Server.MapPath("rdp\\group\\") + group;
+          if( System.IO.Directory.Exists(groupdir) ) {
+              string[] groupfiles = System.IO.Directory.GetFiles(groupdir);
+              int oldSize = allfiles.Length;
+              Array.Resize(ref allfiles,allfiles.Length + groupfiles.Length);
+              Array.Copy(groupfiles,0,allfiles,oldSize,groupfiles.Length);
+          }
+      }
       foreach (string eachfile in allfiles)
       {
          string extfile = eachfile.Substring(eachfile.Length - 4, 4);
@@ -70,11 +116,15 @@
             if (!(GetRDPvalue(eachfile, "full address:s:") == ""))
             {
                string basefilename = eachfile.Substring(Whichfolder.Length, eachfile.Length - Whichfolder.Length - 4);
+
                string appalias = GetRDPvalue(eachfile, "remoteapplicationprogram:s:");
                string apptitle = GetRDPvalue(eachfile, "remoteapplicationname:s:");
                string appicon = basefilename + ".ico";
                string appicon32 = basefilename + ".png";
                string apprdpfile = basefilename + ".rdp";
+               if(basefilename.IndexOf("\\")>0) {
+                    basefilename = basefilename.Substring(basefilename.LastIndexOf("\\")+1);
+               }
                string appresourceid = appalias;
                string appftastring = GetRDPvalue(eachfile, "remoteapplicationfileextensions:s:");
                string appfulladdress = GetRDPvalue(eachfile, "full address:s:");
@@ -94,10 +144,12 @@
                string filedatetime = DateTime.Now.Year.ToString() + "-" + (filedatetimeraw.Month + 100).ToString().Substring(1,2) + "-" + (filedatetimeraw.Day + 100).ToString().Substring(1,2) + "T" + (filedatetimeraw.Hour + 100).ToString().Substring(1,2) + ":" + (filedatetimeraw.Minute + 100).ToString().Substring(1,2) + ":" + (filedatetimeraw.Second + 100).ToString().Substring(1,2) + ".0Z";
                HttpContext.Current.Response.Write("<Resource ID=\"" + appresourceid + "\" Alias=\"" + appalias + "\" Title=\"" + apptitle + "\" LastUpdated=\"" + filedatetime + "\" Type=\"" + rdptype + "\">" + "\r\n");
                HttpContext.Current.Response.Write("<Icons>" + "\r\n");
-               HttpContext.Current.Response.Write("<IconRaw FileType=\"Ico\" FileURL=\"" + Root() + "icon/" + appicon + "\" />" + "\r\n");
+               if (System.IO.File.Exists(HttpContext.Current.Server.MapPath("icon/" + appicon))) {
+                  HttpContext.Current.Response.Write("<IconRaw FileType=\"Ico\" FileURL=\"" + Root() + "icon/" + appicon.Replace("\\","/") + "\" />" + "\r\n");
+               }
                if (System.IO.File.Exists(HttpContext.Current.Server.MapPath("icon32/" + appicon32)))
                {
-                  HttpContext.Current.Response.Write("<Icon32 Dimensions=\"32x32\" FileType=\"Png\" FileURL=\"" + Root() + "icon32/" + appicon32 + "\" />" + "\r\n");
+                  HttpContext.Current.Response.Write("<Icon32 Dimensions=\"32x32\" FileType=\"Png\" FileURL=\"" + Root() + "icon32/" + appicon32.Replace("\\","/") + "\" />" + "\r\n");
                }
                HttpContext.Current.Response.Write("</Icons>" + "\r\n");
                if (appftastring != "")
@@ -106,10 +158,10 @@
                   string[] appftaarray = appftastring.Split(',');
                   foreach(string filetype in appftaarray)
                   {
-                     string docicon = basefilename + "." + filetype + ".ico";
+                     string docicon = basefilename.Replace("\\","/") + "." + filetype + ".ico";
                      HttpContext.Current.Response.Write("<FileExtension Name=\"" + filetype + "\" PrimaryHandler=\"True\">" + "\r\n");
                      HttpContext.Current.Response.Write("<FileAssociationIcons>" + "\r\n");
-                     HttpContext.Current.Response.Write("<IconRaw FileType=\"Ico\" FileURL=\"" + Root() + "icon/" + docicon + "\" />" + "\r\n");
+                     HttpContext.Current.Response.Write("<IconRaw FileType=\"Ico\" FileURL=\"" + Root() + "icon/" + docicon.Replace("\\","/") + "\" />" + "\r\n");
                      HttpContext.Current.Response.Write("</FileAssociationIcons>" + "\r\n");
                      HttpContext.Current.Response.Write("</FileExtension>" + "\r\n");
                   }
@@ -121,7 +173,7 @@
                }
                HttpContext.Current.Response.Write("<HostingTerminalServers>" + "\r\n");
                HttpContext.Current.Response.Write("<HostingTerminalServer>" + "\r\n");
-               HttpContext.Current.Response.Write("<ResourceFile FileExtension=\".rdp\" URL=\"" + Root() + "rdp/" + apprdpfile + "\" />" + "\r\n");
+               HttpContext.Current.Response.Write("<ResourceFile FileExtension=\".rdp\" URL=\"" + Root() + "rdp/" + apprdpfile.Replace("\\","/") + "\" />" + "\r\n");
                HttpContext.Current.Response.Write("<TerminalServerRef Ref=\"" + ServerName + "\" />" + "\r\n");
                HttpContext.Current.Response.Write("</HostingTerminalServer>" + "\r\n");
                HttpContext.Current.Response.Write("</HostingTerminalServers>" + "\r\n");


### PR DESCRIPTION
as already mentioned in https://github.com/kimmknight/raweb/pull/16 the "new" login is not compatible with the way multiuser is documented in the documetation here:

https://github.com/kimmknight/raweb/wiki/Configuring-RAWeb-for-a-multi-user-environment

this PR does not take this feature back but instead implements this feature by using subfolders in the rdp directory:

one for `user` one for `group`. the outermost folder are resources for every user.