### PR TITLE
Do not remove last character of parent folder labels in apps list

### DIFF
--- a/aspx/wwwroot/Default.aspx
+++ b/aspx/wwwroot/Default.aspx
@@ -147,7 +147,7 @@
                     <div class="d-flex flex-column px-2 pb-5">
                         <div v-for="folder in webfeed.availableFolders">
                             <div class="py-1" v-if="resourcesInFolder(folder).length > 0">
-                                <h5 class="my-5" v-if="folder">{{ folder ? folder.replace(/^\//, "").replace(/\/$/, "").replace(/.\//g, " > ") : "" }}</h5>
+                                <h5 class="my-5" v-if="folder">{{ folder ? folder.replace(/^\//, "").replace(/\/$/, "").replace(/\//g, " > ") : "" }}</h5>
                                 <div class="d-flex flex-wrap gap-3 justify-content-center justify-content-sm-start">
                                     <div class="apptile position-relative d-flex flex-column align-items-center px-1 py-2" v-for="resource in resourcesInFolder(folder)">
                                         <a class="stretched-link" :href="resource.hostingTerminalServers[0].resourceFile.url"></a>


### PR DESCRIPTION
If folders were nested, all folders except the deepest folder would have the last character removed from their name. This PR fixes the regular expression that transforms folder paths to folder labels in the UI so that folder names are not altered.

For example, `grandparent/parent/child/` was becoming `grandparen > paren > child`. With this PR, it becomes `grandparent > parent > child` instead.

| Before | After |
|---|---|
|![image](https://github.com/user-attachments/assets/a73d0d8d-9c19-4afa-9c9c-775791521024)| ![image](https://github.com/user-attachments/assets/32152d7c-25f9-4674-b9f4-20b626d51c87) |