### PR TITLE
fix: do not parse and re-create RDP files that have been signed

### DIFF
--- a/frontend/lib/components/ItemCard/TerminalServerPickerDialog.vue
+++ b/frontend/lib/components/ItemCard/TerminalServerPickerDialog.vue
@@ -64,7 +64,7 @@
     // attempt to build the RDP file contents from the selected host, but
     // fall back to the download URL if the rdp file properties could not be found
     let downloadUrl = '';
-    if (host.rdp) {
+    if (host.rdp && !host.rdp.Signed) {
       // attempt to infer the domain name from the host URL
       const maybeDomainHost = `${host.rdp['full address']}`.split('.').slice(1).join('.');
       const maybeDomainNetBios = `${host.rdp['full address']}`.split('.')[1];


### PR DESCRIPTION
Normally, the web app parses each RDP file into a JavaScript object. This object is used to display the app/desktop properties. It is also cached. When it is time to download the app/desktop, a new RDP file is constructed from the JavaScript object.

This change bypasses the parsing and subsequent re-creation for RDP files that are digitally signed.

From what I can tell, digitially signed RDP files have null bytes between every visible character in the RDP file. I added a check that looks for a high number of null bytes in the first 32 bytes of the downloaded RDP file. If at least 10 null bytes are found, the RDP file is considered to be signed.

I have tested this with signed RDP files generated by RemoteApp Tool (which uses rdpsign.exe). This change was only necessary for the web app; the RDP files in the webfeed are unmodified.

Fixes #57.

## Install

Run as an administrator in PowerShell to install this branch:
```
$zipUrl = "https://github.com/jackbuehner/raweb/archive/refs/heads/handle-signed-rdp-files.zip"; $tempDir = "$env:TEMP\raweb"; $zipFile = "$tempDir\master.zip"; New-Item -ItemType Directory -Path $tempDir -Force | Out-Null; $ProgressPreference = "SilentlyContinue"; Write-Host "Downloading..."; Invoke-WebRequest -Uri $zipUrl -OutFile $zipFile; Write-Host "Extracting..."; Expand-Archive -Path $zipFile -DestinationPath $tempDir -Force; Write-Host "Installing (noninteractive)..."; Set-ExecutionPolicy Bypass -Scope Process -Force; & "$tempDir\raweb-handle-signed-rdp-files\setup.ps1" -AcceptAll; Remove-Item -Path $zipFile -Force; Remove-Item -Path $tempDir -Recurse -Force;
```