### PR TITLE
Explicitly specify the default context options on the domain principal context's `ValidateCredentials` method

### DIFF
--- a/aspx/wwwroot/App_Code/AuthUtilities.cs
+++ b/aspx/wwwroot/App_Code/AuthUtilities.cs
@@ -449,7 +449,6 @@ namespace AuthUtilities
                 }
                 catch (Exception ex)
                 {
-                    throw new Exception("An error occurred while validating credentials against the local machine.", ex);
                     return Tuple.Create(false, Resources.WebResources.Login_LocalMachineError, (PrincipalContext)null);
                 }
             }
@@ -457,7 +456,7 @@ namespace AuthUtilities
             try
             {
                 PrincipalContext pc = new PrincipalContext(ContextType.Domain, domain);
-                return Tuple.Create(pc.ValidateCredentials(username, password), (string)null, pc);
+                return Tuple.Create(pc.ValidateCredentials(username, password, ContextOptions.Negotiate | ContextOptions.Signing | ContextOptions.Sealing), (string)null, pc);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Per akarl10's comment in #80, there are some cases where login fails when `ContextOptions.Negotiate | ContextOptions.Signing | ContextOptions.Sealing` are not specified even though they are the default options.

I have tested this on a devices that are domain-joined and not domain-joined. This should only impact domain-joined devices because the impacted code is only reachable when attempting to validate credentials with a domain principal context.

Resolves #92.