### PR TITLE
Show RemoteApps included in TSAppAllowList\Applications

### DIFF
--- a/aspx/wwwroot/App_Code/AuthUtilities.cs
+++ b/aspx/wwwroot/App_Code/AuthUtilities.cs
@@ -132,7 +132,7 @@ namespace AuthUtilities
             // if the account is the anonymous account, return those details
             if (domain == "NT AUTHORITY" && username == "IUSR")
             {
-                return new UserInformation(username, domain, "Anonymous User", new GroupInformation[0]);
+                return new UserInformation("S-1-5-17", username, domain, "Anonymous User", new GroupInformation[0]);
             }
 
             // get the principal context for the domain or machine
@@ -158,6 +158,9 @@ namespace AuthUtilities
             {
                 return null;
             }
+
+            // get the user SID
+            string userSid = user.Sid.ToString();
 
             // get the full name of the user
             string fullName = user.DisplayName ?? user.Name ?? user.SamAccountName;
@@ -208,6 +211,7 @@ namespace AuthUtilities
             }
 
             return new UserInformation(
+                userSid,
                 username,
                 domain,
                 fullName,
@@ -235,11 +239,13 @@ namespace AuthUtilities
     {
         public string Username { get; set; }
         public string Domain { get; set; }
+        public string Sid { get; set; }
         public string FullName { get; set; }
         public GroupInformation[] Groups { get; set; }
 
-        public UserInformation(string username, string domain, string fullName, GroupInformation[] groups)
+        public UserInformation(string sid, string username, string domain, string fullName, GroupInformation[] groups)
         {
+            Sid = sid;
             Username = username;
             Domain = domain;
 
@@ -255,8 +261,9 @@ namespace AuthUtilities
             Groups = groups;
         }
 
-        public UserInformation(string username, string domain)
+        public UserInformation(string sid, string username, string domain)
         {
+            Sid = sid;
             Username = username;
             Domain = domain;
             FullName = username;

--- a/aspx/wwwroot/App_Code/RegistryUtilities.cs
+++ b/aspx/wwwroot/App_Code/RegistryUtilities.cs
@@ -1,0 +1,242 @@
+using AuthUtilities;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Security.AccessControl;
+using System.Security.Principal;
+using System.Web;
+
+namespace RegistryUtilities
+{
+    public class Reader
+    {
+
+        public static Microsoft.Win32.RegistryKey OpenRemoteAppRegistryKey(string keyName)
+        {
+            // open the registry key for the specified application
+            var regKey = Microsoft.Win32.Registry.LocalMachine.OpenSubKey("SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Terminal Server\\TSAppAllowList\\Applications\\" + keyName);
+            if (regKey == null)
+            {
+                throw new ArgumentException("'keyName' must be a valid application name in HKEY_LOCAL_MACHINE\\SOFTWARE\\Windows NT\\CurrentVersion\\Terminal Server\\TSAppAllowList\\Applications.");
+            }
+            return regKey;
+        }
+
+        // checks if the application in the registry can be accessed by the current user
+        // based on the SecurityDescriptor value in the registry key
+        public static bool CanAccessRemoteApp(Microsoft.Win32.RegistryKey registryKey, AuthUtilities.UserInformation userInfo)
+        {
+            try
+            {
+                var securityDescriptorString = registryKey.GetValue("SecurityDescriptor") as string;
+                if (string.IsNullOrEmpty(securityDescriptorString))
+                {
+                    // if there is no SecurityDescriptor, assume access is allowed
+                    return true;
+                }
+
+                // get the security identifiers for the user and groups
+                var userSid = new SecurityIdentifier(userInfo.Sid);
+                var groupSids = userInfo.Groups.Select(g => new SecurityIdentifier(g.Sid)).ToList();
+                var allSids = new List<SecurityIdentifier> { userSid };
+                allSids.AddRange(groupSids);
+
+                // parse the security descriptor from the SSDL string
+                var securityDescriptor = new RawSecurityDescriptor(securityDescriptorString);
+                var knownAccessRules = securityDescriptor.DiscretionaryAcl
+                    .OfType<CommonAce>()
+                    .Where(ace => ace.AceType == AceType.AccessAllowed || ace.AceType == AceType.AccessDenied)
+                    .ToList();
+
+                // give priority to denial rules - if any deny rule matches, access is denied
+                var accessDenied = knownAccessRules
+                    .Where(ace => ace.AceType == AceType.AccessDenied)
+                    .Any(ace => allSids.Any(sid => sid.Equals(ace.SecurityIdentifier)));
+                if (accessDenied)
+                {
+                    return false;
+                }
+
+                // check if any access allowed rule matches the user or group SIDs
+                var accessAllowed = knownAccessRules
+                    .Where(ace => ace.AceType == AceType.AccessAllowed)
+                    .Any(ace => allSids.Any(sid => sid.Equals(ace.SecurityIdentifier)));
+
+                return accessAllowed;
+
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return false;
+            }
+            catch (Exception ex)
+            {
+                throw new Exception("", ex);
+                return false;
+            }
+        }
+
+        public static bool CanAccessRemoteApp(string keyName, AuthUtilities.UserInformation userInfo)
+        {
+            using (var regKey = OpenRemoteAppRegistryKey(keyName))
+            {
+                return CanAccessRemoteApp(regKey, userInfo);
+            }
+        }
+
+        public static string ConstructRdpFileFromRegistry(string keyName)
+        {
+            using (var regKey = OpenRemoteAppRegistryKey(keyName))
+            {
+
+                // get the application details from the registry key
+                string appName = regKey.GetValue("Name") as string;
+                string appPath = regKey.GetValue("Path") as string;
+
+                // if the RDPFileContents key exists, serve the contents of that key
+                object rdpFileContents = regKey.GetValue("RDPFileContents");
+                if (rdpFileContents != null)
+                {
+                    return rdpFileContents as string;
+                }
+
+                string fulladdress = System.Configuration.ConfigurationManager.AppSettings["RegistryApps.FullAddressOverride"];
+                if (string.IsNullOrEmpty(fulladdress))
+                {
+                    // get the machine's IP address
+                    string ipAddress = HttpContext.Current.Request.ServerVariables["LOCAL_ADDR"];
+
+                    // get the rdp port  from HKLM:\SYSTEM\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp
+                    string rdpPort = "";
+                    using (var rdpKey = Microsoft.Win32.Registry.LocalMachine.OpenSubKey("SYSTEM\\CurrentControlSet\\Control\\Terminal Server\\WinStations\\RDP-Tcp"))
+                    {
+                        if (rdpKey != null)
+                        {
+                            object portValue = rdpKey.GetValue("PortNumber");
+                            if (portValue != null)
+                            {
+                                rdpPort = ((int)portValue).ToString();
+                            }
+                        }
+                    }
+
+                    // construct the full address
+                    fulladdress = ipAddress + ":" + rdpPort;
+                }
+
+                string names = "";
+                foreach (string skn in regKey.GetSubKeyNames())
+                {
+                    names += skn + ", ";
+                }
+
+                // calculate the file extensions supported by the application
+                string appFileExtCSV = "";
+                using (var fileTypesKey = regKey.OpenSubKey("Filetypes"))
+                {
+                    if (fileTypesKey == null)
+                    {
+                    }
+                    if (fileTypesKey != null)
+                    {
+                        string[] fileTypeNames = fileTypesKey.GetValueNames();
+                        if (fileTypeNames.Length > 0)
+                        {
+                            appFileExtCSV = "." + string.Join(",.", fileTypeNames);
+                        }
+                    }
+                }
+
+
+                // create the RDP file
+                StringBuilder rdpBuilder = new StringBuilder();
+                rdpBuilder.AppendLine("full address:s:" + fulladdress);
+                rdpBuilder.AppendLine("remoteapplicationname:s:" + appName);
+                rdpBuilder.AppendLine("remoteapplicationprogram:s:||" + appName);
+                rdpBuilder.AppendLine("remoteapplicationmode:i:1");
+                rdpBuilder.AppendLine("remoteapplicationfileextensions:s:" + appFileExtCSV);
+                rdpBuilder.AppendLine("disableremoteappcapscheck:i:1");
+                rdpBuilder.AppendLine("drivestoredirect:s:*");
+                rdpBuilder.AppendLine("redirectclipboard:i:1");
+                string rdpContent = rdpBuilder.ToString();
+
+                // serve as an RDP file
+                return rdpContent;
+            }
+        }
+
+        [DllImport("shell32.dll", CharSet = CharSet.Auto)]
+        public static extern uint ExtractIconEx(string lpszFile, int nIconIndex, [Out] IntPtr[] phiconLarge, [Out] IntPtr[] phiconSmall, [In] uint nIcons);
+
+        [DllImport("user32.dll")]
+        public static extern int DestroyIcon(IntPtr hIcon);
+
+        public static MemoryStream ReadImageFromRegistry(string appName, string maybeFileExtName)
+        {
+            string iconSourcePath = "";
+            int iconIndex = 0;
+
+            // get the icon path from the registry
+            if (!string.IsNullOrEmpty(maybeFileExtName))
+            {
+                // handle the case where a file extension is specified
+                using (var regKey = Reader.OpenRemoteAppRegistryKey(appName + "\\Filetypes"))
+                {
+                    string data = regKey.GetValue(maybeFileExtName) as string;
+                    if (string.IsNullOrEmpty(data))
+                    {
+                        throw new Exception("File extension icon for " + maybeFileExtName + "not found in registry for application: " + appName);
+                    }
+
+                    iconSourcePath = data.Split(',')[0].Trim();
+                    iconIndex = int.Parse(data.Split(',')[1].Trim() ?? "0");
+                }
+            }
+            else
+            {
+                // use the application's default icon path
+                using (var regKey = Reader.OpenRemoteAppRegistryKey(appName))
+                {
+                    // get the icon path from the registry key
+                    iconSourcePath = regKey.GetValue("IconPath") as string;
+                    if (string.IsNullOrEmpty(iconSourcePath))
+                    {
+                        throw new Exception("Icon path not found in registry for application: " + appName);
+                    }
+
+                    // get the icon index from the registry key
+                    iconIndex = (int)(regKey.GetValue("IconIndex") ?? 0);
+                }
+            }
+
+            // attempt to extract the icon
+            try
+            {
+                // extract the icon handle
+                IntPtr[] phiconLarge = new IntPtr[1];
+                ExtractIconEx(iconSourcePath, iconIndex, phiconLarge, null, 1);
+
+                // convert the icon handle to an Icon object and save it to a MemoryStream
+                Icon iconLarge = Icon.FromHandle(phiconLarge[0]);
+                var imageStream = new MemoryStream();
+                iconLarge.ToBitmap().Save(imageStream, ImageFormat.Png);
+                imageStream.Position = 0;
+
+                // dispose the icon and handle
+                DestroyIcon(phiconLarge[0]);
+                iconLarge.Dispose();
+
+                return imageStream;
+            }
+            catch (Exception ex)
+            {
+                throw new Exception("Error extracting icon: " + ex.Message);
+            }
+        }
+    }
+}

--- a/aspx/wwwroot/Web.config
+++ b/aspx/wwwroot/Web.config
@@ -7,6 +7,8 @@
       <!-- <add key="App.FlatModeEnabled" value="false" /> -->
       <!-- <add key="App.IconBackgroundsEnabled" value="true" /> -->
       <!-- <add key="App.SimpleModeEnabled" value="false" /> -->
+      <add key="RegistryApps.Enabled" value="true" />
+      <!-- <add key="RegistryApps.FullAddressOverride" value="example.com:13389" /> -->
    </appSettings>
    <system.web>
       <compilation defaultLanguage="C#" targetFramework="4.0">
@@ -20,15 +22,15 @@
          <mimeMap fileExtension=".mjs" mimeType="application/javascript" />
          <mimeMap fileExtension=".webp" mimeType="image/webp" />
       </staticContent>
-        <caching>
-            <profiles>
-                <add extension=".aspx" policy="CacheForTimePeriod" kernelCachePolicy="DontCache" duration="00:00:01" />
-                <add extension=".css" policy="CacheForTimePeriod" kernelCachePolicy="DontCache" duration="00:00:01" />
-                <add extension=".mjs" policy="CacheForTimePeriod" kernelCachePolicy="DontCache" duration="00:00:01" />
-                <add extension=".rdp" policy="CacheForTimePeriod" kernelCachePolicy="DontCache" duration="00:00:01" />
-                <add extension=".ts" policy="CacheForTimePeriod" kernelCachePolicy="DontCache" duration="00:00:01" />
-                <add extension=".vue" policy="CacheForTimePeriod" kernelCachePolicy="DontCache" duration="00:00:01" />
-            </profiles>
-        </caching>
+      <caching>
+         <profiles>
+            <add extension=".aspx" policy="CacheForTimePeriod" kernelCachePolicy="DontCache" duration="00:00:01" />
+            <add extension=".css" policy="CacheForTimePeriod" kernelCachePolicy="DontCache" duration="00:00:01" />
+            <add extension=".mjs" policy="CacheForTimePeriod" kernelCachePolicy="DontCache" duration="00:00:01" />
+            <add extension=".rdp" policy="CacheForTimePeriod" kernelCachePolicy="DontCache" duration="00:00:01" />
+            <add extension=".ts" policy="CacheForTimePeriod" kernelCachePolicy="DontCache" duration="00:00:01" />
+            <add extension=".vue" policy="CacheForTimePeriod" kernelCachePolicy="DontCache" duration="00:00:01" />
+         </profiles>
+      </caching>
    </system.webServer>
 </configuration>

--- a/aspx/wwwroot/get-rdp.aspx
+++ b/aspx/wwwroot/get-rdp.aspx
@@ -1,0 +1,1 @@
+<%@ Page Language="C#" AutoEventWireup="true" CodeFile="get-rdp.aspx.cs" Inherits="GetRDP" %>

--- a/aspx/wwwroot/get-rdp.aspx.cs
+++ b/aspx/wwwroot/get-rdp.aspx.cs
@@ -1,0 +1,69 @@
+using AuthUtilities;
+using RegistryUtilities;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Web;
+
+public partial class GetRDP : System.Web.UI.Page
+{
+    protected void Page_Load(object sender, EventArgs e)
+    {
+        // retrieve the query string parameters
+        string path = Request.QueryString["path"]; // relative path to the rdp file, or the name of the registry key
+        string from = Request.QueryString["from"]; // rdp or registry
+
+        // ensure the parameters are valid formats
+        if (string.IsNullOrEmpty(path) || string.IsNullOrEmpty(from))
+        {
+            throw new ArgumentException("Parameters 'path' and 'from' are required.");
+        }
+        if (from != "rdp" && from != "registry")
+        {
+            throw new ArgumentException("Parameter 'from' must be either 'rdp' or 'registry'.");
+        }
+
+        // get authentication information
+        AuthCookieHandler authCookieHandler = new AuthCookieHandler();
+        UserInformation userInfo = authCookieHandler.GetUserInformationSafe(Request);
+
+        // refuse to serve RDP files if the user is not authenticated
+        if (userInfo == null)
+        {
+            Response.StatusCode = 401;
+            Response.End();
+            return;
+        }
+
+        // if it is an RDP file, serve it from the file system
+        if (from == "rdp")
+        {
+            string filePath = Server.MapPath("~/" + path);
+            if (!File.Exists(filePath))
+            {
+                throw new FileNotFoundException("The specified RDP file does not exist.", filePath);
+            }
+
+            Response.ContentType = "application/x-rdp";
+            Response.WriteFile(filePath);
+            Response.End();
+            return;
+        }
+
+        // check that the user has permission to access the remoteapp in the registry
+        bool hasPermission = Reader.CanAccessRemoteApp(path, userInfo);
+        if (!hasPermission)
+        {
+            Response.StatusCode = 403;
+            Response.End();
+        }
+
+        // construct an RDP file from the values in the registry and serve it
+        string rdpFileContents = Reader.ConstructRdpFileFromRegistry(path);
+        Response.ContentType = "application/x-rdp";
+        Response.AddHeader("Content-Disposition", "attachment; filename=\"" + path + ".rdp\"");
+        Response.Write(rdpFileContents.ToString());
+        Response.End();
+    }
+}

--- a/aspx/wwwroot/webfeed.aspx
+++ b/aspx/wwwroot/webfeed.aspx
@@ -1,7 +1,9 @@
 <%@ Page language="C#" explicit="true" Debug="true" %>
 <%@ Import Namespace="AliasUtilities" %>
+<%@ Import Namespace="RegistryUtilities" %>
+
 <script runat="server">
-    public string GetRDPvalue(string eachfile, string valuename)
+    public string GetRDPvalue(string eachfile, string valuename, string fallbackValue = "")
     {
         string GetRDPvalue = "";
         string fileline = "";
@@ -22,43 +24,16 @@
             }
         }
         contentfile.Close();
-        GetRDPvalue = theName.Replace("|", "");
-        return GetRDPvalue;
-    }
+        GetRDPvalue = theName.Replace("|", "").Trim();
 
-    public System.Guid GetResourceGUID(string rdpFilePath, string suffix = "", string[] linesToOmit = null)
-    {
-        // read the entire contents of the file into a string
-        string fileContents = System.IO.File.ReadAllText(rdpFilePath);
-
-        // alphabetically sort the lines in the file contents
-        var lines = fileContents.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
-        Array.Sort(lines);
-        fileContents = string.Join("\r\n", lines);
-
-        // omit the full address from the hash calculation
-        //string[] linesToOmit = new string[] { "full address:s:" };
-        if (linesToOmit != null)
+        if (string.IsNullOrEmpty(GetRDPvalue))
         {
-            foreach (var lineToOmit in linesToOmit)
-            {
-                fileContents = Regex.Replace(fileContents, @"(?m)^" + Regex.Escape(lineToOmit) + ".*$", "", RegexOptions.Multiline);
-            }
+            return fallbackValue;
         }
-
-        // if there is a suffix, append it to the file contents
-        if (!string.IsNullOrEmpty(suffix))
+        else
         {
-            fileContents += suffix;
+            return GetRDPvalue;
         }
-
-        // generate a guid from the file contents
-        var byt = Encoding.UTF8.GetBytes(fileContents);
-        var md5 = System.Security.Cryptography.MD5.Create();
-        var hash = md5.ComputeHash(byt);
-        var guid = new Guid(hash);
-
-        return guid;
     }
 
     public string Root()
@@ -81,33 +56,86 @@
 
     private NameValueCollection searchParams = System.Web.HttpUtility.ParseQueryString(HttpContext.Current.Request.Url.Query);
 
-    private string GetIconElements(string relativeIconPath, string mode = "none", string defaultRelativeIconPath = "default.ico")
+    private string GetIconElements(string relativeIconPath, string mode = "none", string defaultRelativeIconPath = "default.ico", bool skipMissing = false)
     {
         string defaultIconPath = System.IO.Path.Combine(HttpContext.Current.Server.MapPath(Root()), defaultRelativeIconPath);
-
-        // get the icon path, preferring the png icon first, then the ico icon, and finally the default icon
+        
         string iconPath = System.IO.Path.Combine(HttpContext.Current.Server.MapPath(Root()), relativeIconPath + ".png");
-        if (!System.IO.File.Exists(iconPath))
-        {
-            iconPath = System.IO.Path.Combine(HttpContext.Current.Server.MapPath(Root()), relativeIconPath + ".ico");
-        }
-        if (!System.IO.File.Exists(iconPath))
-        {
-            iconPath = defaultIconPath;
-            relativeIconPath = defaultRelativeIconPath;
-        }
 
-        // get the icon dimensions
         int iconWidth = 0;
         int iconHeight = 0;
-        using (var fileStream = new System.IO.FileStream(iconPath, System.IO.FileMode.Open, System.IO.FileAccess.Read, System.IO.FileShare.Read))
+
+        // if mode is registry, we need to get the icon dimensions from the registry
+        if (relativeIconPath.StartsWith("registry:"))
         {
-            using (var image = System.Drawing.Image.FromStream(fileStream, false, false))
-            {       
-                iconWidth = image.Width;
-                iconHeight = image.Height;
+            string appKeyName = relativeIconPath.Split(':').LastOrDefault();
+			string maybeFileExtName = relativeIconPath.Split(':')[1];
+            if (maybeFileExtName == appKeyName)
+            {
+                maybeFileExtName = "";
+            }
+
+            try
+            {
+                System.IO.Stream fileStream = Reader.ReadImageFromRegistry(appKeyName, maybeFileExtName);
+                if (fileStream == null)
+                {
+                    if (skipMissing)
+                    {
+                        return "";
+                    }
+
+                    // if the file stream is null, use the default icon
+                    relativeIconPath = defaultRelativeIconPath;
+                    fileStream = new System.IO.FileStream(defaultIconPath, System.IO.FileMode.Open, System.IO.FileAccess.Read, System.IO.FileShare.Read);
+                }
+
+                using (var image = System.Drawing.Image.FromStream(fileStream, false, false))
+                {
+                    iconWidth = image.Width;
+                    iconHeight = image.Height;
+                }
+            }
+            catch (Exception ex)
+            {
+                if (skipMissing)
+                {
+                    return "";
+                }
+
+                // cause the icon to be the default icon
+                iconWidth = 0;
+                iconHeight = 1;
             }
         }
+        else
+        {
+            // get the icon path, preferring the png icon first, then the ico icon, and finally the default icon
+            if (!System.IO.File.Exists(iconPath))
+            {
+                iconPath = System.IO.Path.Combine(HttpContext.Current.Server.MapPath(Root()), relativeIconPath + ".ico");
+            }
+            if (!System.IO.File.Exists(iconPath))
+            {
+                if (skipMissing)
+                {
+                    return "";
+                }
+                iconPath = defaultIconPath;
+                relativeIconPath = defaultRelativeIconPath;
+            }
+
+            // get the icon dimensions
+            using (var fileStream = new System.IO.FileStream(iconPath, System.IO.FileMode.Open, System.IO.FileAccess.Read, System.IO.FileShare.Read))
+            {
+                using (var image = System.Drawing.Image.FromStream(fileStream, false, false))
+                {       
+                    iconWidth = image.Width;
+                    iconHeight = image.Height;
+                }
+            }
+        }
+
 
         // if the icon is not a square, use the default icon
         // or treat it as wallpaper if the mode is set to "wallpaper"
@@ -117,7 +145,6 @@
             // if the icon is not a square, use the default icon instead
             if (mode == "none")
             {
-
                 iconPath = defaultIconPath;
                 relativeIconPath = defaultRelativeIconPath;
                 using (var fileStream = new System.IO.FileStream(iconPath, System.IO.FileMode.Open, System.IO.FileAccess.Read, System.IO.FileShare.Read))
@@ -170,6 +197,418 @@
     // keep track of previous resource GUIDs to avoid duplicates
     string[] previousResourceGUIDs = new string[] {};
 
+    private class Resource
+    {
+        public string Type { get; set; } // Desktop or RemoteApp
+        public string Origin { get; set;} // rdp or registry
+        public string FullAddress { get; set; }
+        public string AppProgram { get; set; }
+        public string Title { get; set; }
+        public string Alias { get; set; }
+        public string AppFileExtCSV { get; set; }
+        public DateTime LastUpdated { get; set; }
+        public string VirtualFolder { get; set; }
+        public string Source { get; set; } // path the RDP file or registry entry
+        public System.Guid Guid { get; set; }
+
+        public bool IsApp
+        {
+            get
+            {
+                return Type == "RemoteApp";
+            }
+        }
+        public bool IsDesktop
+        {
+            get
+            {
+                return Type == "Desktop";
+            }
+        }
+        public string[] FileExtensions
+        {
+            get
+            {
+                if (string.IsNullOrEmpty(AppFileExtCSV))
+                {
+                    return new string[] { };
+                }
+                return AppFileExtCSV.Split(',');
+            }
+        }
+        public string Id
+        {
+            get
+            {
+                return this.Guid.ToString();
+            }
+        }
+
+        // the relative path to the RDP file
+        private string ApplicationRootPath { get; set; }
+        public string RelativePath
+        {
+            get
+            {
+                if (this.Origin == "rdp")
+                {
+                    return this.Source.Replace(HttpContext.Current.Server.MapPath(this.ApplicationRootPath), "").TrimStart('\\').TrimEnd('\\').Replace("\\", "/");
+                }
+                return this.Title;
+            }
+        }
+
+        public Resource(string title, string fullAddress, string appProgram, string alias, string appFileExtCSV, DateTime lastUpdated, string virtualFolder, string origin, string source, string applicationRootPath)
+        {
+            this.ApplicationRootPath = applicationRootPath;
+            this.VirtualFolder = virtualFolder;
+
+            // full address is required because it is the connection address
+            if (string.IsNullOrEmpty(fullAddress))
+            {
+                throw new ArgumentException("Full address cannot be null or empty.");
+            }
+            this.FullAddress = fullAddress;
+
+            // we need to know if this is from the registry or and rdp file because
+            // the icon and rdp file path logic is different
+            if (string.IsNullOrEmpty(origin))
+            {
+                throw new ArgumentException("Origin cannot be null or empty. Use 'rdp' for RDP files or 'registry' for registry entries.");
+            }
+            if (origin != "rdp" && origin != "registry")
+            {
+                throw new ArgumentException("Origin must be either 'rdp' or 'registry'.");
+            }
+            this.Origin = origin;
+
+            // source must be a valid path to an RDP file or registry entry
+            if (string.IsNullOrEmpty(source))
+            {
+                throw new ArgumentException("Source cannot be null or empty. It should be the path to the RDP file or registry entry.");
+            }
+            if (origin == "rdp" && !System.IO.File.Exists(source))
+            {
+                throw new ArgumentException("Source must be a valid path to an RDP file. " + 
+                    "Ensure the file exists at the specified path: " + source);
+            }
+            if (origin == "registry") {
+                using (var regKey = Microsoft.Win32.Registry.LocalMachine.OpenSubKey("SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Terminal Server\\TSAppAllowList\\Applications\\" + source))
+                {
+                    if (regKey == null)
+                    {
+                        throw new ArgumentException("Source must be a valid application name in HKEY_LOCAL_MACHINE\\SOFTWARE\\Windows NT\\CurrentVersion\\Terminal Server\\TSAppAllowList\\Applications.");
+                    }
+                }
+            }
+            this.Source = source;
+
+            // title should not be null or empty
+            if (string.IsNullOrEmpty(title))
+            {
+                throw new ArgumentException("Title cannot be null or empty.");
+            }
+            this.Title = title;
+            this.Alias = alias;
+
+            // if lastUpdated is empty, set it to the current time
+            if (lastUpdated == DateTime.MinValue)
+            {
+                lastUpdated = DateTime.UtcNow;
+            }
+            this.LastUpdated = lastUpdated;
+
+            // is app program is not provided, we assume it is a desktop
+            if (string.IsNullOrEmpty(appProgram))
+            {
+                this.Type = "Desktop";
+                return;
+            }
+
+            // process the remaining remote application properties
+            this.Type = "RemoteApp";
+            this.AppProgram = appProgram;
+            this.AppFileExtCSV = appFileExtCSV;
+        }
+
+        public Resource SetGuid(System.Guid guid)
+        {
+            this.Guid = guid;
+            return this;
+        }
+
+        public Resource SetGuid(string guidString)
+        {
+            if (string.IsNullOrEmpty(guidString))
+            {
+                throw new ArgumentException("GUID cannot be null or empty.");
+            }
+            try
+            {
+                this.Guid = new System.Guid(guidString);
+                return this;
+            }
+            catch (FormatException)
+            {
+                throw new ArgumentException("GUID is not in a valid format: " + guidString);
+            }
+        }
+
+        public Resource CalculateGuid(double schemaVersion, bool mergeTerminalServers)
+        {
+            CalculateGuid(this.Source, schemaVersion, mergeTerminalServers);
+            return this;
+        }
+
+        public Resource CalculateGuid(string rdpFilePathOrContents, double schemaVersion, bool mergeTerminalServers)
+        {
+            // create a unique resource ID based on the RDP file contents
+            string[] linesToOmit = mergeTerminalServers && this.IsApp ? new string[] { "full address:s:" } : null;
+            this.Guid = GetResourceGUID(rdpFilePathOrContents, schemaVersion >= 2.0 ? "" : this.VirtualFolder, linesToOmit);
+            return this;
+        }
+
+        public static System.Guid GetResourceGUID(string rdpFilePath, string suffix = "", string[] linesToOmit = null)
+        {
+            // read the entire contents of the file into a string
+            // or if the file does not exist, treat the path as the contents
+            string fileContents = "";
+            try
+            {
+                fileContents = System.IO.File.ReadAllText(rdpFilePath);
+            }
+            catch
+            {
+                fileContents = rdpFilePath;
+            }
+
+            // alphabetically sort the lines in the file contents
+            var lines = fileContents.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
+            Array.Sort(lines);
+            fileContents = string.Join("\r\n", lines);
+
+            // omit the full address from the hash calculation
+            if (linesToOmit != null)
+            {
+                foreach (var lineToOmit in linesToOmit)
+                {
+                    fileContents = Regex.Replace(fileContents, @"(?m)^" + Regex.Escape(lineToOmit) + ".*$", "", RegexOptions.Multiline);
+                }
+            }
+
+            // if there is a suffix, append it to the file contents
+            if (!string.IsNullOrEmpty(suffix))
+            {
+                fileContents += suffix;
+            }
+
+            // generate a guid from the file contents
+            var byt = Encoding.UTF8.GetBytes(fileContents);
+            var md5 = System.Security.Cryptography.MD5.Create();
+            var hash = md5.ComputeHash(byt);
+            var guid = new Guid(hash);
+
+            return guid;
+        }
+    }
+
+    private void ProcessResource(Resource resource)
+    {
+        string resourceTimestamp = resource.LastUpdated.ToString("yyyy-MM-ddTHH:mm:ssZ");
+
+        // add the timestamp to the terminal server timestamps if it is the latest one
+        if (!terminalServerTimestamps.ContainsKey(resource.FullAddress) || resource.LastUpdated > terminalServerTimestamps[resource.FullAddress])
+        {
+            terminalServerTimestamps[resource.FullAddress] = resource.LastUpdated;
+        }
+
+        // elements to use to create an injection point element for the folder element
+        // that we can use to inject additional folders later
+        string injectionPointElement = "<FolderInjectionPoint guid=\"" + resource.Id + "\"/>";
+        string folderNameElement = "<Folder Name=\"" + (resource.VirtualFolder == "" ? "/" : resource.VirtualFolder) + "\" />" + "\r\n";
+
+        //
+        string tsInjectionPointElement = "<TerminalServerInjectionPoint guid=\"" + resource.Id + "\"/>";
+        string tsElement = "<TerminalServerRef Ref=\"" + resource.FullAddress + "\" />" + "\r\n";
+        string tsElements = "<HostingTerminalServer>" + "\r\n" +
+            "<ResourceFile FileExtension=\".rdp\" URL=\"" + Root() + "get-rdp.aspx?from=" + resource.Origin + "&amp;path=" + resource.RelativePath + "\" />" + "\r\n" +
+            tsElement +
+            "</HostingTerminalServer>" + "\r\n";
+
+        // ensure that the resource ID is unique: skip if it already exists
+        if (Array.IndexOf(previousResourceGUIDs, resource.Id) >= 0)
+        {
+            string existingResources = resourcesBuffer.ToString();
+
+            if (schemaVersion >= 2.0)
+            {
+                // ensure that the folder is not already in the list of folders for this resource
+                int injectionPointIndex = existingResources.IndexOf(injectionPointElement);
+                string frontTruncatedResources = existingResources.Substring(injectionPointIndex);
+                int firstFoldersElemEndIndex = frontTruncatedResources.IndexOf("</Folders>");
+                string currentFoldersElements = frontTruncatedResources.Substring(0, firstFoldersElemEndIndex);
+                bool folderAlreadyExists = currentFoldersElements.Contains(folderNameElement.Trim());
+
+                if (!folderAlreadyExists)
+                {
+                    // insert this folder element in front of the injection point element
+                    resourcesBuffer = resourcesBuffer.Replace(injectionPointElement, injectionPointElement + folderNameElement);
+                }
+            }
+
+            if (searchParams["mergeTerminalServers"] == "1")
+            {
+                // ensure that the terminal server is not already in the list of terminal servers for this resource
+                int tsInjectionPointIndex = existingResources.IndexOf(tsInjectionPointElement);
+                string tsFrontTruncatedResources = existingResources.Substring(tsInjectionPointIndex);
+                int firstTerminalServerElemEndIndex = tsFrontTruncatedResources.IndexOf("</HostingTerminalServers>");
+                string currentTerminalServerElements = tsFrontTruncatedResources.Substring(0, firstTerminalServerElemEndIndex);
+                bool terminalServerAlreadyExists = currentTerminalServerElements.Contains(tsElement.Trim());
+
+                if (!terminalServerAlreadyExists)
+                {
+                    // insert this terminal server element in front of the injection point element
+                    resourcesBuffer = resourcesBuffer.Replace(tsInjectionPointElement, tsInjectionPointElement + tsElements);
+                }
+            }
+
+            return;
+        }
+
+        // construct the resource element
+        resourcesBuffer.Append("<Resource ID=\"" + resource.Id + "\" Alias=\"" + resource.Alias + "\" Title=\"" + resource.Title + "\" LastUpdated=\"" + resourceTimestamp + "\" Type=\"" + resource.Type + "\"" + (schemaVersion >= 2.1 ? " ShowByDefault=\"True\"" : "") + ">" + "\r\n");
+        resourcesBuffer.Append("<Icons>" + "\r\n");
+        resourcesBuffer.Append(GetIconElements((resource.Origin == "registry" ? "registry:" : "") + resource.RelativePath.Replace(".rdp", ""), resource.IsDesktop ? "wallpaper" : "none", resource.IsDesktop ? "lib/assets/wallpaper.png" : "default.ico"));
+        resourcesBuffer.Append("</Icons>" + "\r\n");
+        if (resource.FileExtensions.Length > 0)
+        {
+            resourcesBuffer.Append("<FileExtensions>" + "\r\n");
+            foreach(string fileExt in resource.FileExtensions)
+            {
+                if (schemaVersion >= 2.0)
+                {
+                    resourcesBuffer.Append("<FileExtension Name=\"" + fileExt + "\" PrimaryHandler=\"True\">" + "\r\n");
+                }
+                else
+                {
+                    resourcesBuffer.Append("<FileExtension Name=\"" + fileExt + "\" >" + "\r\n");
+                }
+
+                if (schemaVersion >= 2.0)
+                {
+                    // if the icon exists, add it to the resource
+                    string maybeIconElements = GetIconElements(relativeIconPath: (resource.Origin == "registry" ? ("registry:" + fileExt.Replace(".", "") + ":") : "") + resource.RelativePath.Replace(".rdp", resource.Origin == "registry" ? "" : fileExt), skipMissing: true);
+                    if (!string.IsNullOrEmpty(maybeIconElements))
+                    {
+                        resourcesBuffer.Append("<FileAssociationIcons>" + "\r\n");
+                        resourcesBuffer.Append(maybeIconElements);
+                        resourcesBuffer.Append("</FileAssociationIcons>" + "\r\n");
+                    }
+                }
+
+                resourcesBuffer.Append("</FileExtension>" + "\r\n");
+            }
+            resourcesBuffer.Append("</FileExtensions>" + "\r\n");
+        }
+        else
+        {
+            resourcesBuffer.Append("<FileExtensions />" + "\r\n");
+        }
+        if (schemaVersion >= 2.0)
+        {
+            resourcesBuffer.Append("<Folders>" + "\r\n");
+            resourcesBuffer.Append(injectionPointElement);
+            resourcesBuffer.Append(folderNameElement);
+            resourcesBuffer.Append("</Folders>" + "\r\n");
+        }
+        resourcesBuffer.Append("<HostingTerminalServers>" + "\r\n");
+        resourcesBuffer.Append(tsInjectionPointElement);
+        resourcesBuffer.Append(tsElements);
+        resourcesBuffer.Append("</HostingTerminalServers>" + "\r\n");
+        resourcesBuffer.Append("</Resource>" + "\r\n");
+
+        // add the resource ID to the list of previous resource GUIDs to avoid duplicates
+        Array.Resize(ref previousResourceGUIDs, previousResourceGUIDs.Length + 1);
+        previousResourceGUIDs[previousResourceGUIDs.Length - 1] = resource.Id;
+    }
+
+    public AliasResolver resolver = new AliasResolver();
+
+    private void ProcessRegistryResources()
+    {
+        string publisherName = resolver.Resolve(System.Net.Dns.GetHostName());
+
+        // get the registry entries for the remote applications
+        using (var regKey = Microsoft.Win32.Registry.LocalMachine.OpenSubKey("SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Terminal Server\\TSAppAllowList\\Applications"))
+        {
+            if (regKey == null)
+            {
+                return; // no remote applications found
+            }
+
+            foreach (string appName in regKey.GetSubKeyNames())
+            {
+                using (var appKey = regKey.OpenSubKey(appName))
+                {
+                    if (appKey == null)
+                    {
+                        continue; // skip if the application key is not found
+                    }
+
+                    bool showInTSWA = appKey.GetValue("ShowInTSWA") as int? == 1;
+                    if (!showInTSWA)
+                    {
+                        continue; // skip if the application is not allowed to be shown in the webfeed
+                    }
+
+                    string appProgram = appKey.GetValue("Path") as string;
+                    if (string.IsNullOrEmpty(appProgram))
+                    {
+                        continue; // skip if the application path ismissing
+                    }
+
+                    bool hasPermission = Reader.CanAccessRemoteApp(appKey, getAuthenticatedUserInfo());
+                    if (!hasPermission)
+                    {
+                        continue; // skip if the user does not have permission to access the application
+                    }
+
+                    string appFileExtCSV = "";
+                    using (var fileTypesKey = appKey.OpenSubKey("Filetypes"))
+                    {
+                        if (fileTypesKey != null)
+                        {
+                            string[] fileTypeNames = fileTypesKey.GetValueNames();
+                            if (fileTypeNames.Length > 0)
+                            {
+                                appFileExtCSV = "." + string.Join(",.", fileTypeNames);
+                            }
+                        }
+                    }
+
+                    // get the generated rdp file
+                    string rdpFileContents = RegistryUtilities.Reader.ConstructRdpFileFromRegistry(appName);
+
+                    // create a resource from the registry entry
+                    Resource resource = new Resource(
+                        title: appName,
+                        fullAddress: publisherName,
+                        appProgram: appProgram,
+                        alias: "registry/" + appName,
+                        appFileExtCSV: appFileExtCSV,
+                        lastUpdated: DateTime.UtcNow,
+                        virtualFolder: "",
+                        origin: "registry",
+                        source: appName,
+                        applicationRootPath: Root()
+                    ).CalculateGuid(rdpFileContents, schemaVersion, searchParams["mergeTerminalServers"] == "1");
+
+                    ProcessResource(resource);
+                }
+            }
+        }
+    }
+
     private void ProcessSubFolders(string directoryPath, string relativePath)
     {
         if (System.IO.Directory.Exists(directoryPath) == false)
@@ -215,39 +654,6 @@
                 // extract full relative path from the directoryPath (including the resources or multiuser-resources folder)
                 string relativePathFull = directoryPath.Replace(HttpContext.Current.Server.MapPath(Root()), "").TrimStart('\\').TrimEnd('\\').Replace("\\", "/") + "/";
 
-                string subFolderName = relativePath;
-                if (folderPrefix != null)
-                {
-                    subFolderName = folderPrefix;
-                }
-
-                
-
-                // prepare the info for the resource
-                string appprogram = GetRDPvalue(eachfile, "remoteapplicationprogram:s:");
-                string apptitle = GetRDPvalue(eachfile, "remoteapplicationname:s:");
-                string apprdpfile = basefilename + ".rdp";
-                string appalias = relativePathFull + apprdpfile;
-                string appfileextcsv = GetRDPvalue(eachfile, "remoteapplicationfileextensions:s:");
-                string appfulladdress = GetRDPvalue(eachfile, "full address:s:");
-                string rdptype = "RemoteApp";
-
-                // set the app title to the base filename if the remote application name is empty
-                if (appprogram == "")
-                {
-                    rdptype = "Desktop";
-                    apptitle = basefilename;
-                }
-                else
-                {
-                    rdptype = "RemoteApp";
-                }
-
-                // create a unique resource ID based on the file name and the full address
-                string[] linesToOmit = searchParams["mergeTerminalServers"] == "1" && rdptype == "RemoteApp" ? new string[] { "full address:s:" } : null;
-                string appresourceid = GetResourceGUID(eachfile, schemaVersion >= 2.0 ? "" : subFolderName, linesToOmit).ToString();
-
-
                 // get the paths to all files that start with the same basename as the rdp file
                 // (e.g., get: *.rdp, *.ico, *.png, *.xlsx.ico, *.xls.png, etc.)
                 string[] allResourceFiles = System.IO.Directory.GetFiles(directoryPath, basefilename + ".*");
@@ -262,133 +668,23 @@
                         resourceDateTime = fileDateTime;
                     }
                 }
-                string resourceTimestamp = resourceDateTime.ToString("yyyy-MM-ddTHH:mm:ssZ");
 
-                // add the timestamp to the terminal server timestamps if it is the latest one
-                if (!terminalServerTimestamps.ContainsKey(appfulladdress) || resourceDateTime > terminalServerTimestamps[appfulladdress])
-                {
-                    terminalServerTimestamps[appfulladdress] = resourceDateTime;
-                }
+                // prepare the info for the resource
+                var resource = new Resource(
+                    title: GetRDPvalue(eachfile, "remoteapplicationname:s:", basefilename), // set the app title to the base filename if the remote application name is empty
+                    fullAddress: GetRDPvalue(eachfile, "full address:s:"),
+                    appProgram: GetRDPvalue(eachfile, "remoteapplicationprogram:s:"),
+                    alias: relativePathFull + basefilename + ".rdp",
+                    appFileExtCSV: GetRDPvalue(eachfile, "remoteapplicationfileextensions:s:"),
+                    lastUpdated: resourceDateTime,
+                    virtualFolder: folderPrefix ?? relativePath,
+                    origin: "rdp",
+                    source: directoryPath + "\\" + System.IO.Path.GetFileName(System.IO.Path.GetFileName(eachfile)),
+                    applicationRootPath: Root()
+                ).CalculateGuid(schemaVersion, searchParams["mergeTerminalServers"] == "1");
 
-                // elements to use to create an injection point element for the folder element
-                // that we can use to inject additional folders later
-                string injectionPointElement = "<FolderInjectionPoint guid=\"" + appresourceid + "\"/>";
-                string folderNameElement = "<Folder Name=\"" + (subFolderName==""?"/":subFolderName) + "\" />" + "\r\n";
-
-                //
-                string tsInjectionPointElement = "<TerminalServerInjectionPoint guid=\"" + appresourceid + "\"/>";
-                string tsElement = "<TerminalServerRef Ref=\"" + appfulladdress + "\" />" + "\r\n";
-                string tsElements = "<HostingTerminalServer>" + "\r\n" +
-                    "<ResourceFile FileExtension=\".rdp\" URL=\"" + Root() + appalias + "\" />" + "\r\n" +
-                    tsElement +
-                    "</HostingTerminalServer>" + "\r\n";
-
-                // ensure that the resource ID is unique: skip if it already exists
-                if (Array.IndexOf(previousResourceGUIDs, appresourceid) >= 0)
-                {
-                    string existingResources = resourcesBuffer.ToString();
-
-                    if (schemaVersion >= 2.0)
-                    {
-                        // ensure that the folder is not already in the list of folders for this resource
-                        int injectionPointIndex = existingResources.IndexOf(injectionPointElement);
-                        string frontTruncatedResources = existingResources.Substring(injectionPointIndex);
-                        int firstFoldersElemEndIndex = frontTruncatedResources.IndexOf("</Folders>");
-                        string currentFoldersElements = frontTruncatedResources.Substring(0, firstFoldersElemEndIndex);
-                        bool folderAlreadyExists = currentFoldersElements.Contains(folderNameElement.Trim());
-
-                        if (!folderAlreadyExists)
-                        {
-                            // insert this folder element in front of the injection point element
-                            resourcesBuffer = resourcesBuffer.Replace(injectionPointElement, injectionPointElement + folderNameElement);
-                        }
-                    }
-
-                    if (searchParams["mergeTerminalServers"] == "1")
-                    {
-                        // ensure that the terminal server is not already in the list of terminal servers for this resource
-                        int tsInjectionPointIndex = existingResources.IndexOf(tsInjectionPointElement);
-                        string tsFrontTruncatedResources = existingResources.Substring(tsInjectionPointIndex);
-                        int firstTerminalServerElemEndIndex = tsFrontTruncatedResources.IndexOf("</HostingTerminalServers>");
-                        string currentTerminalServerElements = tsFrontTruncatedResources.Substring(0, firstTerminalServerElemEndIndex);
-                        bool terminalServerAlreadyExists = currentTerminalServerElements.Contains(tsElement.Trim());
-
-                        if (!terminalServerAlreadyExists)
-                        {
-                            // insert this terminal server element in front of the injection point element
-                            resourcesBuffer = resourcesBuffer.Replace(tsInjectionPointElement, tsInjectionPointElement + tsElements);
-                        }
-                    }
-
-
-                    continue;
-                }
-
-                // construct the resource element
-                resourcesBuffer.Append("<Resource ID=\"" + appresourceid + "\" Alias=\"" + appalias + "\" Title=\"" + apptitle + "\" LastUpdated=\"" + resourceTimestamp + "\" Type=\"" + rdptype + "\"" + (schemaVersion >= 2.1 ? " ShowByDefault=\"True\"" : "") + ">" + "\r\n");
-                resourcesBuffer.Append("<Icons>" + "\r\n");
-                resourcesBuffer.Append(GetIconElements(relativePathFull + basefilename, rdptype == "Desktop" ? "wallpaper" : "none", rdptype == "Desktop" ? "lib/assets/wallpaper.png" : "default.ico"));
-                resourcesBuffer.Append("</Icons>" + "\r\n");
-                if (appfileextcsv != "")
-                {
-                    resourcesBuffer.Append("<FileExtensions>" + "\r\n");
-                    string[] fileExtensions = appfileextcsv.Split(',');
-                    foreach(string fileExt in fileExtensions)
-                    {
-                        if (schemaVersion >= 2.0)
-                        {
-                            resourcesBuffer.Append("<FileExtension Name=\"" + fileExt + "\" PrimaryHandler=\"True\">" + "\r\n");
-                        }
-                        else
-                        {
-                            resourcesBuffer.Append("<FileExtension Name=\"" + fileExt + "\" >" + "\r\n");
-                        }
-
-                        if (schemaVersion >= 2.0)
-                        {
-                            // check if the icon exists, and if so, add it to the resource
-                            string iconPath = System.IO.Path.Combine(directoryPath, basefilename + fileExt + ".ico");
-                            string iconExt = ".ico";
-                            string pngIconPath = System.IO.Path.Combine(directoryPath, basefilename + fileExt + ".png");
-                            if (System.IO.File.Exists(pngIconPath))
-                            {
-                                iconPath = pngIconPath;
-                                iconExt = ".png";
-                            }
-                            string relativeIconPath = relativePathFull + basefilename + fileExt + iconExt;
-                            bool iconExists = System.IO.File.Exists(iconPath);
-                            if (iconExists)
-                            {
-                                resourcesBuffer.Append("<FileAssociationIcons>" + "\r\n");
-                                resourcesBuffer.Append(GetIconElements(relativePathFull + basefilename + fileExt));
-                                resourcesBuffer.Append("</FileAssociationIcons>" + "\r\n");
-                            }
-                        }
-
-                        resourcesBuffer.Append("</FileExtension>" + "\r\n");
-                    }
-                    resourcesBuffer.Append("</FileExtensions>" + "\r\n");
-                }
-                else
-                {
-                    resourcesBuffer.Append("<FileExtensions />" + "\r\n");
-                }
-                if (schemaVersion >= 2.0)
-                {
-                    resourcesBuffer.Append("<Folders>" + "\r\n");
-                    resourcesBuffer.Append(injectionPointElement);
-                    resourcesBuffer.Append(folderNameElement);
-                    resourcesBuffer.Append("</Folders>" + "\r\n");
-                }
-                resourcesBuffer.Append("<HostingTerminalServers>" + "\r\n");
-                resourcesBuffer.Append(tsInjectionPointElement);
-                resourcesBuffer.Append(tsElements);
-                resourcesBuffer.Append("</HostingTerminalServers>" + "\r\n");
-                resourcesBuffer.Append("</Resource>" + "\r\n");
-
-                // add the resource ID to the list of previous resource GUIDs to avoid duplicates
-                Array.Resize(ref previousResourceGUIDs, previousResourceGUIDs.Length + 1);
-                previousResourceGUIDs[previousResourceGUIDs.Length - 1] = appresourceid;
+                // process the resource
+                ProcessResource(resource);
             }
         }
     }
@@ -447,6 +743,10 @@
       // process resources
       string resourcesFolder = "resources";
       string multiuserResourcesFolder = "multiuser-resources";
+      if (System.Configuration.ConfigurationManager.AppSettings["RegistryApps.Enabled"] == "true")
+      {
+        ProcessRegistryResources();
+      }
       ProcessResources(resourcesFolder, "");
       ProcessMultiuserResources(multiuserResourcesFolder);
       ProcessSubFolders(resourcesFolder, "");


### PR DESCRIPTION
This change allows RAWeb to include apps from `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Terminal Server\TSAppAllowList\Applications`.
- Applications are included in the webfeed if `ShowInTSWA=1` and `Path` has a non-empty value.
- If the `Name` value exists, it will be used as the display name for the RemoteApp in the webfeed.
- If `Filetypes` subkey, if it exists, is used when constructing the value for `remoteapplicationfileextensions:s:`.
- If the RemoteApp in the registry has a value for `SecurityDescriptor` (an SSDL string), it will only be included in the webfeed if the currently authenticated user or their groups are included in an `AccessAllowed` access control entry (ACE) in the discrentionary access controll list (DACL). If the user or one of their groups has an `AccessDenied` ACE in addition to an `AccessAllowed` ACE, the RemoteApp will be excluded from the registry.
- RDP files are now served by `get-rdp.aspx`. It can serve RDP files from resources, multiuser-resources, and the registry.
  - Registry RemoteApps that are omitted from the webfeed due to an `AccessDenied` ACS will not be served, even if they exist. `get-rdp.aspx` will respond with an HTTP 403 error.
- `get-image.aspx` can now serve up to 32x32 icons for RemoteApps from the registry. Instead of providing a relative path to the image file for the `image` query param, use `image=registry:<keyName>`, where `<keyName>` is the name of the RemoteApp's key in the registry. For filetype images, use `image=registry:<extension>:<keyName>`, where `<extensions>` is the the extension listed the `Filetypes` key in the registry for that RemoteApp.
- Registry RemoteApps are enabled by default, but they can be disabled by setting the `RegistryApps.Enabled` application setting to `true` in IIS manager
- Generated RDP files for registry RemoteApps will use the server's IPv4 address and the RDP port number (from `HKLM:\SYSTEM\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp`) for `full address`. This can be overriden with the `RegistryApps.FullAddressOverride` application setting in IIS manager.
- Additional properties for RDP files generated based on the registry can be specififed in the `RegistryApps.AdditionalProperties` application setting. Each property should be separated by a semicolon. If a semicolon is needed in a property value, it can be escaped with a single backslash. The default value is `drivestoredirect:s:*;redirectclipboard:i:1`. I am open to more options being added - these are just what I though would be minimally good to include by default. @kimmknight, since you are more experienced, I am curious whether you think more properties should be added by default.

Tested on web client, Windows RADC, Android client, iPadOS client.

Registry entries for mmc.exe, regedit.exe, vscode.exe, and explorer.exe were created with RemoteApp Tool for development and testing. I used a manually-created security descriptor to confirm that the logic in works. "O:SYG:BAD:(D;OICI;GR;;;S-1-5-21-1530441725-727401802-247631028-1006)(A;OICI;FA;;;S-1-5-32-545)". The owner is SYSTEM and primary group is Built-in Administrators. The DACL allows all users in the Users group (`(A;OICI;FA;;;S-1-5-32-545)`) and disallows access to one of my testing users (`(D;OICI;GR;;;S-1-5-21-1530441725-727401802-247631028-1006)`).

