### PR TITLE
Show version numbers in settings and show an update notice for local admins when a newer version is available

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,6 +46,25 @@ jobs:
           echo "Using version $new_version"
           echo "version=$new_version" >> $GITHUB_OUTPUT
 
+      - name: Update AssemblyInfo.cs
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+
+          # remove 'v' prefix
+          VERSION=${VERSION#v}
+
+          # split by '.' and remove leading zeros from each part
+          IFS='.' read -ra ADDR <<< "$VERSION"
+          CLEAN_VERSION=""
+          for i in "${ADDR[@]}"; do
+            # remove leading zeros unless it's a single zero
+            CLEAN_VERSION+="$(echo "$i" | sed 's/^0\([0-9]\)/\1/g')."
+          done
+          CLEAN_VERSION=${CLEAN_VERSION%.} # remove trailing dot
+
+          echo "Setting AssemblyVersion to $CLEAN_VERSION"
+          sed -i -E "s/^(\[assembly: AssemblyFileVersion\(\")[0-9\.]+(\"\)\])/\1$CLEAN_VERSION\2/" aspx/wwwroot/App_Code/AssemblyInfo.cs
+
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
         with:

--- a/aspx/wwwroot/App_Code/AssemblyInfo.cs
+++ b/aspx/wwwroot/App_Code/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+using System.Reflection;
+
+[assembly: AssemblyTitle("RAWeb")]
+[assembly: AssemblyProduct("RAWeb")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")] // this should be replaced with the actual release version during the release process
+[assembly: AssemblyCompany("RAWeb")]

--- a/aspx/wwwroot/App_Code/VersionUtilities.cs
+++ b/aspx/wwwroot/App_Code/VersionUtilities.cs
@@ -1,0 +1,77 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Reflection;
+using System.Linq;
+using System.Web;
+using System.Web.Script.Serialization;
+
+namespace VersionUtilities
+{
+    public class VersionHelpers
+    {
+        static public Version ToVersion(string versionString)
+        {
+            if (string.IsNullOrEmpty(versionString))
+            {
+                return new Version(1, 0, 0, 0);
+            }
+
+            string[] versionParts = versionString.Split('.');
+            if (versionParts.Length >= 4)
+            {
+                int year = int.Parse(versionParts[0]);
+                int month = int.Parse(versionParts[1]);
+                int day = int.Parse(versionParts[2]);
+                int revision = int.Parse(versionParts[3]);
+
+                return new Version(year, month, day, revision);
+            }
+
+            return new Version(1, 0, 0, 0);
+        }
+    }
+    public class LocalVersions
+    {
+        static public string GetApplicationVersionString()
+        {
+            // get the AssemblyFileVersion from AssemblyInfo.cs
+            // (this version is set during the release process for RAWeb)
+            string fileVersion = null;
+            AssemblyFileVersionAttribute versionAttribute = Assembly.GetExecutingAssembly()
+                                                                    .GetCustomAttributes(typeof(AssemblyFileVersionAttribute), false)
+                                                                    .OfType<AssemblyFileVersionAttribute>()
+                                                                    .FirstOrDefault();
+
+            if (versionAttribute != null)
+            {
+                fileVersion = versionAttribute.Version;
+            }
+
+            if (!string.IsNullOrEmpty(fileVersion))
+            {
+                return fileVersion;
+            }
+
+            return "1.0.0.0";
+        }
+
+        static public string GetFrontendVersionString()
+        {
+            string timestampFilePath = HttpContext.Current.Server.MapPath("~/lib/build.timestamp");
+            if (File.Exists(timestampFilePath))
+            {
+                try
+                {
+                    string timestamp = File.ReadAllText(timestampFilePath).Trim();
+                    return timestamp;
+                }
+                catch (Exception ex)
+                {
+                    return null;
+                }
+            }
+            return null;
+        }
+    }
+}

--- a/aspx/wwwroot/lib/controls/AppRoot.ascx
+++ b/aspx/wwwroot/lib/controls/AppRoot.ascx
@@ -5,6 +5,7 @@
 <%@ Import Namespace="System.Web.UI" %>
 <%@ Import Namespace="System.Web.Security" %>
 <%@ Import Namespace="System.Xml" %>
+<%@ Import Namespace="VersionUtilities" %>
 
 <script runat="server">
     protected void Page_Load(object sender, EventArgs e)
@@ -266,4 +267,6 @@
     }
     window.__machineName = '<%= resolver.Resolve(Environment.MachineName) %>';
     window.__envMachineName = '<%= Environment.MachineName %>';
+    window.__coreVersion = '<%= VersionUtilities.LocalVersions.GetApplicationVersionString() %>';
+    window.__webVersion = '<%= VersionUtilities.LocalVersions.GetFrontendVersionString() %>';
 </script>

--- a/frontend/lib/App.vue
+++ b/frontend/lib/App.vue
@@ -11,6 +11,7 @@
     registerServiceWorker,
     removeSplashScreen,
     simpleModeEnabled,
+    useUpdateDetails,
     useWebfeedData,
   } from '$utils';
   import { computed, onMounted, ref, watch, watchEffect } from 'vue';
@@ -198,6 +199,11 @@
       }
     });
   }
+
+  const { updateDetails, populateUpdateDetails } = useUpdateDetails();
+  onMounted(() => {
+    populateUpdateDetails();
+  });
 </script>
 
 <template>
@@ -231,7 +237,7 @@
           <Devices :data v-else-if="hash === '#devices'" />
           <Apps :data v-else-if="hash === '#apps'" />
           <Simple :data v-else-if="hash === '#simple'" />
-          <Settings :data v-else-if="hash === '#settings'" />
+          <Settings :update="updateDetails" v-else-if="hash === '#settings'" />
           <Policies :data v-else-if="hash === '#policies'" />
           <div v-else>
             <TextBlock variant="title">404</TextBlock>

--- a/frontend/lib/App.vue
+++ b/frontend/lib/App.vue
@@ -207,7 +207,7 @@
 </script>
 
 <template>
-  <Titlebar forceVisible :loading="titlebarLoading || loading" />
+  <Titlebar forceVisible :loading="titlebarLoading || loading" :update="updateDetails" />
   <div id="appContent">
     <NavigationRail v-if="!simpleModeEnabled" />
     <main :class="{ simple: simpleModeEnabled }">

--- a/frontend/lib/components/ContentDialog/ContentDialog.vue
+++ b/frontend/lib/components/ContentDialog/ContentDialog.vue
@@ -110,6 +110,7 @@
 </script>
 
 <template>
+  <slot name="opener" :popoverId :open :close></slot>
   <dialog
     ref="dialog"
     popover="manual"
@@ -126,7 +127,7 @@
         <slot></slot>
       </div>
       <footer class="content-dialog-footer">
-        <slot name="footer"></slot>
+        <slot name="footer" :close></slot>
       </footer>
     </div>
   </dialog>
@@ -226,7 +227,7 @@
 
   .content-dialog-footer {
     display: grid;
-    grid-auto-rows: 1fr;
+    grid-auto-columns: 1fr;
     grid-auto-flow: column;
     grid-gap: 8px;
     border-block-start: 1px solid var(--wui-card-stroke-default);

--- a/frontend/lib/components/Titlebar/Titlebar.vue
+++ b/frontend/lib/components/Titlebar/Titlebar.vue
@@ -1,22 +1,28 @@
 <script setup lang="ts">
-  import Button from '$components/Button/Button.vue';
-  import IconButton from '$components/IconButton/IconButton.vue';
-  import { MenuFlyout, MenuFlyoutItem } from '$components/MenuFlyout/index.mjs';
-  import ProgressRing from '$components/ProgressRing/ProgressRing.vue';
-  import TextBlock from '$components/TextBlock/TextBlock.vue';
-  import { restoreSplashScreen, simpleModeEnabled } from '$utils';
-  import { onMounted, ref, useTemplateRef } from 'vue';
+  import {
+    Button,
+    ContentDialog,
+    IconButton,
+    MenuFlyout,
+    MenuFlyoutItem,
+    ProgressRing,
+    TextBlock,
+  } from '$components';
+  import { restoreSplashScreen, simpleModeEnabled, useUpdateDetails } from '$utils';
+  import { onMounted, ref, type UnwrapRef, useTemplateRef } from 'vue';
 
   const {
     forceVisible = false,
     loading = false,
     hideProfileMenu = false,
     withBorder = false,
+    update,
   } = defineProps<{
     forceVisible?: boolean;
     loading?: boolean;
     hideProfileMenu?: boolean;
     withBorder?: boolean;
+    update?: UnwrapRef<ReturnType<typeof useUpdateDetails>['updateDetails']>;
   }>();
 
   // TODO [Anchors]: Remove this when all major browsers support CSS Anchor Positioning
@@ -146,6 +152,31 @@
       <ProgressRing :size="16" style="padding: 0 8px" v-if="loading" />
     </div>
     <div class="right">
+      <ContentDialog size="max" v-if="update?.details" :title="update.details.name">
+        <template #opener="{ open }">
+          <Button
+            :class="['profile-menu-button']"
+            style="color: var(--wui-system-attention)"
+            v-if="update?.details"
+            @click="() => open()"
+          >
+            <template #icon>
+              <svg width="24" height="24" fill="none" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                <path
+                  d="M16 8.25a.75.75 0 0 1 1.5 0v3.25a.75.75 0 0 1-.75.75H14a.75.75 0 0 1 0-1.5h1.27A3.502 3.502 0 0 0 12 8.5c-1.093 0-2.037.464-2.673 1.23a.75.75 0 1 1-1.154-.96C9.096 7.66 10.463 7 12 7c1.636 0 3.088.785 4 2v-.75ZM8 15v.75a.75.75 0 0 1-1.5 0v-3a.75.75 0 0 1 .75-.75H10a.75.75 0 0 1 0 1.5H8.837a3.513 3.513 0 0 0 5.842.765.75.75 0 1 1 1.142.972A5.013 5.013 0 0 1 8 15Zm4-13C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2Zm8.5 10a8.5 8.5 0 1 1-17 0 8.5 8.5 0 0 1 17 0Z"
+                  fill="currentColor"
+                />
+              </svg>
+            </template>
+            {{ $t('titlebar.updateAvailable') }}
+          </Button>
+        </template>
+        <div class="gfm" v-html="update.details.notes"></div>
+        <template v-slot:footer="{ close }">
+          <Button :href="update.details.html_url" target="_blank">View on GitHub</Button>
+          <Button @click="close">Close</Button>
+        </template>
+      </ContentDialog>
       <IconButton
         href="#settings"
         class="profile-menu-button"

--- a/frontend/lib/pages/Settings.vue
+++ b/frontend/lib/pages/Settings.vue
@@ -231,7 +231,7 @@
           <TextBlock> {{ $t('settings.about.webVersion') }}: {{ webVersion }} </TextBlock>
         </div>
       </div>
-      <div class="updates">
+      <div class="updates" v-if="isLocalAdministrator">
         <template v-if="update.loading">
           <TextBlock>
             {{ $t('settings.about.updates.checking') }}

--- a/frontend/lib/pages/Settings.vue
+++ b/frontend/lib/pages/Settings.vue
@@ -21,6 +21,20 @@
   const workspaceUrl = `${window.location.origin}${window.__iisBase}webfeed.aspx`;
 
   const policies = ref(window.__policies);
+  const coreVersion = window.__coreVersion;
+  const webVersion = (() => {
+    const version = window.__webVersion;
+    return (
+      version.slice(0, 4) +
+      '.' +
+      version.slice(5, 7) +
+      '.' +
+      version.slice(8, 10) +
+      '.' +
+      version.slice(11, 13) +
+      version.slice(14, 16)
+    );
+  })();
 
   const { favoriteResources } = useFavoriteResources();
 
@@ -204,6 +218,14 @@
       <Button variant="hyperlink" href="https://github.com/kimmknight/raweb">{{
         $t('settings.about.learnMore')
       }}</Button>
+      <div>
+        <div>
+          <TextBlock> {{ $t('settings.about.coreVersion') }}: {{ coreVersion }} </TextBlock>
+        </div>
+        <div>
+          <TextBlock> {{ $t('settings.about.webVersion') }}: {{ webVersion }} </TextBlock>
+        </div>
+      </div>
     </div>
     <Button style="margin-top: 8px" href="#policies" v-if="simpleModeEnabled && isLocalAdministrator">
       Manage policies

--- a/frontend/lib/pages/Settings.vue
+++ b/frontend/lib/pages/Settings.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { Button, InfoBar, TextBlock, ToggleSwitch } from '$components';
+  import { Button, ContentDialog, InfoBar, TextBlock, ToggleSwitch } from '$components';
   import {
     combineTerminalServersModeEnabled,
     favoritesEnabled,
@@ -7,8 +7,13 @@
     iconBackgroundsEnabled,
     simpleModeEnabled,
     useFavoriteResources,
+    useUpdateDetails,
   } from '$utils';
-  import { ref } from 'vue';
+  import { ref, type UnwrapRef } from 'vue';
+
+  const { update } = defineProps<{
+    update: UnwrapRef<ReturnType<typeof useUpdateDetails>['updateDetails']>;
+  }>();
 
   const isLocalAdministrator = window.__authUser.isLocalAdministrator;
 
@@ -226,6 +231,42 @@
           <TextBlock> {{ $t('settings.about.webVersion') }}: {{ webVersion }} </TextBlock>
         </div>
       </div>
+      <div class="updates">
+        <template v-if="update.loading">
+          <TextBlock>
+            {{ $t('settings.about.updates.checking') }}
+          </TextBlock>
+        </template>
+        <template v-else-if="update.status === 429">
+          <TextBlock>
+            {{ $t('settings.about.updates.rateLimited') }}
+          </TextBlock>
+        </template>
+        <template v-else-if="update.details">
+          <TextBlock>
+            {{ $t('settings.about.updates.available') }}: {{ update.details.name }} ({{
+              update.details.version
+            }})
+          </TextBlock>
+          <div class="button-row">
+            <ContentDialog size="max" v-if="update.details" :title="update.details.name">
+              <template #opener="{ open }">
+                <Button @click="() => open()">View details</Button>
+              </template>
+              <div class="gfm" v-html="update.details.notes"></div>
+              <template v-slot:footer="{ close }">
+                <Button :href="update.details.html_url" target="_blank">View on GitHub</Button>
+                <Button @click="close">Close</Button>
+              </template>
+            </ContentDialog>
+          </div>
+        </template>
+        <template v-else>
+          <TextBlock>
+            {{ $t('settings.about.updates.upToDate') }}
+          </TextBlock>
+        </template>
+      </div>
     </div>
     <Button style="margin-top: 8px" href="#policies" v-if="simpleModeEnabled && isLocalAdministrator">
       Manage policies
@@ -280,5 +321,82 @@
     align-items: center;
     gap: 16px;
     margin-bottom: 8px;
+  }
+
+  .updates {
+    margin-top: 8px;
+  }
+
+  .updates .button-row {
+    margin-top: 8px;
+  }
+</style>
+
+<style>
+  .gfm {
+    font-size: 14px;
+    font-family: var(--wui-font-family-text);
+    font-size: var(--wui-font-size-body);
+    line-height: var(--wui-line-height-body);
+    --note-color: light-dark(rgb(79, 140, 201), rgb(79, 140, 201));
+    --important-color: light-dark(#8250df, #8957e5);
+  }
+  .gfm h2 {
+    font-size: 16px !important;
+    font-weight: 500 !important;
+  }
+  .gfm h3 {
+    font-size: 15px !important;
+    font-weight: 500 !important;
+  }
+  .gfm strong {
+    font-weight: 600 !important;
+  }
+  .gfm .markdown-alert {
+    padding: 0.5rem 1rem;
+    margin-bottom: 1rem;
+    color: inherit;
+    border-left: 0.25em solid #3d444d;
+  }
+  .gfm .markdown-alert > :first-child {
+    margin-top: 0;
+  }
+  .gfm .markdown-alert > :last-child {
+    margin-bottom: 0;
+  }
+  .gfm .markdown-alert .markdown-alert-title {
+    display: flex;
+    font-weight: 500;
+    align-items: center;
+    line-height: 1;
+  }
+  .gfm .octicon {
+    fill: currentColor;
+    margin-right: 0.5rem;
+  }
+  .gfm .markdown-alert.markdown-alert-important .markdown-alert-title {
+    color: var(--important-color);
+  }
+  .gfm .markdown-alert.markdown-alert-important {
+    border-left-color: var(--important-color);
+  }
+  .gfm .markdown-alert.markdown-alert-note .markdown-alert-title {
+    color: var(--note-color);
+  }
+  .gfm .markdown-alert.markdown-alert-note {
+    border-left-color: var(--note-color);
+  }
+  .gfm pre {
+    overflow: auto;
+    user-select: text;
+    border: 1px solid var(--wui-control-stroke-default);
+    background-color: var(--wui-solid-background-base);
+    padding: 12px;
+    border-radius: var(--wui-control-corner-radius);
+  }
+  .gfm code:not(.gfm pre code) {
+    background-color: var(--wui-solid-background-base);
+    border-radius: var(--wui-control-corner-radius);
+    padding: 2px;
   }
 </style>

--- a/frontend/lib/public/locales/en.json
+++ b/frontend/lib/public/locales/en.json
@@ -79,7 +79,13 @@
       "appDesc": "A web interface for your RemoteApps and Desktops hosted on Windows 10, 11 and Server. Powered by RAWeb.",
       "learnMore": "Learn more on GitHub",
       "coreVersion": "Server version",
-      "webVersion": "App version"
+      "webVersion": "App version",
+      "updates": {
+        "checking": "Checking for updates…",
+        "available": "An update is available",
+        "rateLimited": "Failed to check for updates (rate limited). Please try again later.",
+        "upToDate": "Up to date"
+      }
     }
   },
   "policies": {

--- a/frontend/lib/public/locales/en.json
+++ b/frontend/lib/public/locales/en.json
@@ -77,7 +77,9 @@
     "about": {
       "title": "About",
       "appDesc": "A web interface for your RemoteApps and Desktops hosted on Windows 10, 11 and Server. Powered by RAWeb.",
-      "learnMore": "Learn more on GitHub"
+      "learnMore": "Learn more on GitHub",
+      "coreVersion": "Server version",
+      "webVersion": "App version"
     }
   },
   "policies": {

--- a/frontend/lib/public/locales/en.json
+++ b/frontend/lib/public/locales/en.json
@@ -14,6 +14,9 @@
   "profile": {
     "signOut": "Sign out"
   },
+  "titlebar": {
+    "updateAvailable": "Update available"
+  },
   "favorites": {
     "title": "Favorites",
     "getStarted": "Get started with favorites",

--- a/frontend/lib/types.d.ts
+++ b/frontend/lib/types.d.ts
@@ -31,6 +31,10 @@ declare global {
     __machineName: string;
     /** The machine name (`Environment.MachineName`) */
     __envMachineName: string;
+    /** The current version of RAWeb */
+    __coreVersion: string;
+    /** The build timestamp for the frontend */
+    __webVersion: string;
   }
 }
 

--- a/frontend/lib/utils/index.mjs
+++ b/frontend/lib/utils/index.mjs
@@ -15,6 +15,7 @@ import {
   useFavoriteResources,
   useFavoriteResourceTerminalServers,
 } from './useFavoriteResources.ts';
+import { useUpdateDetails } from './useUpdateDetails.ts';
 import { useWebfeedData } from './useWebfeedData.ts';
 
 export {
@@ -34,5 +35,6 @@ export {
   simpleModeEnabled,
   useFavoriteResources,
   useFavoriteResourceTerminalServers,
+  useUpdateDetails,
   useWebfeedData,
 };

--- a/frontend/lib/utils/useUpdateDetails.ts
+++ b/frontend/lib/utils/useUpdateDetails.ts
@@ -1,0 +1,128 @@
+import { ref } from 'vue';
+
+const update = ref({
+  loading: false,
+  status: null as number | null,
+  details: null as {
+    tag: string;
+    version: string;
+    notes: string;
+    name: string;
+    html_url: string;
+  } | null,
+});
+
+function populateUpdateDetails(force = false) {
+  // do not fetch if details are already populated
+  if (update.value.details && !force) {
+    return;
+  }
+
+  // do not fetch if already in progress
+  if (update.value.loading) {
+    return;
+  }
+
+  if (window.__authUser.isLocalAdministrator) {
+    update.value.loading = true;
+    fetch('https://api.github.com/repos/kimmknight/raweb/releases', {})
+      .then((res) => {
+        update.value.status = res.status;
+        if (!res.ok) {
+          throw new Error(`HTTP error: ${res.status}`);
+        }
+        return res.json();
+      })
+      .then(async (data) => {
+        // find the first release that is not a draft or prerelease
+        const latestRelease = data.find(
+          (release: { draft: boolean; prerelease: boolean }) => !release.draft && !release.prerelease
+        );
+
+        if (!latestRelease) {
+          update.value.details = null;
+          return;
+        }
+
+        const tagName = latestRelease.tag_name as string;
+        const version = tagName.replace(/^v/, ''); // Remove leading 'v' if present
+
+        // stop if the new version is not newer than the current version
+        const newVersionParts = version.split('.');
+        const currentVersionParts = window.__coreVersion.split('.');
+        const currentVersionYear = parseInt(currentVersionParts[0], 10);
+        const currentVersionMonth = parseInt(currentVersionParts[1], 10);
+        const currentVersionDay = parseInt(currentVersionParts[2], 10);
+        const currentVersionPatch = parseInt(currentVersionParts[3] || '0', 10);
+        const newVersionYear = parseInt(newVersionParts[0], 10);
+        const newVersionMonth = parseInt(newVersionParts[1], 10);
+        const newVersionDay = parseInt(newVersionParts[2], 10);
+        const newVersionPatch = parseInt(newVersionParts[3] || '0', 10);
+        if (
+          newVersionYear < currentVersionYear ||
+          (newVersionYear === currentVersionYear && newVersionMonth < currentVersionMonth) ||
+          (newVersionYear === currentVersionYear &&
+            newVersionMonth === currentVersionMonth &&
+            newVersionDay < currentVersionDay) ||
+          (newVersionYear === currentVersionYear &&
+            newVersionMonth === currentVersionMonth &&
+            newVersionDay === currentVersionDay &&
+            newVersionPatch <= currentVersionPatch)
+        ) {
+          return;
+        }
+
+        // remove leading zeros from version
+        const cleanedVersion = newVersionParts
+          .map((part) => (part.startsWith('0') ? part.replace(/^0+/, '') : part))
+          .map((part) => part || '0')
+          .join('.');
+
+        // convert notes markdown to html
+        let markdown = await fetch('https://api.github.com/markdown', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            text: latestRelease.body || 'No release notes available',
+            mode: 'gfm',
+          }),
+        }).then((res) => res.text());
+
+        // make all links in the markdown open in a new tab
+        const linkRegex = /<a([^>]*?)\s+href="([^"]+)"([^>]*)>(.*?)<\/a>/g;
+        markdown = markdown.replace(linkRegex, (match, beforeHref, href, afterHref, text) => {
+          // Remove any existing target or rel attributes
+          let attrs = (beforeHref + afterHref).replace(/\s*(target|rel)=["'][^"']*["']/gi, '').trim();
+          return `<a ${
+            attrs ? attrs : ''
+          } href="${href}" target="_blank" rel="noopener noreferrer">${text}</a>`;
+        });
+
+        const releaseDetails = {
+          tag: tagName,
+          version: cleanedVersion,
+          notes: markdown || 'No release notes available',
+          name: latestRelease.name,
+          html_url: latestRelease.html_url,
+        };
+
+        update.value.details = releaseDetails;
+      })
+      .catch((error) => {
+        console.error('Error fetching update details:', error);
+        update.value.details = null;
+      })
+      .finally(() => {
+        update.value.loading = false;
+      });
+  }
+}
+
+export function useUpdateDetails() {
+  return {
+    updateDetails: update,
+    populateUpdateDetails,
+  };
+}


### PR DESCRIPTION
This PR adds the version numbers and an update checker to the settings page. The update checker only runs for accounts in the local administrators group. See below for what it looks like:

![image](https://github.com/user-attachments/assets/9187e139-b31c-44ac-891c-914f447dd5b1)

The details button shows a dialog with the release ntoes from GitHub:

![image](https://github.com/user-attachments/assets/63658761-3719-4e96-a642-1d1b30e73478)

Tested on:

- [x] Windows - chromium
- [x] Windows - gecko
- [x] Android - chromium
- [x] iPadOS - webkit
- [x] macOS - webkit