### PR TITLE
Fix: Errors when running from pwsh.exe (Issue #114) & Removal of harmless error text on clean install

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -140,13 +140,14 @@ jobs:
           New-Item -ItemType Directory -Force -Path \$frontendDirPath | Out-Null
 
           # run setup.ps1
-          Write-Verbose "Running setup.ps1"
+          Write-Verbose "Running setup.ps1 using powershell.exe"
           if (\$AcceptAll) {
               Write-Verbose "Accepting all prompts"
-              Set-ExecutionPolicy Bypass -Scope Process -Force; & ".\setup.ps1" -AcceptAll
+              \$setupCommand = '.\setup.ps1 -AcceptAll'
           } else {
-              Set-ExecutionPolicy Bypass -Scope Process -Force; & ".\setup.ps1"
+              \$setupCommand = '.\setup.ps1'
           }
+          powershell.exe -NoProfile -ExecutionPolicy Bypass -Command \$setupCommand
 
           # clean up
           \$loc = \$pwd

--- a/setup.ps1
+++ b/setup.ps1
@@ -499,6 +499,9 @@ if ($install_copy_raweb) {
         #  - App_Data: where the RAWeb data is stored
         #  - resources: where RAWeb used to read RDP files and icons (now in App_Data\resources)
         #  - multiuser-resources: where RAWeb used to read RDP files and icons and assigned permissions based on folder name (now in App_Data\multiuser-resources)
+        Write-Host "Existing installation identified. Preserving app data resources..."
+        Write-Host
+        $needs_restore = $true
         $appdata = "$inetpub\RAWeb\App_Data"
         $resources = "$inetpub\RAWeb\resources"
         $multiuser_resources = "$inetpub\RAWeb\multiuser-resources"
@@ -560,8 +563,9 @@ $($appSettings.OuterXml)
     Copy-Item -Path "$ScriptPath\$source_dir\*" -Destination "$inetpub\RAWeb" -Recurse -Force | Out-Null
 
     # Restore the app data folders
-    if (Test-Path $tmp_resources_copy) {
-
+    if ($needs_restore) {
+        Write-Host "Restoring app data resources from previous installation..."
+        Write-Host
         if (Test-Path "$tmp_resources_copy\App_Data") {
             robocopy "$tmp_resources_copy\App_Data" "$inetpub\RAWeb\App_Data" /E /COPYALL /DCOPY:T | Out-Null
         }


### PR DESCRIPTION
## Issues Resolved
This pull request addresses two problems:
- When running `install.ps1` from modern PowerShell (Core; `pwsh.exe`), the `setup.ps1` script fails to execute commands from the WebAdministration PowerShell module.
- When testing temporary resources to restore, if no resources were preserved (i.e. a clean installation), harmless error text would be displayed in the console.

---
## Discussion
### Running from pwsh.exe
This is probably an edge case. Most users probably do not default their terminal to use modern PowerShell instead of Windows PowerShell. The suggestion provided by @MrBrianGale in [the issue I opened](https://github.com/kimmknight/raweb/issues/114) was to import the WebAdministration PowerShell module prior to executing the script. 

I took a modified approach wherein I directly modified `setup.ps1` to load the module if it was not already found via `Get-Module`, however that failed with the following:

```powershell
WebAdministration module is not loaded. Attempting to import...
WARNING: Module WebAdministration is loaded in Windows PowerShell using WinPSCompatSession remoting session; please note that all input and output of commands from this module will be deserialized objects. If you want to load this module into PowerShell please use 'Import-Module -SkipEditionCheck' syntax.
Imported WebAdministration module.
Get-WebItemState: Cannot find path 'IIS:\AppPools\raweb' because it does not exist.
Creating the RAWeb application...

MethodInvocationException: C:\Users\raweb\AppData\Local\Temp\af0b6a2514774b0f9e0794df4f5fb71a\setup.ps1:632
Line |
 632 |      $rawebAcl.SetAccessRule($accessRule)
     |      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Exception calling "SetAccessRule" with "1" argument(s): "Some or all identity references could not be
     | translated."
MethodInvocationException: C:\Users\raweb\AppData\Local\Temp\af0b6a2514774b0f9e0794df4f5fb71a\setup.ps1:638
Line |
 638 |      $appDataAcl.SetAccessRule($appDataAccessRule)
     |      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Exception calling "SetAccessRule" with "1" argument(s): "Some or all identity references could not be
     | translated."
MethodInvocationException: C:\Users\raweb\AppData\Local\Temp\af0b6a2514774b0f9e0794df4f5fb71a\setup.ps1:659
Line |
 659 |          $sqliteInteropAcl.SetAccessRule($sqliteInteropAccessRule)
     |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Exception calling "SetAccessRule" with "1" argument(s): "Some or all identity references could not be
     | translated."
Enabling Authentication on RAWeb\auth...

Enabling HTTPS on the Default Web Site...

Creating a self-signed SSL certificate...

Binding the SSL certificate to the Default Web Site...

InvalidOperation: C:\Users\raweb\AppData\Local\Temp\af0b6a2514774b0f9e0794df4f5fb71a\setup.ps1:701
Line |
 701 |      (Get-WebBinding -Name $sitename -Port 443 -Protocol "https").AddS …
     |      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Method invocation failed because
     | [Deserialized.Microsoft.IIs.PowerShell.Framework.ConfigurationElement#bindings#binding] does not contain
     | a method named 'AddSslCertificate'.
RAWeb setup is complete.
```

Upon further digging, I found that the WebAdministration module **is not compatible with PowerShell 7.**
> Although perhaps not ideal, it seems that `IISAdministration` may be good enough as the `WebAdministration` module relies on APIs that are not planned to be supported in .NET (Core) so cannot be supported in PS7. -- SteveL-MSFT

*Source: [WebAdministration Module - IIS Provider does not load in PowerShell 7 (P.4) · Issue #14 · PowerShell/PowerShellModuleCoverage](https://github.com/PowerShell/PowerShellModuleCoverage/issues/14)*

Given the following, it made sense to modify `install.ps1` generated by the GitHub Workflow to directly call `powershell.exe` instead directly invoking the script itself.
- Windows PowerShell is a hard requirement for the WebAdministration PowerShell module
- Windows PowerShell is present by default
- Calling `powershell.exe` for `setup.ps1` will work regardless of the version used to invoke `install.ps1` and provide a seamless execution experience
- `install.ps1` is otherwise fully compatible with modern PowerShell
- The added overhead of a second PowerShell process is minimal
- The existing workflow is otherwise preserved
- **Modifying `setup.ps1` to use the suggested IISAdministration module would require a high-effort, low-value rewrite of the existing codebase**

### Harmless error text from Test-Path cmdlet in setup.ps1
When running a **clean installation** of RAWeb, the following error text is presented in the terminal:

```powershell
Installing IIS and required components...

Copying the RAWeb directory to the inetpub directory...

Test-Path : Cannot bind argument to parameter 'Path' because it is null.
At C:\Users\raweb\AppData\Local\Temp\9505a5be34554b359b89f0df4bcd5be2\setup.ps1:563 char:19
+     if (Test-Path $tmp_resources_copy) {
+                   ~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidData: (:) [Test-Path], ParameterBindingValidationException
    + FullyQualifiedErrorId : ParameterArgumentValidationErrorNullNotAllowed,Microsoft.PowerShell.Commands.Tes
   tPathCommand

Creating the RAWeb application pool...
```

This occurs because the `setup.ps1` script only populates a value to `$tmp_resources_copy` if there are resources from an existing installation that need to be preserved. 

While this error is harmless from a practical perspective, it is nonetheless error text that needs to be parsed and analyzed the user. I considered two approaches to resolve this:

1. Add `-ErrorAction SilentlyContinue` to the `Test-Path` cmdlet
2. Create a variable holding a boolean value of `True` when preservation occurs and check the boolean instead of the path.

Method 1 would have provided a simpler change to the code (not that Method 2 is convoluted by any means), but may also have suppressed other error text in edge cases. I chose Method 2 because as it ultimately seemed cleaner while preserving diagnostic error text for the aforementioned edge cases. I chose `$needs_restore` as the variable name.

Additionally, I added a couple lines of terminal output to show when the preservation/restore was occurring.

```
Existing installation identified. Preserving app data resources...

Restoring app data resources from previous installation...
```

---
## Testing methodology used
I tested these changes by using a fresh Hyper-V virtual machine installed with a fully-updated installation of Windows 11 Pro 24H2. After installing Windows, I installed PowerShell 7.5.2 and Visual Studio Code via WinGet. There were no other deviations from the default state of Windows.

```powershell
winget install Microsoft.Powershell Microsoft.VisualStudioCode
```

Prior to executing any scripts, I took a snapshot of the VM. I performed the following tests:

#### Windows PowerShell 5.1 Clean Install & Upgrade
- Install via Windows PowerShell 5.1 (Clean installation)
- Install via Windows PowerShell 5.1 (Over existing installation)

#### PowerShell 7.5.2 Clean Install & Upgrade
- Reverted the VM to the snapshot and installed via PowerShell 7.5.2 (Clean Installation)
- Installed via PowerShell 7.5.2 (Over existing installation)

#### Mix & Match PowerShell Clean Install & Upgrade (5.1 -> 7.5.2)
- Reverted the VM to the snapshot and installed via Windows PowerShell 5.1 (Clean installation)
- Install via PowerShell 7.5.2 (Over existing installation)

#### Mix & Match PowerShell Clean Install & Upgrade (7.5.2 -> 5.1)
- Reverted the VM to the snapshot and installed via PowerShell 7.5.2 (Clean installation)
- Install via Windows PowerShell 5.1 (Over existing installation)

All tests were preformed using the `Invoke-RestMethod` command line:

```powershell
irm https://github.com/SaltSpectre/raweb_installation_fix/releases/download/v2025.07.29.0/install.ps1 | iex
```

---
## Conclusion
These are relatively minor changes. I've tried to be thurough in explaining my thought process (sorry for the novel). If you have any questions or feedback, I'd be happy to discuss. 

Cheers!
SaltSpectre

