### PR TITLE
Add support for utf-16 and utf-32 encoded RDP files

### DIFF
--- a/frontend/lib/components/ItemCard/GenericResourceCardMenuButton.vue
+++ b/frontend/lib/components/ItemCard/GenericResourceCardMenuButton.vue
@@ -150,7 +150,9 @@
         getRdpFileContents = gfc;
 
         const foundHost = resource.hosts.find((host) => host.id === selectedTerminalServer);
-        const isSignedRdpFile = foundHost?.rdp?.Signed;
+        const isSignedRdpFile = foundHost?.rdp?.signature;
+
+        // signed RDP files are too long - see https://issues.chromium.org/issues/41322340#comment3
         const allowedMethods = isSignedRdpFile ? ['rdpFile'] : ['rdpFile', 'rdpProtocolUri'];
 
         openMethodPickerDialog(forceShowMethodPicker, allowedMethods);

--- a/frontend/lib/utils/index.mjs
+++ b/frontend/lib/utils/index.mjs
@@ -5,6 +5,7 @@ import { generateRdpFileContents } from './generateRdpFileContents.ts';
 import { generateRdpUri } from './generateRdpUri.ts';
 import { getAppsAndDevices } from './getAppsAndDevices.ts';
 import { iconBackgroundsEnabled } from './iconBackgrounds.ts';
+import { inferUtfEncoding } from './inferUtfEncoding.ts';
 import { parseXmlResponse } from './parseXmlResponse.ts';
 import { PreventableEvent } from './PreventableEvent.ts';
 import { registerServiceWorker } from './registerServiceWorker.ts';
@@ -28,6 +29,7 @@ export {
   generateRdpUri,
   getAppsAndDevices,
   iconBackgroundsEnabled,
+  inferUtfEncoding,
   parseXmlResponse,
   PreventableEvent,
   unproxify as raw,

--- a/frontend/lib/utils/inferUtfEncoding.ts
+++ b/frontend/lib/utils/inferUtfEncoding.ts
@@ -1,0 +1,31 @@
+/**
+ * Looks at the byte-order mark (BOM) of a given ArrayBuffer to infer the UTF encoding.
+ *
+ * This function supports detecting UTF-8, UTF-16, and UTF-32 encodings. A buffer
+ * with no recognized BOM is assumed to be UTF-8.
+ */
+export function inferUtfEncoding(
+  buffer: Uint8Array
+): 'utf-8' | 'utf-16le' | 'utf-16be' | 'utf-32le' | 'utf-32be' {
+  if (buffer[0] == 0xef && buffer[1] == 0xbb && buffer[2] == 0xbf) {
+    return 'utf-8';
+  }
+
+  if (buffer[0] == 0xff && buffer[1] == 0xfe && buffer[2] == 0x00 && buffer[3] == 0x00) {
+    return 'utf-32le';
+  }
+
+  if (buffer[0] == 0x00 && buffer[1] == 0x00 && buffer[2] == 0xfe && buffer[3] == 0xff) {
+    return 'utf-32be';
+  }
+
+  if (buffer[0] == 0xff && buffer[1] == 0xfe) {
+    return 'utf-16le';
+  }
+
+  if (buffer[0] == 0xfe && buffer[1] == 0xff) {
+    return 'utf-16be';
+  }
+
+  return 'utf-8'; // default to utf-8 if no known BOM is found
+}


### PR DESCRIPTION
This commit adds proper support for reading RDP files with the following encodings: UTF-8, UTF-16LE, UTF-16BE, UTF-32LE, and UTF-32BE.

Resolves #79