### PR TITLE
When signing out, only attempt to clear service worker cache when `caches` exists in `window`

### DIFF
--- a/frontend/lib/Logoff.vue
+++ b/frontend/lib/Logoff.vue
@@ -13,11 +13,14 @@
       });
 
     // clear service worker cache
-    await caches.keys().then((cacheNames) => {
-      cacheNames.forEach((cacheName) => {
-        caches.delete(cacheName);
-      });
-    });
+    if ('caches' in window) {
+      const cacheNames = await caches.keys();
+      await Promise.all(
+        cacheNames.map((cacheName) => {
+          return caches.delete(cacheName);
+        })
+      );
+    }
 
     const redirectHref = window.__iisBase + 'login.aspx';
     const returnUrl = new URLSearchParams(window.location.search).get('ReturnUrl');


### PR DESCRIPTION
When using http instead of https, the sign out process fails because caches is only available in secure contexts.

Resolves #99