### PR TITLE
Include `SupportsReconnect="false"` on the `ResourceCollection` element in the webfeed for schema versions >= 2.0

### DIFF
--- a/aspx/wwwroot/webfeed.aspx
+++ b/aspx/wwwroot/webfeed.aspx
@@ -774,7 +774,7 @@
       }
       string publisherTimestamp = publisherDateTime.ToString("yyyy-MM-ddTHH:mm:ssZ");
 
-      HttpContext.Current.Response.Write("<ResourceCollection PubDate=\"" + datetime + "\" SchemaVersion=\"" + schemaVersion.ToString() + "\" xmlns=\"http://schemas.microsoft.com/ts/2007/05/tswf\">" + "\r\n");
+      HttpContext.Current.Response.Write("<ResourceCollection PubDate=\"" + datetime + "\" SchemaVersion=\"" + schemaVersion.ToString() + "\" " + (schemaVersion >= 2.0 ? "SupportsReconnect=\"false\" " : "") + "xmlns=\"http://schemas.microsoft.com/ts/2007/05/tswf\">" + "\r\n");
       HttpContext.Current.Response.Write("<Publisher LastUpdated=\"" + publisherTimestamp + "\" Name=\"" + publisherName + "\" ID=\"" + serverFQDN + "\" Description=\"\">" + "\r\n");
 
       HttpContext.Current.Response.Write("<Resources>" + "\r\n");


### PR DESCRIPTION
Without `SupportsReconnect="false"`, Windows RADC adds a system tray icon for reconnecting via remote desktop workspace runtime protocol (MS-RDWR).

RAWeb cannot support MS-RDWR, so we should set this attribute to false. Per MS-TSWP, this attribute is only valid on schema versions >= 2.0.

Tested on:
- [x] Web client
- [x] Windows RADC
- [x] Android client
- [x] iOS/iPadOS client