### PR TITLE
Show security warnings on login page, and auto-login if anonymous authentication is enabled

### DIFF
--- a/aspx/wwwroot/App_Code/AuthUtilities.cs
+++ b/aspx/wwwroot/App_Code/AuthUtilities.cs
@@ -129,6 +129,12 @@ namespace AuthUtilities
                 throw new ArgumentException("Username or domain cannot be null or empty.");
             }
 
+            // if the account is the anonymous account, return those details
+            if (domain == "NT AUTHORITY" && username == "IUSR")
+            {
+                return new UserInformation(username, domain, "Anonymous User", new GroupInformation[0]);
+            }
+
             // get the principal context for the domain or machine
             bool domainIsMachine = string.IsNullOrEmpty(domain) || domain.Trim() == Environment.MachineName;
             PrincipalContext principalContext;
@@ -217,6 +223,7 @@ namespace AuthUtilities
             }
             catch (Exception ex)
             {
+                throw new Exception("An error occurred while getting user information.", ex);
                 // log the exception if needed
                 System.Diagnostics.Debug.WriteLine("Error getting user information: " + ex.Message);
                 return null; // return null if an error occurs
@@ -235,7 +242,7 @@ namespace AuthUtilities
         {
             Username = username;
             Domain = domain;
-            
+
             if (string.IsNullOrEmpty(fullName))
             {
                 FullName = username; // default to username if full name is not provided

--- a/aspx/wwwroot/lib/controls/InfoBarCaution.ascx
+++ b/aspx/wwwroot/lib/controls/InfoBarCaution.ascx
@@ -1,0 +1,111 @@
+<%@ Control Language="C#" AutoEventWireup="true" %>
+
+<script runat="server">
+    public string Title {get; set; }
+    public string Message {get; set; }
+    public string style {get; set; }
+    public string href {get; set; }
+    public string AnchorText {get; set; }
+</script>
+
+<div class="info-bar severity-caution" role="alert" style="<%= style %>">
+    <div class="info-bar-icon">
+        <span class="info-badge severity-caution">
+            <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="406 86 213 875">
+                <path
+                    fill="currentColor"
+                    d="M426.5,512L426.5,170.5C426.5,158.833 428.75,147.833 433.25,137.5C437.75,127.167 443.917,118.167 451.75,110.5C459.583,102.833 468.667,96.75 479,92.25C489.333,87.75 500.333,85.5 512,85.5C523.667,85.5 534.667,87.75 545,92.25C555.333,96.75 564.417,102.833 572.25,110.5C580.083,118.167 586.25,127.167 590.75,137.5C595.25,147.833 597.5,158.833 597.5,170.5L597.5,512C597.5,523.667 595.25,534.667 590.75,545C586.25,555.333 580.083,564.417 572.25,572.25C564.417,580.083 555.333,586.25 545,590.75C534.667,595.25 523.667,597.5 512,597.5C500.333,597.5 489.333,595.25 479,590.75C468.667,586.25 459.583,580.083 451.75,572.25C443.917,564.417 437.75,555.333 433.25,545C428.75,534.667 426.5,523.667 426.5,512ZM405.5,853.5C405.5,838.833 408.333,825 414,812C419.667,799 427.333,787.667 437,778C446.667,768.333 457.917,760.667 470.75,755C483.583,749.333 497.333,746.5 512,746.5C526.667,746.5 540.417,749.333 553.25,755C566.083,760.667 577.333,768.333 587,778C596.667,787.667 604.333,799 610,812C615.667,825 618.5,838.833 618.5,853.5C618.5,868.167 615.667,881.917 610,894.75C604.333,907.583 596.667,918.833 587,928.5C577.333,938.167 566,945.833 553,951.5C540,957.167 526.333,960 512,960C497.333,960 483.583,957.167 470.75,951.5C457.917,945.833 446.667,938.167 437,928.5C427.333,918.833 419.667,907.583 414,894.75C408.333,881.917 405.5,868.167 405.5,853.5Z"
+                ></path>
+            </svg>
+        </span>
+    </div>
+    
+    <div class="info-bar-content">
+        <span><%= Title %></span>
+        <p><%= Message %></p>
+        <a href="<%= href %>" class="button style-hyperlink unindent"><%= AnchorText %></a>
+    </div>
+</div>
+
+<style>
+    .info-bar {
+        align-items: center;
+        background-clip: padding-box;
+        border: 1px solid var(--wui-card-stroke-default);
+        border-radius: var(--wui-control-corner-radius);
+        box-sizing: border-box;
+        display: flex;
+        font-family: var(--wui-font-family-text);
+        min-block-size: 48px;
+        padding-inline-start: 15px;
+        position: relative;
+        user-select: none;
+    }
+
+    .info-bar.severity-caution {
+        background-color: var(--wui-system-caution-background);
+    }
+
+    .info-bar-icon {
+        align-self: flex-start;
+        display: flex;
+        flex: 0 0 auto;
+        margin-block-start: 16px;
+    }
+
+    .info-badge {
+        align-items: center;
+        border-radius: 16px;
+        box-sizing: border-box;
+        color: var(--wui-text-on-accent-primary);
+        display: inline-flex;
+        font-family: var(--wui-font-family-small);
+        font-size: var(--wui-font-size-caption);
+        justify-content: center;
+        line-height: var(--wui-font-size-caption);
+        min-block-size: 16px;
+        min-inline-size: 16px;
+        padding: 2px 4px;
+        user-select: none;
+    }
+
+    .info-badge.severity-caution {
+        background-color: var(--wui-system-caution);
+    }
+
+    .info-bar-content {
+        align-items: center;
+        box-sizing: border-box;
+        display: flex;
+        flex: 1 1 auto;
+        flex-wrap: wrap;
+        margin-block-end: 15px;
+        margin-block-start: 13px;
+        margin-inline-start: 13px;
+        position: relative;
+    }
+
+    .info-bar-content > span {
+        color: var(--wui-text-primary);
+        font-size: var(--wui-font-size-body-strong);
+        font-weight: 600;
+        line-height: 20px;
+        margin: 0;
+        margin-inline-end: 12px;
+    }
+
+    .info-bar-content > p {
+        flex: 1 1 auto;
+        margin-inline-end: 15px;
+        color: var(--wui-text-primary);
+        font-size: var(--wui-font-size-body);
+        font-weight: 400;
+        line-height: 20px;
+        margin: 0;
+    }
+
+    svg {
+    aspect-ratio: 1 / 1;
+    width: 8px;
+  }
+</style>

--- a/aspx/wwwroot/login.aspx
+++ b/aspx/wwwroot/login.aspx
@@ -2,6 +2,7 @@
 <%@ Register Src="./lib/controls/Header.ascx" TagName="Header" TagPrefix="raweb" %>
 <%@ Register Src="./lib/controls/head.ascx" TagName="head" TagPrefix="raweb" %>
 <%@ Register Src="./lib/controls/InfoBarCritical.ascx" TagName="InfoBarCritical" TagPrefix="winui" %>
+<%@ Register Src="./lib/controls/InfoBarCaution.ascx" TagName="InfoBarCaution" TagPrefix="winui" %>
 
 <!DOCTYPE html>
 <html lang="en">
@@ -77,7 +78,10 @@
     <raweb:Header runat="server" forceVisible="true"></raweb:Header>
 
     <div class="dialog-wrapper">
-        <div class="dialog">
+        <div class="dialog" style="display: flex; flex-direction: column;">
+        <div id="sslErrorMessage" style="display: none;">
+            <winui:InfoBarCaution runat="server" id="InfoBarCaution1" Visible="true" Title="Your credentials are at risk <span style='font-size: 13px; font-weight: 400; opacity: 0.7; position: absolute; top: -12px; right: 6px;'>Security Error 5003</span>" Message="This page is not secure. A malicious actor could steal your password." href="https://github.com/kimmknight/raweb/wiki/Trusting-the-RAWeb-server-(Fix-security-error-5003)" AnchorText="View solution" style="border-radius: var(--wui-overlay-corner-radius) var(--wui-overlay-corner-radius) 0 0; flex-grow: 0; flex-shrink: 0;" />
+        </div>
             <div class="dialog-body">
                 <h1 class="dialog-title">Sign in</h1>
                 <form action="login.aspx" runat="server"
@@ -299,7 +303,7 @@
         cursor: default;
         display: inline-flex;
         font-family: var(--wui-font-family-text);
-        font-size: var(--wui-body-font-size);
+        font-size: var(--wui-font-size-body);
         font-weight: 400;
         justify-content: center;
         line-height: 20px;
@@ -358,6 +362,40 @@
             window.location.href = currentOrigin + loginPath;
         }
     })
+</script>
+
+<script lang="javascript" type="module">
+    window.__base = '<%= ResolveUrl("~/") %>';
+    window.__iisBase = '<%= ResolveUrl("~/") %>' + '';
+
+    if ('serviceWorker' in navigator) {
+      try {
+        const registration = await navigator.serviceWorker.register(window.__base + 'service-worker.js', {
+          scope: window.__base,
+        });
+        if (registration.installing) {
+          console.debug('Service worker installing');
+        } else if (registration.waiting) {
+          console.debug('Service worker installed');
+        } else if (registration.active) {
+          console.debug('Service worker active');
+          registration.active.postMessage({ type: 'variable', key: '__iisBase', value: window.__iisBase });
+        }
+
+      } catch (error) {
+        console.error('Service worker registration registration failed: ', error);
+
+        if (
+          error instanceof Error &&
+          error.name === 'SecurityError' &&
+          error.message.includes('SSL certificate error')
+        ) {
+            document.querySelector('#sslErrorMessage').style.display = 'block';
+        }
+      }
+    } else {
+        document.querySelector('#sslErrorMessage').style.display = 'block';
+    }
 </script>
 
 <script lang="javascript">

--- a/aspx/wwwroot/login.aspx
+++ b/aspx/wwwroot/login.aspx
@@ -82,6 +82,7 @@
                 <h1 class="dialog-title">Sign in</h1>
                 <form action="login.aspx" runat="server"
                     class="content-wrapper">
+                    <asp:ScriptManager ID="ScriptManager1" runat="server" EnablePageMethods="true" />
                     <div class="content">
                         <p>
                             To continue to
@@ -347,6 +348,17 @@
 </style>
 
 </body>
+
+<script lang="javascript">
+    // redirect to the anonymous login if anonymous authentication is enabled
+    const currentOrigin = window.location.origin;
+    const loginPath = '<%= ResolveUrl("~/auth/login.aspx") %>';
+    PageMethods.CheckLoginPageForAnonymousAuthentication(currentOrigin + loginPath, (anonEnabled) => {
+        if (anonEnabled) {
+            window.location.href = currentOrigin + loginPath;
+        }
+    })
+</script>
 
 <script lang="javascript">
     async function authenticateUser(username, password) {

--- a/aspx/wwwroot/login.aspx.cs
+++ b/aspx/wwwroot/login.aspx.cs
@@ -1,7 +1,9 @@
 using AliasUtilities;
 using System;
 using System.DirectoryServices.AccountManagement;
+using System.Web;
 using System.Web.Security;
+using System.Web.Services;
 using System.Diagnostics;
 
 public partial class Login : System.Web.UI.Page
@@ -118,5 +120,25 @@ public partial class Login : System.Web.UI.Page
             // Handle other exceptions (e.g., network issues)
             return Environment.MachineName;
         }
+    }
+
+    [WebMethod]
+    public static bool CheckLoginPageForAnonymousAuthentication(string loginPageUrl)
+    {
+        if (HttpContext.Current == null) return false;
+
+        try
+        {
+            System.Net.HttpWebRequest request = (System.Net.HttpWebRequest)System.Net.WebRequest.Create(loginPageUrl);
+            using (System.Net.HttpWebResponse response = (System.Net.HttpWebResponse)request.GetResponse())
+            {
+                return true;
+            }
+        }
+        catch (Exception ex)
+        {
+            return false;
+        }
+        return false;
     }
 }


### PR DESCRIPTION
The login page will not show a secuity error when IIS is not configured with a trusted SSL certificate. This warning does not appear if connecting to RAWeb with a localhost URL. The solution button navigates the browser to https://github.com/kimmknight/raweb/wiki/Trusting-the-RAWeb-server-(Fix-security-error-5003) Closes #55 and #53.

<img width="446" alt="{D93BBA39-381B-4601-872F-956B7566E0EA}" src="https://github.com/user-attachments/assets/554f376b-a6c7-47d3-bb19-e2e9f6f2713c" />


Additionally, the login page will detect whether anonymous authentication is enabled on the auth folder. If it is enabled, the login page will redirect to /auth/login.aspx so that the anonymous authentication immediately activates. Closes #54.