### PR TITLE
Add internationalization support, including translations for common english variants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ aspx/wwwroot/lib/winui.css
 aspx/wwwroot/service-worker.js
 aspx/wwwroot/manifest.aspx
 aspx/wwwroot/lib/build.timestamp
+aspx/wwwroot/locales/

--- a/README.md
+++ b/README.md
@@ -12,19 +12,19 @@ To setup RemoteApps on your PC, try [RemoteApp Tool](https://github.com/kimmknig
 
 ## Features
 
-* A web interface for viewing your RemoteApp and Desktop RDP connections
-  * Search the list of apps and devices
-  * Favorite your most-used apps and devices for easy access
-  * Sort apps and desktops by name, date modifed, and terminal server
-  * Stale-while-revalidate caching for fast load times
-  * Progressive web app with [window controls overlay](https://github.com/WICG/window-controls-overlay/blob/main/explainer.md) support
-  * Follows the style and layout of WinUI 3
-* Fully-compliant Workspace (webfeed) feature to place your RemoteApps and desktop connections in:
-  *  The Start Menu of Windows clients
-  *  The Android/iOS/iPadOS/MacOS Windows app
-* File type associations on webfeed clients
-* Different RemoteApps for different users and groups
-* A setup script for easy installation
+- A web interface for viewing your RemoteApp and Desktop RDP connections
+  - Search the list of apps and devices
+  - Favorite your most-used apps and devices for easy access
+  - Sort apps and desktops by name, date modifed, and terminal server
+  - Stale-while-revalidate caching for fast load times
+  - Progressive web app with [window controls overlay](https://github.com/WICG/window-controls-overlay/blob/main/explainer.md) support
+  - Follows the style and layout of WinUI 3
+- Fully-compliant Workspace (webfeed) feature to place your RemoteApps and desktop connections in:
+  - The Start Menu of Windows clients
+  - The Android/iOS/iPadOS/MacOS Windows app
+- File type associations on webfeed clients
+- Different RemoteApps for different users and groups
+- A setup script for easy installation
 
 ## Installation
 
@@ -33,7 +33,7 @@ To setup RemoteApps on your PC, try [RemoteApp Tool](https://github.com/kimmknig
 
 2. **Copy and paste the code below, then press enter.**
 
- ```
+```
 irm https://github.com/kimmknight/raweb/releases/latest/download/install.ps1 | iex
 ```
 
@@ -66,7 +66,6 @@ If RAWeb is already installed, installing with this option will replace the exis
 1. Download the [latest RAWeb repository zip file](https://github.com/kimmknight/raweb/archive/master.zip).
 2. Extract the zip file and run **Setup.ps1** in PowerShell as administrator.
 
-
 ### Method 4. Manual installation in IIS
 
 Before you follow these steps, ensure you have installed Internet Information Services with the management console, ASP.NET 4.5, Windows authentication, and basic authentication.
@@ -75,7 +74,7 @@ Before you follow these steps, ensure you have installed Internet Information Se
 2. Extract the contents of the zip file to the desired location within your IIS website.
 3. In IIS, convert the folder to an application.
 4. On the **auth** subfolder only, disable **Anonymous Authentication** and enabled **Basic Authentication** and **Windows Authentication**
-Copy the **aspx/wwwroot** folder to the desired location within your IIS website(s). In IIS, convert the folder to an application. To enable authentication, on the **auth** subfolder only, disable *Anonymous Authentication* and enable *Windows Authentication*. 
+   Copy the **aspx/wwwroot** folder to the desired location within your IIS website(s). In IIS, convert the folder to an application. To enable authentication, on the **auth** subfolder only, disable _Anonymous Authentication_ and enable _Windows Authentication_.
 
 </details>
 
@@ -87,8 +86,12 @@ The following resources from the RAWeb wiki are also helpful when getting starte
 
 - [Publishing RemoteApps and Desktops](https://github.com/kimmknight/raweb/wiki/Publishing-RemoteApps-and-Desktops)
 - [File type associations for RAWeb webfeed clients](https://github.com/kimmknight/raweb/wiki/File-type-associations-for-RAWeb-webfeed-clients)
-- [Trusting the RAWeb server SSL certificate](https://github.com/kimmknight/raweb/wiki/Trusting-the-RAWeb-server-(Fix-security-error-5003))
+- [Trusting the RAWeb server SSL certificate](<https://github.com/kimmknight/raweb/wiki/Trusting-the-RAWeb-server-(Fix-security-error-5003)>)
 - [Configure hosting server and terminal server aliases](https://github.com/kimmknight/raweb/wiki/Configure-hosting-server-and-terminal-server-aliases)
+
+## Translations
+
+Please follow the instructions at [TRANSLATING.md](TRANSLATING.md) to add or update translations.
 
 ## Screenshots
 

--- a/TRANSLATING.md
+++ b/TRANSLATING.md
@@ -1,0 +1,93 @@
+# Translating RA Web
+
+This guide is for contributing translations to RA Web.
+
+## Translation File Locations and Formats
+
+Translation files are located in two main directories and use different formats:
+
+1.  **Main Application:**
+
+    - **Location:** `frontend/lib/public/locales/{{locale}}.json`
+    - **Format:** **JSON**
+    - Replace `{{locale}}` with the language code (e.g., `en-GB`, `fr`, `es`).
+
+2.  **Login and Logoff Pages:**
+    - **Location:** `aspx/wwwroot/App_GlobalResources/WebResources.{{locale}}.resx`
+    - **Format:** **.RESX** (XML-based resource file)
+    - Replace `{{locale}}` with the language code (e.g., `en-GB`, `fr`, `es`).
+
+**For a brand new language, you will need to create a new file in the correct location.** For existing languages, the file will already be present.
+
+## How to Translate and Add Missing Keys
+
+Often, new features are added, and the base language files are updated with new strings. These new keys will be missing from the translation files. Here's how to handle this:
+
+### Identifying Missing Keys
+
+- **In the Application:** If you are testing the application with a non-base language, you might see the base language string displayed instead of the translated string. This indicates a missing key.
+- **Comparing Files:** You can compare the base language file (e.g., `en.json` or `WebResources.en.resx`) with the translation file for your language. Keys present in the base file but not in the translation file are missing.
+
+### Adding and Translating Missing Keys
+
+Once you've identified missing keys, follow these steps to add them to your translation file:
+
+### For Main Application (.json files)
+
+1.  Locate the `frontend/lib/public/locales/` directory.
+2.  Find the `.json` file for the language you want to translate (or create it if it's a new language).
+3.  Open the base language `.json` file (e.g., `en.json`) to find the new keys and their base language values.
+4.  Add the missing keys to your language's `.json` file, maintaining the correct JSON structure.
+5.  Translate the text value for each new key. **Do not change the key names.**
+6.  Preserve any placeholders (like `{{name}}`, `{count}`) or HTML tags within the strings.
+
+Example (`.json`):
+
+```json
+{
+  "existing_key": "Existing Translation",
+  "new_key": "New Translation for New Key" // add and translate the new key
+}
+```
+
+### For Login and Logoff Pages (.resx files)
+
+1.  Locate the `aspx/wwwroot/App_GlobalResources/` directory.
+2.  Find the `.resx` file for the language you want to translate (or create it if it's a new language).
+3.  Open the base language `.resx` file (e.g., `WebResources.en.resx`) to find the new `<data>` elements.
+4.  Copy the entire `<data>` element for the missing key from the base `.resx` file and paste it into your language's `.resx` file, maintaining the correct XML structure.
+5.  Translate the content inside the `<value>` tags for the newly added `<data>` elements. **Do not change the `<name>` attribute of the `<data>` elements.**
+6.  Be careful to preserve any placeholders or formatting specific to `.resx` files.
+
+Example (`.resx` - simplified):
+
+```xml
+<root>
+  <data name="existing_key" xml:space="preserve">
+    <value>Existing Translation</value>
+  </data>
+  <data name="new_key" xml:space="preserve">
+    <value>New Translation for New Key</value> <!-- Add and translate the new data element -->
+  </data>
+</root>
+```
+
+Translate the content inside the `<value>` tags for the new key.
+
+## Submitting Your Translations
+
+To submit your translations:
+
+1.  Fork the [RA Web repository](https://github.com/kimmknight/raweb).
+2.  Clone your forked repository.
+3.  Create a new branch for your translation work (e.g., `translate/fr-main`, `translate/es-login`).
+4.  Add your translated content, including any newly added keys, to the relevant `.json` and/or `.resx` file(s) (creating a new file if necessary for a new language).
+5.  Commit your changes with a clear message (e.g., `feat(i18n): Add French login translations`, `feat(i18n): Update Spanish main app with new keys`).
+6.  Push your branch to your fork.
+7.  Open a Pull Request to the main [RA Web repository](https://github.com/kimmknight/raweb). Mention the language and which part(s) of the app you've translated in the PR description.
+
+## Need Help?
+
+If you have questions or need clarification on a string's context, or are unsure how to add missing keys, please open an issue on the [issue tracker](https://github.com/kimmknight/raweb/issues) with the label `i18n` or `translation`.
+
+Thank you for your contribution!

--- a/aspx/wwwroot/App_GlobalResources/WebResources.resx
+++ b/aspx/wwwroot/App_GlobalResources/WebResources.resx
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+    <resheader name="resmimetype">
+        <value>text/microsoft-resx</value>
+    </resheader>
+    <resheader name="version">
+        <value>2.0</value>
+    </resheader>
+    <resheader name="reader">
+        <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    </resheader>
+    <resheader name="writer">
+        <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    </resheader>
+
+    <data name="LongAppName" xml:space="preserve">
+        <value>RemoteApp and Desktop Connections</value>
+    </data>
+    <data name="AppName" xml:space="preserve">
+        <value>RemoteApps</value>
+    </data>
+    <data name="SignOut_PageTitle" xml:space="preserve">
+        <value>RemoteApps - Signing out</value>
+    </data>
+    <data name="SignOut_Title" xml:space="preserve">
+        <value>Signing out</value>
+    </data>
+    <data name="PleaseWait" xml:space="preserve">
+        <value>Please wait</value>
+    </data>
+    <data name="SignIn_PageTitle" xml:space="preserve">
+        <value>Sign in - RemoteApps</value>
+    </data>
+    <data name="SignIn_DialogTitle" xml:space="preserve">
+        <value>Sign in</value>
+    </data>
+    <data name="SignIn_DialogCaptionContinue" xml:space="preserve">
+        <value>To continue to</value>
+    </data>
+    <data name="SignIn_DialogCaptionOn" xml:space="preserve">
+        <value>on</value>
+    </data>
+    <data name="Domain" xml:space="preserve">
+        <value>Domain</value>
+    </data>
+    <data name="Username" xml:space="preserve">
+        <value>Username</value>
+    </data>
+    <data name="Password" xml:space="preserve">
+        <value>Password</value>
+    </data>
+    <data name="PoweredBy" xml:space="preserve">
+        <value>Powered by RAWeb</value>
+    </data>
+    <data name="SignIn_PoweredBy_LearnMore" xml:space="preserve">
+        <value>Learn more</value>
+    </data>
+    <data name="SignIn_Continue" xml:space="preserve">
+        <value>Continue</value>
+    </data>
+    <data name="Login_IncorrectUsernameOrPassword" xml:space="preserve">
+        <value>Incorrect username or password.</value>
+    </data>
+    <data name="Login_UnfoundDomain" xml:space="preserve">
+        <value>Could not find the specified domain. Please check your domain name and try again.</value>
+    </data>
+    <data name="Login_LocalMachineError" xml:space="preserve">
+        <value>Something went wrong while validating credentials against the local machine. Please try again later.</value>
+    </data>
+    <data name="SecError5003" xml:space="preserve">
+        <value>Security Error 5003</value>
+    </data>
+    <data name="SecError5003_Title" xml:space="preserve">
+        <value>Your credentials are at risk</value>
+    </data>
+    <data name="SecError5003_Message" xml:space="preserve">
+        <value>This page is not secure. A malicious actor could steal your password.</value>
+    </data>
+    <data name="SecError5003_Action" xml:space="preserve">
+        <value>View solution</value>
+    </data>
+</root>

--- a/aspx/wwwroot/Web.config
+++ b/aspx/wwwroot/Web.config
@@ -12,6 +12,7 @@
       <compilation defaultLanguage="C#" targetFramework="4.0">
       </compilation>
       <customErrors mode="Off" />
+      <globalization culture="auto" uiCulture="auto" />
    </system.web>
    <system.webServer>
       <staticContent>
@@ -20,15 +21,15 @@
          <mimeMap fileExtension=".mjs" mimeType="application/javascript" />
          <mimeMap fileExtension=".webp" mimeType="image/webp" />
       </staticContent>
-        <caching>
-            <profiles>
-                <add extension=".aspx" policy="CacheForTimePeriod" kernelCachePolicy="DontCache" duration="00:00:01" />
-                <add extension=".css" policy="CacheForTimePeriod" kernelCachePolicy="DontCache" duration="00:00:01" />
-                <add extension=".mjs" policy="CacheForTimePeriod" kernelCachePolicy="DontCache" duration="00:00:01" />
-                <add extension=".rdp" policy="CacheForTimePeriod" kernelCachePolicy="DontCache" duration="00:00:01" />
-                <add extension=".ts" policy="CacheForTimePeriod" kernelCachePolicy="DontCache" duration="00:00:01" />
-                <add extension=".vue" policy="CacheForTimePeriod" kernelCachePolicy="DontCache" duration="00:00:01" />
-            </profiles>
-        </caching>
+      <caching>
+         <profiles>
+            <add extension=".aspx" policy="CacheForTimePeriod" kernelCachePolicy="DontCache" duration="00:00:01" />
+            <add extension=".css" policy="CacheForTimePeriod" kernelCachePolicy="DontCache" duration="00:00:01" />
+            <add extension=".mjs" policy="CacheForTimePeriod" kernelCachePolicy="DontCache" duration="00:00:01" />
+            <add extension=".rdp" policy="CacheForTimePeriod" kernelCachePolicy="DontCache" duration="00:00:01" />
+            <add extension=".ts" policy="CacheForTimePeriod" kernelCachePolicy="DontCache" duration="00:00:01" />
+            <add extension=".vue" policy="CacheForTimePeriod" kernelCachePolicy="DontCache" duration="00:00:01" />
+         </profiles>
+      </caching>
    </system.webServer>
 </configuration>

--- a/aspx/wwwroot/lib/controls/AppRoot.ascx
+++ b/aspx/wwwroot/lib/controls/AppRoot.ascx
@@ -37,7 +37,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, viewport-fit=cover">
-    <title><%= resolver.Resolve(System.Net.Dns.GetHostName()) %> - RemoteApps</title>
+    <title><%= resolver.Resolve(System.Net.Dns.GetHostName()) %> - <%= Resources.WebResources.AppName %></title>
     <link rel="stylesheet" href='<%= ResolveUrl("~/lib/winui.css") %>'>
     <meta name="theme-color" content="hsl(0, 0%, 14%)" media="(prefers-color-scheme: dark)">
     <meta name="theme-color" content="hsl(122, 39%, 40%)">
@@ -235,7 +235,7 @@
         </svg>
 
 
-        <span class="root-splash-note">Powered by RAWeb</span>
+        <span class="root-splash-note"><%= Resources.WebResources.PoweredBy %></span>
         <span class="root-splash-note" style="bottom: 150px">
             <svg tabindex="-1" class="progress-ring indeterminate" width="32" height="32" viewBox="0 0 16 16"
                 role="status">

--- a/aspx/wwwroot/lib/controls/Header.ascx
+++ b/aspx/wwwroot/lib/controls/Header.ascx
@@ -8,7 +8,7 @@
 <header class="app-header">
     <div class="left">
         <img src="<%= ResolveUrl("~/lib/assets/icon.svg") %>" alt="" class="logo" />
-        <span class="title">RemoteApps</span>
+        <span class="title"><%= Resources.WebResources.AppName %></span>
     </div>
 </header>
 

--- a/aspx/wwwroot/login.aspx
+++ b/aspx/wwwroot/login.aspx
@@ -7,7 +7,7 @@
 <!DOCTYPE html>
 <html lang="en">
 
-<raweb:head runat="server" title="RemoteApps - Sign in" additional='<meta cache-control="no-cache, no-store, must-revalidate" />'/>
+<raweb:head runat="server" title="<%$ Resources: WebResources, SignIn_PageTitle %>" additional='<meta cache-control="no-cache, no-store, must-revalidate" />'/>
 
 <style>
     .input {
@@ -80,21 +80,21 @@
     <div class="dialog-wrapper">
         <div class="dialog" style="display: flex; flex-direction: column;">
         <div id="sslErrorMessage" style="display: none;">
-            <winui:InfoBarCaution runat="server" id="InfoBarCaution1" Visible="true" Title="Your credentials are at risk <span style='font-size: 13px; font-weight: 400; opacity: 0.7; position: absolute; top: -12px; right: 6px;'>Security Error 5003</span>" Message="This page is not secure. A malicious actor could steal your password." href="https://github.com/kimmknight/raweb/wiki/Trusting-the-RAWeb-server-(Fix-security-error-5003)" AnchorText="View solution" style="border-radius: var(--wui-overlay-corner-radius) var(--wui-overlay-corner-radius) 0 0; flex-grow: 0; flex-shrink: 0;" />
+            <winui:InfoBarCaution runat="server" id="InfoBarSecurityError5003" Visible="true" Title="<%$ Resources: WebResources, SecError5003_Title %>" Message="<%$ Resources: WebResources, SecError5003_Message %>" href="https://github.com/kimmknight/raweb/wiki/Trusting-the-RAWeb-server-(Fix-security-error-5003)" AnchorText="<%$ Resources: WebResources, SecError5003_Action %>" style="border-radius: var(--wui-overlay-corner-radius) var(--wui-overlay-corner-radius) 0 0; flex-grow: 0; flex-shrink: 0;" />
         </div>
             <div class="dialog-body">
-                <h1 class="dialog-title">Sign in</h1>
+                <h1 class="dialog-title"><%= Resources.WebResources.SignIn_DialogTitle %></h1>
                 <form action="login.aspx" runat="server"
                     class="content-wrapper">
                     <asp:ScriptManager ID="ScriptManager1" runat="server" EnablePageMethods="true" />
                     <div class="content">
                         <p>
-                            To continue to
+                            <%= Resources.WebResources.SignIn_DialogCaptionContinue %>
                             <strong>
-                                RemoteApp and Desktop Connections
+                                <%= Resources.WebResources.LongAppName %>
                             </strong>
                             <span style="white-space: nowrap;">
-                                on
+                                <%= Resources.WebResources.SignIn_DialogCaptionOn %>
                                 <strong>
                                     <%= resolver.Resolve(Environment.MachineName) %>
                                 </strong>
@@ -105,7 +105,7 @@
                              />
 
                         <div class="input" id="username-group">
-                            <div class="textblock">Domain\Username</div>
+                            <div class="textblock"><%= Resources.WebResources.Domain %>\<%= Resources.WebResources.Username %></div>
                             <div class="text-box-container">
                                 <input class="text-box" name="username" autocomplete="username" required id="Username" runat="server" autofocus autocorrect="off" autocapitalize="off" spellcheck="false" />
                                 <div class="text-box-underline"></div>
@@ -113,7 +113,7 @@
                         </div>
 
                         <div class="input">
-                            <div class="textblock">Password</div>
+                            <div class="textblock"><%= Resources.WebResources.Password %></div>
                             <div class="text-box-container">
                                 <input class="text-box" name="password" type="password"
                                     autocomplete="current-password" required id="password" runat="server" autocorrect="off" autocapitalize="off" spellcheck="false" />
@@ -122,10 +122,10 @@
                         </div>
 
                         <p class="access">
-                            Powered by RAWeb
+                            <%= Resources.WebResources.PoweredBy %>
                             <br />
                             <a href="https://github.com/kimmknight/raweb" class="button style-hyperlink unindent">
-                                Learn more
+                                <%= Resources.WebResources.SignIn_PoweredBy_LearnMore %>
                             </a>
                         </p>
                     </div>

--- a/aspx/wwwroot/login.aspx.cs
+++ b/aspx/wwwroot/login.aspx.cs
@@ -21,6 +21,14 @@ public partial class Login : System.Web.UI.Page
         Response.Cache.SetNoStore();
         Response.Cache.SetExpires(DateTime.UtcNow.AddMinutes(-1));
 
+        // set the title of the security error info bar
+        // (we set it here because it mixes resource strings with static text)
+        InfoBarSecurityError5003.Title =
+            Resources.WebResources.SecError5003_Title +
+            "<span style='font-size: 13px; font-weight: 400; opacity: 0.7; position: absolute; top: -12px; right: 6px;'>" +
+            Resources.WebResources.SecError5003 +
+            "</span>";
+
         if (IsPostBack)
         {
 
@@ -60,7 +68,7 @@ public partial class Login : System.Web.UI.Page
             }
             else
             {
-                InfoBarCritical1.Message = errorMessage != null ? System.Web.HttpUtility.HtmlEncode(errorMessage) : "Incorrect username or password.";
+                InfoBarCritical1.Message = errorMessage != null ? System.Web.HttpUtility.HtmlEncode(errorMessage) : Resources.WebResources.Login_IncorrectUsernameOrPassword;
                 InfoBarCritical1.Visible = true;
             }
 
@@ -90,7 +98,7 @@ public partial class Login : System.Web.UI.Page
             }
             catch (Exception ex)
             {
-                return Tuple.Create(false, "Something went wrong while validating credentials against the local machine. Please try again later.", (PrincipalContext)null);
+                return Tuple.Create(false, Resources.WebResources.Login_LocalMachineError, (PrincipalContext)null);
             }
         }
 
@@ -101,7 +109,7 @@ public partial class Login : System.Web.UI.Page
         }
         catch (Exception ex)
         {
-            return Tuple.Create(false, "Could not find the specified domain. Please check your domain name and try again.", (PrincipalContext)null);
+            return Tuple.Create(false, Resources.WebResources.Login_UnfoundDomain, (PrincipalContext)null);
         }
     }
 

--- a/aspx/wwwroot/logoff.aspx
+++ b/aspx/wwwroot/logoff.aspx
@@ -5,7 +5,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
 
-<raweb:head runat="server" title="RemoteApps - Signing out" additional='<meta cache-control="no-cache, no-store, must-revalidate" />'/>
+<raweb:head runat="server" title="<%$ Resources: WebResources, SignOut_PageTitle %>" additional='<meta cache-control="no-cache, no-store, must-revalidate" />'/>
 
 <body>
     <raweb:Header runat="server" forceVisible="true"></raweb:Header>
@@ -54,8 +54,8 @@
     </script>
 
     <div>
-        <h1>Signing out</h1>
-        <p>Please wait...</p>
+        <h1><%= Resources.WebResources.SignOut_Title %></h1>
+        <p><%= Resources.WebResources.PleaseWait %>...</p>
     </div>
 
     <style>

--- a/frontend/dev.ps1
+++ b/frontend/dev.ps1
@@ -1,0 +1,15 @@
+# change the working directory to the script's directory
+$oldWorkingDir = Get-Location
+cd $PSScriptRoot
+
+# temporarily add binaries to PATH
+$binDir = "$PSScriptRoot/bin"
+$env:PATH = "$binDir;$env:PATH"
+
+# install dependencies if not already installed
+if (-not (Test-Path "node_modules")) {
+    pnpm install --loglevel=warn
+}
+
+# build frontend in watch mode
+pnpm build --watch

--- a/frontend/lib/App.vue
+++ b/frontend/lib/App.vue
@@ -12,6 +12,7 @@
     useWebfeedData,
   } from '$utils';
   import { computed, onMounted, ref, watch, watchEffect } from 'vue';
+  import { i18nextPromise } from './i18n';
   import Apps from './pages/Apps.vue';
   import Devices from './pages/Devices.vue';
   import Favorites from './pages/Favorites.vue';
@@ -154,6 +155,13 @@
     }
   });
 
+  // track whether i18n is ready
+  const i18nReady = ref(false);
+  i18nextPromise.then(() => {
+    i18nReady.value = true;
+    console.log('ready');
+  });
+
   // track whether the component has been mounted
   const mounted = ref(false);
   onMounted(() => {
@@ -161,7 +169,7 @@
   });
 
   watchEffect(() => {
-    if (mounted.value && data.value && !error.value) {
+    if (mounted.value && data.value && !error.value && i18nReady.value) {
       removeSplashScreen();
     }
   });
@@ -230,24 +238,21 @@
           <InfoBar
             severity="caution"
             v-if="sslError"
-            title="Security Error 5003"
+            :title="$t('securityError503.title')"
             style="
               margin: calc(-1 * var(--padding)) calc(-1 * var(--padding)) var(--padding)
                 calc(-1 * var(--padding));
               border-radius: 0;
             "
           >
-            The service worker failed to install because the SSL certificate is not trusted by your device. Add
-            the certificate to the trusted root certification authorities store on this computer or configure
-            RAWeb to use a trusted certificate. Performance and functionality may be limited. Offline feaures
-            are unavailable.
+            {{ $t('securityError503.message') }}
             <br />
             <Button
               variant="hyperlink"
               href="https://github.com/kimmknight/raweb/wiki/Trusting-the-RAWeb-server-(Fix-security-error-5003)"
               style="margin-left: -11px; margin-bottom: -6px"
             >
-              Learn more
+              {{ $t('securityError503.action') }}
             </Button>
           </InfoBar>
           <Favorites :data v-if="hash === '#favorites'" />

--- a/frontend/lib/components/ItemCard/DesktopCard.vue
+++ b/frontend/lib/components/ItemCard/DesktopCard.vue
@@ -71,7 +71,7 @@
         </TextBlock>
       </div>
       <div class="buttons">
-        <Button variant="accent" @click="openTsPickerDialog">Connect</Button>
+        <Button variant="accent" @click="openTsPickerDialog">{{ $t('resource.menu.connect') }}</Button>
         <MenuFlyout placement="top" v-if="!shouldHideMenu">
           <template v-slot="{ popoverId }">
             <IconButton :popovertarget="popoverId" @click.stop>
@@ -93,7 +93,7 @@
                 v-if="favoriteTerminalServers.includes(host.id)"
                 @click="setFavorite(host.id, false)"
               >
-                Remove from favorites
+                {{ $t('resource.menu.favRemove') }}
                 <template v-slot:icon>
                   <svg
                     width="24"
@@ -110,7 +110,7 @@
                 </template>
               </MenuFlyoutItem>
               <MenuFlyoutItem v-else @click="setFavorite(host.id, true)">
-                Add to favorites
+                {{ $t('resource.menu.favAdd') }}
                 <template v-slot:icon>
                   <svg
                     width="24"
@@ -128,7 +128,7 @@
               </MenuFlyoutItem>
             </template>
             <MenuFlyoutItem @click="openPropertiesDialog" v-if="canUseDialogs">
-              Properties
+              {{ $t('resource.menu.props') }}
               <template v-slot:icon>
                 <svg width="24" height="24" fill="none" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
                   <path

--- a/frontend/lib/components/ItemCard/GenericResourceCardMenuButton.vue
+++ b/frontend/lib/components/ItemCard/GenericResourceCardMenuButton.vue
@@ -49,7 +49,7 @@
     </template>
     <template v-slot:menu>
       <MenuFlyoutItem @click="openTsPickerDialog">
-        Connect
+        {{ $t('resource.menu.connect') }}
         <template v-slot:icon>
           <svg width="24" height="24" fill="none" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
             <path
@@ -62,7 +62,7 @@
       <template v-for="host in resource.hosts" :key="host.id" v-if="favoritesEnabled && !simpleModeEnabled">
         <MenuFlyoutItem v-if="favoriteTerminalServers.includes(host.id)" @click="setFavorite(host.id, false)">
           <span class="dual-line-menu-item">
-            <span>Remove from favorites</span>
+            <span>{{ $t('resource.menu.favRemove') }}</span>
             <span v-if="resource.hosts.length > 1">{{ terminalServerAliases[host.name] ?? host.name }}</span>
           </span>
           <template v-slot:icon>
@@ -76,7 +76,7 @@
         </MenuFlyoutItem>
         <MenuFlyoutItem v-else @click="setFavorite(host.id, true)">
           <span class="dual-line-menu-item">
-            <span>Add to favorites</span>
+            <span>{{ $t('resource.menu.favAdd') }}</span>
             <span v-if="resource.hosts.length > 1">{{ terminalServerAliases[host.name] ?? host.name }}</span>
           </span>
           <template v-slot:icon>
@@ -90,7 +90,7 @@
         </MenuFlyoutItem>
       </template>
       <MenuFlyoutItem @click="openPropertiesDialog" v-if="canUseDialogs">
-        Properties
+        {{ $t('resource.menu.props') }}
         <template v-slot:icon>
           <svg width="24" height="24" fill="none" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
             <path

--- a/frontend/lib/components/ItemCard/PropertiesDialog.vue
+++ b/frontend/lib/components/ItemCard/PropertiesDialog.vue
@@ -2,7 +2,7 @@
   import Button from '$components/Button/Button.vue';
   import ContentDialog from '$components/ContentDialog/ContentDialog.vue';
   import TextBlock from '$components/TextBlock/TextBlock.vue';
-  import { raw } from '$utils';
+  import { capitalize, raw } from '$utils';
   import { computed, ref, useTemplateRef } from 'vue';
   import TerminalServerPickerDialog from './TerminalServerPickerDialog.vue';
 
@@ -67,7 +67,7 @@
 
 <template>
   <ContentDialog
-    :title="`Properties`"
+    :title="$t('resource.props.title')"
     ref="propertiesDialog"
     size="max"
     @beforeClose="resetSelectedTerminalServer"
@@ -75,24 +75,28 @@
   >
     <div v-if="properties" class="properties">
       <div class="property">
-        <TextBlock variant="bodyStrong">{{ resource.type === 'Desktop' ? 'Device' : 'Application' }}</TextBlock>
+        <TextBlock variant="bodyStrong">{{
+          capitalize(resource.type === 'Desktop' ? $t('device') : $t('application'))
+        }}</TextBlock>
         <TextBlock variant="caption">{{ resource.title }}</TextBlock>
       </div>
       <div class="property">
-        <TextBlock variant="bodyStrong">Terminal server</TextBlock>
+        <TextBlock variant="bodyStrong">{{ $t('resource.props.ts') }}</TextBlock>
         <TextBlock variant="caption">
           {{ terminalServerAliases[selectedTerminalServer || ''] ?? selectedTerminalServer }}
         </TextBlock>
       </div>
       <div class="property" v-for="(value, key) in properties" :key="key">
         <TextBlock variant="bodyStrong">{{ key }}</TextBlock>
-        <TextBlock variant="caption" v-if="key === ''" style="font-size: italic">empty</TextBlock>
+        <TextBlock variant="caption" v-if="key === ''" style="font-size: italic">{{
+          $t('resource.props.empty')
+        }}</TextBlock>
         <TextBlock variant="caption" v-else>{{ value }}</TextBlock>
       </div>
     </div>
 
     <template v-slot:footer>
-      <Button @click="closeDialog">Close</Button>
+      <Button @click="closeDialog">{{ $t('dialog.close') }}</Button>
     </template>
   </ContentDialog>
 

--- a/frontend/lib/components/ItemCard/TerminalServerPickerDialog.vue
+++ b/frontend/lib/components/ItemCard/TerminalServerPickerDialog.vue
@@ -131,7 +131,7 @@
 
 <template>
   <ContentDialog
-    :title="`Select a terminal server for ${props.resource.title}`"
+    :title="`${$t('resource.tsPicker.title')} ${props.resource.title}`"
     ref="tsPickerDialog"
     @contextmenu.stop
     @keydown.stop
@@ -151,7 +151,7 @@
     </div>
 
     <template v-slot:footer>
-      <Button @click="submit" @keydown.stop="handleSubmitKeydown">Just once</Button>
+      <Button @click="submit" @keydown.stop="handleSubmitKeydown">{{ $t('dialog.once') }}</Button>
     </template>
   </ContentDialog>
 </template>

--- a/frontend/lib/components/Layout/HeaderActions.vue
+++ b/frontend/lib/components/Layout/HeaderActions.vue
@@ -52,29 +52,29 @@
         <template v-slot="{ popoverId }">
           <Button :popovertarget="popoverId" @click.stop>
             <template v-slot:icon><span v-swap="sortIcon"></span></template>
-            <span class="label">Sort</span>
+            <span class="label">{{ $t('actions.sort.label') }}</span>
             <template v-slot:icon-end><span v-swap="chevronDown"></span></template>
           </Button>
         </template>
         <template v-slot:menu>
           <MenuFlyoutItem @click="() => (sortName = 'Name')" :selected="sortName === 'Name'">
-            Name
+            {{ $t('actions.sort.name') }}
           </MenuFlyoutItem>
           <MenuFlyoutItem
             @click="() => (sortName = 'Terminal server')"
             :selected="sortName === 'Terminal server'"
           >
-            Terminal server
+            {{ $t('actions.sort.ts') }}
           </MenuFlyoutItem>
           <MenuFlyoutItem @click="() => (sortName = 'Date modified')" :selected="sortName === 'Date modified'">
-            Date modified
+            {{ $t('actions.sort.date') }}
           </MenuFlyoutItem>
-          <MenuFlyoutDivider>hmm</MenuFlyoutDivider>
+          <MenuFlyoutDivider />
           <MenuFlyoutItem @click="() => (sortOrder = 'asc')" :selected="sortOrder === 'asc'">
-            Ascending
+            {{ $t('actions.sort.asc') }}
           </MenuFlyoutItem>
           <MenuFlyoutItem @click="() => (sortOrder = 'desc')" :selected="sortOrder === 'desc'">
-            Descending
+            {{ $t('actions.sort.desc') }}
           </MenuFlyoutItem>
         </template>
       </MenuFlyout>
@@ -82,26 +82,26 @@
         <template v-slot="{ popoverId }">
           <Button :popovertarget="popoverId" @click.stop>
             <template v-slot:icon><span v-swap="view"></span></template>
-            <span class="label">View</span>
+            <span class="label">{{ $t('actions.view.label') }}</span>
             <template v-slot:icon-end><span v-swap="chevronDown"></span></template>
           </Button>
         </template>
         <template v-slot:menu>
           <MenuFlyoutItem @click="() => (mode = 'card')" :selected="mode === 'card'">
             <template v-slot:icon><span v-swap="rectangle"></span></template>
-            Card
+            {{ $t('actions.view.card') }}
           </MenuFlyoutItem>
           <MenuFlyoutItem @click="() => (mode = 'grid')" :selected="mode === 'grid'">
             <template v-slot:icon><span v-swap="grid"></span></template>
-            Grid
+            {{ $t('actions.view.grid') }}
           </MenuFlyoutItem>
           <MenuFlyoutItem @click="() => (mode = 'tile')" :selected="mode === 'tile'">
             <template v-slot:icon><span v-swap="tiles"></span></template>
-            Tile
+            {{ $t('actions.view.tile') }}
           </MenuFlyoutItem>
           <MenuFlyoutItem @click="() => (mode = 'list')" :selected="mode === 'list'">
             <template v-slot:icon><span v-swap="content"></span></template>
-            List
+            {{ $t('actions.view.list') }}
           </MenuFlyoutItem>
         </template>
       </MenuFlyout>
@@ -109,7 +109,7 @@
         <template v-slot="{ popoverId }">
           <Button :popovertarget="popoverId" @click.stop>
             <template v-slot:icon><span v-swap="server"></span></template>
-            <span class="label">Terminal servers</span>
+            <span class="label">{{ $t('actions.ts.label') }}</span>
             <template v-slot:icon-end><span v-swap="chevronDown"></span></template>
           </Button>
         </template>
@@ -140,7 +140,7 @@
             <template v-slot:icon v-if="terminalServersFilter.length === 0">
               <span v-swap="checkmark"></span>
             </template>
-            All terminal servers
+            {{ $t('actions.ts.all') }}
           </MenuFlyoutItem>
         </template>
       </MenuFlyout>

--- a/frontend/lib/components/Navigation/NavigationRail.vue
+++ b/frontend/lib/components/Navigation/NavigationRail.vue
@@ -48,7 +48,7 @@
                 />
               </svg>
             </template>
-            Favorites
+            {{ $t('favorites.title') }}
           </RailButton>
         </li>
         <li>
@@ -69,7 +69,7 @@
                 />
               </svg>
             </template>
-            Devices
+            {{ $t('devices.title') }}
           </RailButton>
         </li>
         <li>
@@ -90,7 +90,7 @@
                 />
               </svg>
             </template>
-            Apps
+            {{ $t('apps.title') }}
           </RailButton>
         </li>
       </ul>
@@ -113,7 +113,7 @@
             />
           </svg>
         </template>
-        Settings
+        {{ $t('settings.title') }}
       </RailButton>
       <RailButton
         href="https://github.com/kimmknight/raweb/wiki"
@@ -132,7 +132,7 @@
             />
           </svg>
         </template>
-        Wiki
+        {{ $t('wiki.title') }}
       </RailButton>
     </div>
   </div>

--- a/frontend/lib/components/Titlebar/Titlebar.vue
+++ b/frontend/lib/components/Titlebar/Titlebar.vue
@@ -157,7 +157,7 @@
         </template>
         <template v-slot:menu>
           <MenuFlyoutItem hint="Alt + L" @click="signOut">
-            Sign out
+            {{ $t('profile.signOut') }}
             <template v-slot:icon>
               <svg width="24" height="24" fill="none" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
                 <path

--- a/frontend/lib/entry.dist.mjs
+++ b/frontend/lib/entry.dist.mjs
@@ -1,7 +1,8 @@
 import { createApp } from 'vue';
 import App from './App.vue';
+import i18n from './i18n.ts';
 
-const app = createApp(App);
+const app = i18n(createApp(App));
 
 app.directive('swap', (el, binding) => {
   if (el.parentNode) {

--- a/frontend/lib/i18n.ts
+++ b/frontend/lib/i18n.ts
@@ -1,0 +1,26 @@
+import i18next from 'i18next';
+import Backend from 'i18next-http-backend';
+import I18NextVue from 'i18next-vue';
+import { App } from 'vue';
+
+export const i18nextPromise = i18next
+  .use(
+    new Backend(null, {
+      loadPath: window.__base + 'locales/{{lng}}.json',
+    })
+  )
+  .init({
+    debug: false,
+    lng: (() => {
+      if (typeof window === 'undefined' || !('language' in navigator)) {
+        return undefined;
+      }
+      return navigator.language;
+    })(),
+    fallbackLng: 'en',
+  });
+
+export default function (app: App) {
+  app.use(I18NextVue, { i18next });
+  return app;
+}

--- a/frontend/lib/pages/Apps.vue
+++ b/frontend/lib/pages/Apps.vue
@@ -66,7 +66,7 @@
 
 <template>
   <div class="titlebar-row">
-    <TextBlock variant="title" tag="h1">Apps</TextBlock>
+    <TextBlock variant="title" tag="h1">{{ $t('apps.title') }}</TextBlock>
     <HeaderActions
       :data="props.data"
       :resourceTypes="['RemoteApp']"
@@ -75,7 +75,7 @@
       v-model:sortOrder="sortOrder"
       v-model:terminalServersFilter="terminalServersFilter"
       v-model:query="query"
-      searchPlaceholder="Search apps"
+      :searchPlaceholder="$t('apps.search')"
     />
   </div>
 

--- a/frontend/lib/pages/Devices.vue
+++ b/frontend/lib/pages/Devices.vue
@@ -40,14 +40,14 @@
 
 <template>
   <div class="titlebar-row">
-    <TextBlock variant="title" tag="h1">Devices</TextBlock>
+    <TextBlock variant="title" tag="h1">{{ $t('devices.title') }}</TextBlock>
     <HeaderActions
       :data="props.data"
       v-model:mode="mode"
       v-model:sortName="sortName"
       v-model:sortOrder="sortOrder"
       v-model:query="query"
-      searchPlaceholder="Search devices"
+      :searchPlaceholder="$t('devices.search')"
     />
   </div>
 

--- a/frontend/lib/pages/Favorites.vue
+++ b/frontend/lib/pages/Favorites.vue
@@ -116,13 +116,13 @@
 
 <template>
   <div class="titlebar-row">
-    <TextBlock variant="title">Favorites</TextBlock>
+    <TextBlock variant="title">{{ $t('favorites.title') }}</TextBlock>
   </div>
   <section class="favorite-devices" v-if="desktops.length > 0">
     <div class="section-title-row">
-      <TextBlock variant="subtitle">Devices</TextBlock>
+      <TextBlock variant="subtitle">{{ $t('devices.title') }}</TextBlock>
       <Button href="#devices">
-        All devices
+        {{ $t('favorites.allDevices') }}
         <template v-slot:icon-end>
           <svg width="24" height="24" fill="none" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
             <path
@@ -161,9 +161,9 @@
   </section>
   <section class="favorite-apps" v-if="apps.length > 0">
     <div class="section-title-row">
-      <TextBlock variant="subtitle">Apps</TextBlock>
+      <TextBlock variant="subtitle">{{ $t('apps.title') }}</TextBlock>
       <Button href="#apps">
-        All apps
+        {{ $t('favorites.allApps') }}
         <template v-slot:icon-end>
           <svg width="24" height="24" fill="none" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
             <path
@@ -184,17 +184,17 @@
   </section>
 
   <div class="no-favorites-notice" v-if="desktops.length === 0 && apps.length === 0">
-    <TextBlock variant="subtitle">Get started with favorites</TextBlock>
+    <TextBlock variant="subtitle">{{ $t('favorites.getStarted') }}</TextBlock>
     <div class="prose">
-      <TextBlock block>Favoriting makes it easy to get to your most-used devices and apps.</TextBlock>
-      <TextBlock block>Add to favorites via the menu button near the device or app name.</TextBlock>
+      <TextBlock block>{{ $t('favorites.prose.description') }}</TextBlock>
+      <TextBlock block>{{ $t('favorites.prose.howTo') }}</TextBlock>
     </div>
     <div class="buttons">
       <div class="button-row">
-        <Button href="#devices" variant="accent">Go to devices</Button>
-        <Button href="#apps" variant="accent">Go to apps</Button>
+        <Button href="#devices" variant="accent">{{ $t('favorites.goToDevices') }}</Button>
+        <Button href="#apps" variant="accent">{{ $t('favorites.goToApps') }}</Button>
       </div>
-      <Button variant="hyperlink" @click="handleDisbleFavorites">Disable favorites</Button>
+      <Button variant="hyperlink" @click="handleDisbleFavorites">{{ $t('favorites.disable') }}</Button>
     </div>
   </div>
 </template>

--- a/frontend/lib/pages/Settings.vue
+++ b/frontend/lib/pages/Settings.vue
@@ -74,105 +74,107 @@
 
 <template>
   <div class="titlebar-row">
-    <TextBlock variant="title">Settings</TextBlock>
+    <TextBlock variant="title">{{ $t('settings.title') }}</TextBlock>
   </div>
   <section>
     <div class="section-title-row">
-      <TextBlock variant="subtitle">Favorites</TextBlock>
+      <TextBlock variant="subtitle">{{ $t('settings.favorites.title') }}</TextBlock>
     </div>
     <div class="favorites">
       <InfoBar severity="caution" v-if="!supportsAnchorPositions">
-        This setting is disabled beacuse your browser does not support CSS Anchor Positioning.
+        {{ $t('settings.favorites.disabledNoAnchorPos') }}
       </InfoBar>
       <ToggleSwitch
         v-model="favoritesEnabled"
         :disabled="simpleModeEnabled || policies?.favoritesEnabled !== '' || !supportsAnchorPositions"
       >
-        Enable favorites
+        {{ $t('settings.favorites.switch') }}
       </ToggleSwitch>
       <div class="button-row">
-        <Button @click="exportFavorites" :disabled="!supportsAnchorPositions">Export</Button>
-        <Button @click="importFavorites" :disabled="!supportsAnchorPositions">Import</Button>
+        <Button @click="exportFavorites" :disabled="!supportsAnchorPositions">{{
+          $t('settings.favorites.export')
+        }}</Button>
+        <Button @click="importFavorites" :disabled="!supportsAnchorPositions">{{
+          $t('settings.favorites.import')
+        }}</Button>
       </div>
     </div>
   </section>
   <section>
     <div class="section-title-row">
-      <TextBlock variant="subtitle">Flatten folders</TextBlock>
+      <TextBlock variant="subtitle">{{ $t('settings.flatMode.title') }}</TextBlock>
     </div>
     <div class="favorites">
       <TextBlock>
-        On views that support folders, flatten folders to show all apps and desktops in a single list.
+        {{ $t('settings.flatMode.desc') }}
       </TextBlock>
       <ToggleSwitch v-model="flatModeEnabled" :disabled="policies?.flatModeEnabled !== ''">
-        Enable flat mode
+        {{ $t('settings.flatMode.switch') }}
       </ToggleSwitch>
     </div>
   </section>
   <section>
     <div class="section-title-row">
-      <TextBlock variant="subtitle">Icon backgrounds</TextBlock>
+      <TextBlock variant="subtitle">{{ $t('settings.iconBackgrounds.title') }}</TextBlock>
     </div>
     <div class="favorites">
       <TextBlock>
-        Add a square background with padding to app and desktop icons for better visibility.
+        {{ $t('settings.iconBackgrounds.desc') }}
       </TextBlock>
       <ToggleSwitch v-model="iconBackgroundsEnabled" :disabled="policies?.iconBackgroundsEnabled !== ''">
-        Enable icon backgrounds
+        {{ $t('settings.iconBackgrounds.switch') }}
       </ToggleSwitch>
     </div>
   </section>
   <section>
     <div class="section-title-row">
-      <TextBlock variant="subtitle">Combine apps across servers</TextBlock>
+      <TextBlock variant="subtitle">{{ $t('settings.combineTerminalServersMode.title') }}</TextBlock>
     </div>
     <div class="favorites">
       <InfoBar severity="caution" v-if="!canUseDialogs">
-        This setting is disabled because your browser does not support the <code>requestClose()</code> method on
-        <code>&lt;dialog &#47;&gt;</code> elements
+        <span v-html="$t('settings.combineTerminalServersMode.disabledNoDialogs')"></span>
       </InfoBar>
       <TextBlock>
-        Show only one icon for each app, regardless of the number of terminal servers they are hosted on. If
-        multiple terminal servers are available, a prompt to select one will be shown when launching the app.
+        {{ $t('settings.combineTerminalServersMode.desc') }}
       </TextBlock>
       <ToggleSwitch
         v-model="combineTerminalServersModeEnabled"
         :disabled="policies?.combineTerminalServersModeEnabled !== '' || !canUseDialogs"
       >
-        Enable combined apps
+        {{ $t('settings.combineTerminalServersMode.switch') }}
       </ToggleSwitch>
     </div>
   </section>
   <section>
     <div class="section-title-row">
-      <TextBlock variant="subtitle">Simple mode</TextBlock>
+      <TextBlock variant="subtitle">{{ $t('settings.simpleMode.title') }}</TextBlock>
     </div>
     <div class="favorites">
       <TextBlock>
-        Enable simple mode to use a compact, combined, single-page list of apps and desktops.
+        {{ $t('settings.simpleMode.desc') }}
       </TextBlock>
       <TextBlock>
-        The flatten folders option is supported. All other pages and features will be disabled.
+        {{ $t('settings.simpleMode.desc2') }}
       </TextBlock>
       <ToggleSwitch v-model="simpleModeEnabled" :disabled="policies?.simpleModeEnabled !== ''">
-        Enable simple mode
+        {{ $t('settings.simpleMode.switch') }}
       </ToggleSwitch>
     </div>
   </section>
   <section>
     <div class="section-title-row">
-      <TextBlock variant="subtitle">Workspace URL</TextBlock>
+      <TextBlock variant="subtitle">{{ $t('settings.workspaceUrl.title') }}</TextBlock>
     </div>
     <div class="worksapce">
       <TextBlock variant="body">{{ workspaceUrl }}</TextBlock>
       <div class="button-row">
-        <Button @click="copyWorkspaceUrl">Copy workspace URL</Button>
+        <Button @click="copyWorkspaceUrl">{{ $t('settings.workspaceUrl.copy') }}</Button>
       </div>
     </div>
   </section>
   <section>
     <div class="section-title-row">
-      <TextBlock variant="subtitle">About</TextBlock>
+      <TextBlock variant="subtitle">{{ $t('settings.about.title') }}</TextBlock>
     </div>
     <div class="about">
       <div class="logo">
@@ -192,12 +194,14 @@
           <rect x="8" y="36" width="20" height="20" rx="4" fill="#EF5350" />
           <circle cx="46" cy="46" r="10" fill="#66BB6A" />
         </svg>
-        <TextBlock variant="subtitle">RemoteApps</TextBlock>
+        <TextBlock variant="subtitle">{{ $t('appName') }}</TextBlock>
       </div>
       <TextBlock>
-        A web interface for your RemoteApps and Desktops hosted on Windows 10, 11 and Server. Powered by RAWeb.
+        {{ $t('settings.about.appDesc') }}
       </TextBlock>
-      <Button variant="hyperlink" href="https://github.com/kimmknight/raweb">Learn more on GitHub</Button>
+      <Button variant="hyperlink" href="https://github.com/kimmknight/raweb">{{
+        $t('settings.about.learnMore')
+      }}</Button>
     </div>
   </section>
 </template>

--- a/frontend/lib/pages/Simple.vue
+++ b/frontend/lib/pages/Simple.vue
@@ -57,7 +57,7 @@
 
 <template>
   <div class="titlebar-row">
-    <TextBlock variant="title" tag="h1">Apps and desktops</TextBlock>
+    <TextBlock variant="title" tag="h1">{{ $t('simple.title') }}</TextBlock>
     <HeaderActions
       :data="props.data"
       v-model:mode="mode"
@@ -65,7 +65,7 @@
       v-model:sortOrder="sortOrder"
       v-model:terminalServersFilter="terminalServersFilter"
       v-model:query="query"
-      searchPlaceholder="Search apps and desktops"
+      :searchPlaceholder="$t('simple.search')"
     />
   </div>
 

--- a/frontend/lib/public/locales/en-AU.json
+++ b/frontend/lib/public/locales/en-AU.json
@@ -1,0 +1,22 @@
+{
+  "favorites": {
+    "title": "Favourites",
+    "getStarted": "Get started with favourites",
+    "prose": {
+      "howTo": "Add to favourites via the menu button near the device or app name."
+    },
+    "disable": "Disable favourites"
+  },
+  "settings": {
+    "favorites": {
+      "title": "Favourites",
+      "switch": "Enable favourites"
+    }
+  },
+  "resource": {
+    "menu": {
+      "favAdd": "Add to favourites",
+      "favRemove": "Remove from favourites"
+    }
+  }
+}

--- a/frontend/lib/public/locales/en-CA.json
+++ b/frontend/lib/public/locales/en-CA.json
@@ -1,0 +1,22 @@
+{
+  "favorites": {
+    "title": "Favourites",
+    "getStarted": "Get started with favourites",
+    "prose": {
+      "howTo": "Add to favourites via the menu button near the device or app name."
+    },
+    "disable": "Disable favourites"
+  },
+  "settings": {
+    "favorites": {
+      "title": "Favourites",
+      "switch": "Enable favourites"
+    }
+  },
+  "resource": {
+    "menu": {
+      "favAdd": "Add to favourites",
+      "favRemove": "Remove from favourites"
+    }
+  }
+}

--- a/frontend/lib/public/locales/en-GB.json
+++ b/frontend/lib/public/locales/en-GB.json
@@ -1,0 +1,22 @@
+{
+  "favorites": {
+    "title": "Favourites",
+    "getStarted": "Get started with favourites",
+    "prose": {
+      "howTo": "Add to favourites via the menu button near the device or app name."
+    },
+    "disable": "Disable favourites"
+  },
+  "settings": {
+    "favorites": {
+      "title": "Favourites",
+      "switch": "Enable favourites"
+    }
+  },
+  "resource": {
+    "menu": {
+      "favAdd": "Add to favourites",
+      "favRemove": "Remove from favourites"
+    }
+  }
+}

--- a/frontend/lib/public/locales/en-NZ.json
+++ b/frontend/lib/public/locales/en-NZ.json
@@ -1,0 +1,22 @@
+{
+  "favorites": {
+    "title": "Favourites",
+    "getStarted": "Get started with favourites",
+    "prose": {
+      "howTo": "Add to favourites via the menu button near the device or app name."
+    },
+    "disable": "Disable favourites"
+  },
+  "settings": {
+    "favorites": {
+      "title": "Favourites",
+      "switch": "Enable favourites"
+    }
+  },
+  "resource": {
+    "menu": {
+      "favAdd": "Add to favourites",
+      "favRemove": "Remove from favourites"
+    }
+  }
+}

--- a/frontend/lib/public/locales/en.json
+++ b/frontend/lib/public/locales/en.json
@@ -1,0 +1,125 @@
+{
+  "appName": "RemoteApps",
+  "device": "device",
+  "app": "app",
+  "application": "application",
+  "dialog": {
+    "close": "Close",
+    "always": "Always",
+    "once": "Just once"
+  },
+  "profile": {
+    "signOut": "Sign out"
+  },
+  "favorites": {
+    "title": "Favorites",
+    "getStarted": "Get started with favorites",
+    "prose": {
+      "description": "Favoriting makes it easy to get to your most-used devices and apps.",
+      "howTo": "Add to favorites via the menu button near the device or app name."
+    },
+    "allDevices": "All devices",
+    "allApps": "All apps",
+    "goToDevices": "Go to devices",
+    "goToApps": "Go to apps",
+    "disable": "Disable favorites"
+  },
+  "devices": {
+    "title": "Devices",
+    "search": "Search devices"
+  },
+  "apps": {
+    "title": "Apps",
+    "search": "Search apps"
+  },
+  "simple": {
+    "title": "Apps and desktops",
+    "search": "Search apps and desktops"
+  },
+  "settings": {
+    "title": "Settings",
+    "favorites": {
+      "title": "Favorites",
+      "disabledNoAnchorPos": "This setting is disabled beacuse your browser does not support CSS Anchor Positioning.",
+      "switch": "Enable favorites",
+      "import": "Import",
+      "export": "Export"
+    },
+    "flatMode": {
+      "title": "Flatten folders",
+      "desc": " On views that support folders, flatten folders to show all apps and desktops in a single list.",
+      "switch": "Enable flat mode"
+    },
+    "iconBackgrounds": {
+      "title": "Icon backgrounds",
+      "desc": " Add a square background with padding to app and desktop icons for better visibility.",
+      "switch": "Enable icon backgrounds"
+    },
+    "combineTerminalServersMode": {
+      "title": "Combine apps across servers",
+      "desc": "Show only one icon for each app, regardless of the number of terminal servers they are hosted on. If multiple terminal servers are available, a prompt to select one will be shown when launching the app.",
+      "switch": "Enable combined apps",
+      "disabledNoDialogs": " This setting is disabled because your browser does not support the <code>requestClose()</code> method on <code>&lt;dialog &#47;&gt;</code> elements"
+    },
+    "simpleMode": {
+      "title": "Simple mode",
+      "desc": "Enable simple mode to use a compact, combined, single-page list of apps and desktops.",
+      "desc2": "The flatten folders option is supported. All other pages and features will be disabled.",
+      "switch": "Enable simple mode"
+    },
+    "workspaceUrl": {
+      "title": "Workspace URL",
+      "copy": "Copy workspace URL"
+    },
+    "about": {
+      "title": "About",
+      "appDesc": "A web interface for your RemoteApps and Desktops hosted on Windows 10, 11 and Server. Powered by RAWeb.",
+      "learnMore": "Learn more on GitHub"
+    }
+  },
+  "wiki": {
+    "title": "Wiki"
+  },
+  "actions": {
+    "sort": {
+      "label": "Sort",
+      "name": "Name",
+      "ts": "Terminal server",
+      "date": "Date modified",
+      "asc": "Ascending",
+      "desc": "Descending"
+    },
+    "view": {
+      "label": "View",
+      "card": "Card",
+      "grid": "Grid",
+      "tile": "Tile",
+      "list": "List"
+    },
+    "ts": {
+      "label": "Terminal servers",
+      "all": "All terminal servers"
+    }
+  },
+  "resource": {
+    "menu": {
+      "connect": "Connect",
+      "favAdd": "Add to favorites",
+      "favRemove": "Remove from favorites",
+      "props": "Properties"
+    },
+    "props": {
+      "title": "Properties",
+      "ts": "Terminal server",
+      "empty": "empty"
+    },
+    "tsPicker": {
+      "title": "Select a terminal server for"
+    }
+  },
+  "securityError503": {
+    "title": "Security Error 5003",
+    "message": "The service worker failed to install because the SSL certificate is not trusted by your device. Add the certificate to the trusted root certification authorities store on this computer or configure RAWeb to use a trusted certificate. Performance and functionality may be limited. Offline feaures are unavailable.",
+    "action": "Learn more"
+  }
+}

--- a/frontend/lib/public/manifest.aspx
+++ b/frontend/lib/public/manifest.aspx
@@ -11,7 +11,7 @@
         // define the webmanifest
         var manifest = new
         {
-            name = "RemoteApps",
+            name = Resources.WebResources.AppName,
             start_url = ResolveUrl("~/#favorites"),
             display = "standalone",
             display_override = new[] { "window-controls-overlay" },

--- a/frontend/lib/utils/capitalize.ts
+++ b/frontend/lib/utils/capitalize.ts
@@ -1,0 +1,6 @@
+export function capitalize(str: string): string {
+  if (typeof str !== 'string') {
+    return '';
+  }
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}

--- a/frontend/lib/utils/index.mjs
+++ b/frontend/lib/utils/index.mjs
@@ -1,3 +1,4 @@
+import { capitalize } from './capitalize.ts';
 import { combineTerminalServersModeEnabled } from './combineTerminalServersMode.ts';
 import { flatModeEnabled } from './flatMode.ts';
 import { generateRdpFileContents } from './generateRdpFileContents.ts';
@@ -14,6 +15,7 @@ import {
 import { useWebfeedData } from './useWebfeedData.ts';
 
 export {
+  capitalize,
   combineTerminalServersModeEnabled,
   favoritesEnabled,
   flatModeEnabled,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,9 @@
   },
   "dependencies": {
     "devalue": "^5.1.1",
+    "i18next": "^25.2.1",
+    "i18next-http-backend": "^3.0.2",
+    "i18next-vue": "^5.3.0",
     "vue": "^3.5.13",
     "vue-router": "^4.5.0"
   },

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -11,6 +11,15 @@ importers:
       devalue:
         specifier: ^5.1.1
         version: 5.1.1
+      i18next:
+        specifier: ^25.2.1
+        version: 25.2.1(typescript@5.8.3)
+      i18next-http-backend:
+        specifier: ^3.0.2
+        version: 3.0.2
+      i18next-vue:
+        specifier: ^5.3.0
+        version: 5.3.0(i18next@25.2.1(typescript@5.8.3))(vue@3.5.13(typescript@5.8.3))
       vue:
         specifier: ^3.5.13
         version: 3.5.13(typescript@5.8.3)
@@ -45,6 +54,10 @@ packages:
     resolution: {integrity: sha512-QYLs8299NA7WM/bZAdp+CviYYkVoYXlDW2rzliy3chxd1PQjej7JORuMJDJXJUb9g0TT+B99EwaVLKmX+sPXWw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  '@babel/runtime@7.27.3':
+    resolution: {integrity: sha512-7EYtGezsdiDMyY80+65EzwiGmcJqpmcZCojSXaRgdrBaGtWTgDZKq69cPIVped6MkIM78cTQ2GOiEYjwOlG4xw==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/types@7.27.1':
     resolution: {integrity: sha512-+EzkxvLNfiUeKMgy/3luqfsCWFRXLb7U6wNQTk60tovuckwB15B191tJWvpp4HjiQWdJkCxO3Wbvc6jlk3Xb2Q==}
@@ -348,6 +361,9 @@ packages:
   '@vue/shared@3.5.13':
     resolution: {integrity: sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ==}
 
+  cross-fetch@4.0.0:
+    resolution: {integrity: sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==}
+
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
@@ -379,6 +395,23 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  i18next-http-backend@3.0.2:
+    resolution: {integrity: sha512-PdlvPnvIp4E1sYi46Ik4tBYh/v/NbYfFFgTjkwFl0is8A18s7/bx9aXqsrOax9WUbeNS6mD2oix7Z0yGGf6m5g==}
+
+  i18next-vue@5.3.0:
+    resolution: {integrity: sha512-X5gYF1R9FadUdRyIze6p+mU4+kztIRWb1SYeoegB0eFBt/lDA++i0A235enWq5qdrRpWZIHlLV8gd/D5xakOsw==}
+    peerDependencies:
+      i18next: '>=23'
+      vue: ^3.4.38
+
+  i18next@25.2.1:
+    resolution: {integrity: sha512-+UoXK5wh+VlE1Zy5p6MjcvctHXAhRwQKCxiJD8noKZzIXmnAX8gdHX5fLPA3MEVxEN4vbZkQFy8N0LyD9tUqPw==}
+    peerDependencies:
+      typescript: ^5
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
 
@@ -386,6 +419,15 @@ packages:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -410,6 +452,9 @@ packages:
   tinyglobby@0.2.13:
     resolution: {integrity: sha512-mEwzpUgrLySlveBwEVDMKk5B57bhLPYovRfPAXD5gA/98Opn0rCDj3GtLwFvCvH5RK9uPCExUROW5NjDwvqkxw==}
     engines: {node: '>=12.0.0'}
+
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
   typescript@5.8.3:
     resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
@@ -472,6 +517,12 @@ packages:
       typescript:
         optional: true
 
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
 snapshots:
 
   '@babel/helper-string-parser@7.27.1': {}
@@ -481,6 +532,8 @@ snapshots:
   '@babel/parser@7.27.2':
     dependencies:
       '@babel/types': 7.27.1
+
+  '@babel/runtime@7.27.3': {}
 
   '@babel/types@7.27.1':
     dependencies:
@@ -691,6 +744,12 @@ snapshots:
 
   '@vue/shared@3.5.13': {}
 
+  cross-fetch@4.0.0:
+    dependencies:
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
+
   csstype@3.1.3: {}
 
   devalue@5.1.1: {}
@@ -734,11 +793,32 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
+  i18next-http-backend@3.0.2:
+    dependencies:
+      cross-fetch: 4.0.0
+    transitivePeerDependencies:
+      - encoding
+
+  i18next-vue@5.3.0(i18next@25.2.1(typescript@5.8.3))(vue@3.5.13(typescript@5.8.3)):
+    dependencies:
+      i18next: 25.2.1(typescript@5.8.3)
+      vue: 3.5.13(typescript@5.8.3)
+
+  i18next@25.2.1(typescript@5.8.3):
+    dependencies:
+      '@babel/runtime': 7.27.3
+    optionalDependencies:
+      typescript: 5.8.3
+
   magic-string@0.30.17:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
 
   nanoid@3.3.11: {}
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
 
   picocolors@1.1.1: {}
 
@@ -783,6 +863,8 @@ snapshots:
       fdir: 6.4.4(picomatch@4.0.2)
       picomatch: 4.0.2
 
+  tr46@0.0.3: {}
+
   typescript@5.8.3: {}
 
   undici-types@6.21.0: {}
@@ -813,3 +895,10 @@ snapshots:
       '@vue/shared': 3.5.13
     optionalDependencies:
       typescript: 5.8.3
+
+  webidl-conversions@3.0.1: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1


### PR DESCRIPTION
This adds i18n for the Vue app via `i18next` and the login/logoff pages with `.resx` files.

Instructions for adding translations are in `TRANSLATING.md`.

Closes #59