### PR TITLE
fix: disable autocorrect, autocapitalize, and spellcheck on login form fields

### DIFF
--- a/aspx/wwwroot/login.aspx
+++ b/aspx/wwwroot/login.aspx
@@ -102,7 +102,7 @@
                         <div class="input" id="username-group">
                             <div class="textblock">Domain\Username</div>
                             <div class="text-box-container">
-                                <input class="text-box" name="username" autocomplete="username" required id="Username" runat="server" autofocus />
+                                <input class="text-box" name="username" autocomplete="username" required id="Username" runat="server" autofocus autocorrect="off" autocapitalize="off" spellcheck="false" />
                                 <div class="text-box-underline"></div>
                             </div>
                         </div>
@@ -111,7 +111,7 @@
                             <div class="textblock">Password</div>
                             <div class="text-box-container">
                                 <input class="text-box" name="password" type="password"
-                                    autocomplete="current-password" required id="password" runat="server" />
+                                    autocomplete="current-password" required id="password" runat="server" autocorrect="off" autocapitalize="off" spellcheck="false" />
                                 <div class="text-box-underline"></div>
                             </div>
                         </div>


### PR DESCRIPTION
## Changes

This PR disables the `autocorrect`, `autocapitalize`, and `spellcheck` attributes on the login page. This should disable browser spellcheck and autocapitalization behavior for usernames and passwords. For spellcheck-related browser extensions that respect these attributes, they will also be disabled for the username and password fields.

Addresses https://github.com/kimmknight/raweb/pull/44#issuecomment-2900405676

## Install

Run as an administrator in PowerShell to install this branch:
```
$zipUrl = "https://github.com/jackbuehner/raweb/archive/refs/heads/no-spellcheck.zip"; $tempDir = "$env:TEMP\raweb"; $zipFile = "$tempDir\master.zip"; New-Item -ItemType Directory -Path $tempDir -Force | Out-Null; Invoke-WebRequest -Uri $zipUrl -OutFile $zipFile; Expand-Archive -Path $zipFile -DestinationPath $tempDir -Force; Set-ExecutionPolicy Bypass -Scope Process -Force; & "$tempDir\no-spellcheck\setup.ps1" -AcceptAll; Remove-Item -Path $zipFile -Force; Remove-Item -Path $tempDir -Recurse -Force;
```