### PR TITLE
Add an option to hide ports from terminal server names in the RAWeb frontend when the hostname does not have more than

### DIFF
--- a/aspx/wwwroot/lib/controls/AppRoot.ascx
+++ b/aspx/wwwroot/lib/controls/AppRoot.ascx
@@ -264,6 +264,7 @@
         combineTerminalServersModeEnabled: '<%= System.Configuration.ConfigurationManager.AppSettings["App.CombineTerminalServersModeEnabled"] %>',
         favoritesEnabled: '<%= System.Configuration.ConfigurationManager.AppSettings["App.FavoritesEnabled"] %>',
         flatModeEnabled: '<%= System.Configuration.ConfigurationManager.AppSettings["App.FlatModeEnabled"] %>',
+        hidePortsEnabled: '<%= System.Configuration.ConfigurationManager.AppSettings["App.HidePortsEnabled"] %>',
         iconBackgroundsEnabled: '<%= System.Configuration.ConfigurationManager.AppSettings["App.IconBackgroundsEnabled"] %>',
         simpleModeEnabled: '<%= System.Configuration.ConfigurationManager.AppSettings["App.SimpleModeEnabled"] %>',
     }

--- a/frontend/lib/pages/Policies.vue
+++ b/frontend/lib/pages/Policies.vue
@@ -174,6 +174,14 @@
       },
     },
     {
+      key: 'App.HidePortsEnabled',
+      appliesTo: ['Web client'],
+      onApply: async (closeDialog, state: boolean | null) => {
+        await setPolicy('App.HidePortsEnabled', state);
+        closeDialog();
+      },
+    },
+    {
       key: 'App.SimpleModeEnabled',
       appliesTo: ['Web client'],
       onApply: async (closeDialog, state: boolean | null) => {

--- a/frontend/lib/pages/Settings.vue
+++ b/frontend/lib/pages/Settings.vue
@@ -9,6 +9,7 @@
     useFavoriteResources,
     useUpdateDetails,
   } from '$utils';
+  import { hidePortsEnabled } from '$utils/hidePorts';
   import { ref, type UnwrapRef } from 'vue';
 
   const { update } = defineProps<{
@@ -179,6 +180,19 @@
       </TextBlock>
       <ToggleSwitch v-model="simpleModeEnabled" :disabled="policies?.simpleModeEnabled !== ''">
         {{ $t('settings.simpleMode.switch') }}
+      </ToggleSwitch>
+    </div>
+  </section>
+  <section>
+    <div class="section-title-row">
+      <TextBlock variant="subtitle">{{ $t('settings.hidePorts.title') }}</TextBlock>
+    </div>
+    <div class="favorites">
+      <TextBlock>
+        {{ $t('settings.hidePorts.desc') }}
+      </TextBlock>
+      <ToggleSwitch v-model="hidePortsEnabled" :disabled="policies?.hidePortsEnabled !== ''">
+        {{ $t('settings.hidePorts.switch') }}
       </ToggleSwitch>
     </div>
   </section>

--- a/frontend/lib/public/locales/en.json
+++ b/frontend/lib/public/locales/en.json
@@ -73,6 +73,11 @@
       "desc2": "The flatten folders option is supported. All other pages and features will be disabled.",
       "switch": "Enable simple mode"
     },
+    "hidePorts": {
+      "title": "Hide ports from terminal server names",
+      "desc": "Hide the terminal server's port from the list of apps and desktops when only one port is used for a hostname",
+      "switch": "Hide ports when possible"
+    },
     "workspaceUrl": {
       "title": "Workspace URL",
       "copy": "Copy workspace URL"
@@ -130,6 +135,10 @@
     "App.SimpleModeEnabled": {
       "title": "Only show a combined list of apps and desktops",
       "help": "Controls the availability of the simple mode feature in RAWeb. \n\nIf enabled, a compact, combined, single-page list of apps and desktops will be shown instead of separate tabs for desktops and apps. \n\nIf disabled, the full RAWeb interface will be available. \n\nIf not configured, each user will be able to control this setting. \n\nThis setting only has an effect when "
+    },
+    "App.HidePortsEnabled": {
+      "title": "Hide ports from terminal server names",
+      "help": "Controls whether the terminal server's port will be hidden from the list of apps and desktops when only one port is used for a hostname. \n\nIf enabled, the port will be hidden from the terminal server name in the list of apps and desktops. \n\nIf disabled, the port will be shown in the terminal server name. \n\nIf not configured, each user will be able to control this setting."
     },
     "RegistryApps.Enabled": {
       "title": "Show RemoteApps listed in the registry",

--- a/frontend/lib/types.d.ts
+++ b/frontend/lib/types.d.ts
@@ -24,6 +24,7 @@ declare global {
       combineTerminalServersModeEnabled: string;
       favoritesEnabled: string;
       flatModeEnabled: string;
+      hidePortsEnabled: string;
       iconBackgroundsEnabled: string;
       simpleModeEnabled: string;
     };

--- a/frontend/lib/utils/hidePorts.ts
+++ b/frontend/lib/utils/hidePorts.ts
@@ -1,0 +1,34 @@
+import { computed, ref } from 'vue';
+
+const hidePortsEnabledKey = `${window.__namespace}::hide-ports:enabled`;
+
+const boolTrigger = ref(0);
+function boolRefresh() {
+  boolTrigger.value++;
+}
+
+const hidePortsEnabled = computed({
+  get: () => {
+    // apply the policy from Web.config if it exists
+    if (window.__policies?.hidePortsEnabled) {
+      return window.__policies.hidePortsEnabled === 'true';
+    }
+
+    // otherwise, use localStorage
+    boolTrigger.value;
+    const storageValue = localStorage.getItem(hidePortsEnabledKey);
+    return storageValue === 'true'; // default to false if not set
+  },
+  set: (newValue) => {
+    localStorage.setItem(hidePortsEnabledKey, String(newValue));
+    boolRefresh();
+  },
+});
+
+window.addEventListener('storage', (event) => {
+  if (event.key === hidePortsEnabledKey) {
+    boolRefresh();
+  }
+});
+
+export { hidePortsEnabled };

--- a/frontend/lib/utils/useWebfeedData.ts
+++ b/frontend/lib/utils/useWebfeedData.ts
@@ -42,10 +42,10 @@ window.addEventListener('storage', (event) => {
 const loading = ref(false);
 const error = ref<unknown>();
 
-async function getData(base?: string, { mergeTerminalServers = true } = {}) {
+async function getData(base?: string, { mergeTerminalServers = true, hidePortsWhenPossible = false } = {}) {
   loading.value = true;
 
-  return getAppsAndDevices(base, { mergeTerminalServers, redirect: true })
+  return getAppsAndDevices(base, { mergeTerminalServers, redirect: true, hidePortsWhenPossible })
     .then((result) => {
       data.value = result;
       error.value = null;
@@ -63,14 +63,21 @@ const hasRunAtLeastOnce = ref(false);
 
 interface UseWebfeedDataOptions {
   mergeTerminalServers?: WritableComputedRef<boolean>;
+  hidePortsWhenPossible?: WritableComputedRef<boolean>;
 }
 
-export function useWebfeedData(base?: string, { mergeTerminalServers }: UseWebfeedDataOptions = {}) {
+export function useWebfeedData(
+  base?: string,
+  { mergeTerminalServers, hidePortsWhenPossible }: UseWebfeedDataOptions = {}
+) {
   // whenever this function is first called,
   // update the data, even if it is cached
   // in localStorage
   if (!hasRunAtLeastOnce.value) {
-    getData(base, { mergeTerminalServers: mergeTerminalServers?.value });
+    getData(base, {
+      mergeTerminalServers: mergeTerminalServers?.value,
+      hidePortsWhenPossible: hidePortsWhenPossible?.value,
+    });
     hasRunAtLeastOnce.value = true;
   }
 
@@ -78,8 +85,11 @@ export function useWebfeedData(base?: string, { mergeTerminalServers }: UseWebfe
     data,
     loading,
     error,
-    refresh: async ({ mergeTerminalServers }: UseWebfeedDataOptions = {}) => {
-      await getData(base, { mergeTerminalServers: mergeTerminalServers?.value });
+    refresh: async ({ mergeTerminalServers, hidePortsWhenPossible }: UseWebfeedDataOptions = {}) => {
+      await getData(base, {
+        mergeTerminalServers: mergeTerminalServers?.value,
+        hidePortsWhenPossible: hidePortsWhenPossible?.value,
+      });
       return { data, loading, error };
     },
   };


### PR DESCRIPTION
This change adds an option to hide ports from terminal server names on the RAWeb frontend. Ports are only removed if the server name without the port exists only once (e.g., the port will not be removed if testbox:21425 and testbox:21426 are both in the list of terminal servers). This change only affects the RAWeb frontend; it does not affect the webfeed or RDP files. This option is disabled by default, but it can be enabled in settings or policy.

resolves #73