### PR TITLE
fix: use POST instead of GET when validating credentials

### DIFF
--- a/frontend/lib/Login.vue
+++ b/frontend/lib/Login.vue
@@ -166,13 +166,16 @@
     }
 
     // verify that the username and password are correct
-    const response = await fetch(
-      window.__iisBase +
-        'auth.asmx/ValidateCredentials?username=' +
-        encodeURIComponent(usernameValue.value) +
-        '&password=' +
-        encodeURIComponent(password)
-    )
+    const response = await fetch(window.__iisBase + 'auth.asmx/ValidateCredentials', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: new URLSearchParams({
+        username: usernameValue.value,
+        password: password,
+      }),
+    })
       .then(parseXmlResponse)
       .then((xmlDoc) => JSON.parse(xmlDoc.textContent || '{ success: false }') as CredentialsResponse)
       .catch(() => ({ success: false } as InvalidCredentialsResponse));


### PR DESCRIPTION
This change switches the credential validation request from GET to POST. When it was a GET request, the cerednetials were encoded in the URL. This ensures that credentials are not exposed in the IIS logs, which would include the credentials from the URL.

Tested with:

- [x] local credentials
- [x] domain credentials

Test release: https://github.com/jackbuehner/raweb/releases/tag/v2025.07.10.0

Resolves #89 