### PR TITLE
Filter the webfeed to a single terminal server by specifying the terminalServer query parameter

### DIFF
--- a/aspx/wwwroot/webfeed.aspx.cs
+++ b/aspx/wwwroot/webfeed.aspx.cs
@@ -39,7 +39,7 @@ public partial class GetWorkspace : System.Web.UI.Page
             ProcessMultiuserResources(multiuserResourcesFolder);
 
             HttpContext.Current.Response.ContentType = (schemaVersion >= 2.0 ? "application/x-msts-radc+xml; charset=utf-8" : "text/xml; charset=utf-8");
-            string serverName = System.Net.Dns.GetHostName();
+            string serverName = searchParams["terminalServer"] ?? System.Net.Dns.GetHostName();
             string serverFQDN = HttpContext.Current.Request.Url.Host;
             string datetime = DateTime.Now.Year.ToString() + "-" + (DateTime.Now.Month + 100).ToString().Substring(1, 2) + "-" + (DateTime.Now.Day + 100).ToString().Substring(1, 2) + "T" + (DateTime.Now.Hour + 100).ToString().Substring(1, 2) + ":" + (DateTime.Now.Minute + 100).ToString().Substring(1, 2) + ":" + (DateTime.Now.Second + 100).ToString().Substring(1, 2) + ".0Z";
 
@@ -507,6 +507,13 @@ public partial class GetWorkspace : System.Web.UI.Page
 
     private void ProcessResource(Resource resource)
     {
+        // if the terminal server is specified in the search parameters,
+        // skip resources that do not match the terminal server
+        if (!string.IsNullOrEmpty(searchParams["terminalServer"]) && resource.FullAddress != searchParams["terminalServer"])
+        {
+            return;
+        }
+
         string resourceTimestamp = resource.LastUpdated.ToString("yyyy-MM-ddTHH:mm:ssZ");
 
         // add the timestamp to the terminal server timestamps if it is the latest one


### PR DESCRIPTION
RAWeb supports multiple terminal servers in a single webfeed, but in some cases, you may only want RDP files from one of those devices.

By specifying `?terminalServer=<terminal server name>` at the end of the URL to the webfeed, you can filter the webfeed to a single terminal server. The name of the webfeed will be changed to match the terminal server name.

This can also be used to specify separate credentials per terminal server in the remote desktop client apps.

Note that this is usable in Windows RemoteApp and Desktop Connection, but Windows RADC requires each webfeed to have a unique full-qualified domain name (FQDN). To use, you must expose RAWeb via multiple different domains or subdomains and use a different FQDN for each connection with a different terminalServer query parameter. For example, use https://raweb1.example.com/raweb/webfeed.aspx?terminalServer=testbox and https://raweb2.example.com/raweb/webfeed.aspx?terminalServer=personal-pc.