### PR TITLE
Always show the connection method picker when menus are unavailable

### DIFF
--- a/frontend/lib/components/ItemCard/DesktopCard.vue
+++ b/frontend/lib/components/ItemCard/DesktopCard.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
   import { Button, TextBlock } from '$components';
-  import { favoritesEnabled, raw } from '$utils';
+  import { raw } from '$utils';
   import { computed, useTemplateRef } from 'vue';
   import GenericResourceCardMenuButton from './GenericResourceCardMenuButton.vue';
 
@@ -12,12 +12,6 @@
     resource: Resource;
     width?: string;
   }>();
-
-  // TODO: requestClose: remove this logic once all browsers have supported this for some time
-  const canUseDialogs = HTMLDialogElement.prototype.requestClose !== undefined;
-  // TODO [Anchors]: Remove this when all major browsers support CSS Anchor Positioning
-  const supportsAnchorPositions = CSS.supports('position-area', 'center center');
-  const shouldHideMenu = !canUseDialogs || !supportsAnchorPositions || !favoritesEnabled.value;
 
   const terminalServerAliases = window.__terminalServerAliases;
 
@@ -64,7 +58,6 @@
       <div class="buttons">
         <Button variant="accent" @click="connect">{{ $t('resource.menu.connect') }}</Button>
         <GenericResourceCardMenuButton
-          v-if="!shouldHideMenu"
           :resource="resource"
           placement="top"
           hideDefaultConnect

--- a/frontend/lib/components/ItemCard/GenericResourceCardMenuButton.vue
+++ b/frontend/lib/components/ItemCard/GenericResourceCardMenuButton.vue
@@ -86,7 +86,11 @@
           </svg>
         </template>
       </MenuFlyoutItem>
-      <MenuFlyoutItem @click="() => connect('forcePicker')" :indented="!hideDefaultConnect">
+      <MenuFlyoutItem
+        @click="() => connect('forcePicker')"
+        :indented="!hideDefaultConnect"
+        v-if="canUseDialogs"
+      >
         {{ $t('resource.menu.connectWith') }}…
         <template v-slot:icon v-if="hideDefaultConnect">
           <svg width="24" height="24" fill="none" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
@@ -153,7 +157,7 @@
         const isSignedRdpFile = foundHost?.rdp?.signature;
 
         // signed RDP files are too long - see https://issues.chromium.org/issues/41322340#comment3
-        const allowedMethods = isSignedRdpFile ? ['rdpFile'] : ['rdpFile', 'rdpProtocolUri'];
+        const allowedMethods = isSignedRdpFile || !canUseDialogs ? ['rdpFile'] : ['rdpFile', 'rdpProtocolUri'];
 
         openMethodPickerDialog(forceShowMethodPicker, allowedMethods);
       }
@@ -163,6 +167,7 @@
   <MethodPickerDialog
     :resourceTitle="resource.title"
     ref="methodPickerDialog"
+    :allowRememberMethod="supportsAnchorPositions"
     @close="
       ({ selectedMethod }) => {
         if (selectedMethod === 'rdpFile') {

--- a/frontend/lib/components/ItemCard/MethodPickerDialog.vue
+++ b/frontend/lib/components/ItemCard/MethodPickerDialog.vue
@@ -18,6 +18,7 @@
 
   const props = defineProps<{
     resourceTitle: string;
+    allowRememberMethod?: boolean;
   }>();
 
   const emit = defineEmits<{
@@ -182,7 +183,12 @@
     </PickerItem>
 
     <template v-slot:footer>
-      <Button @click="() => submit(true)" @keydown.stop="handleSubmitKeydown">{{ $t('dialog.always') }}</Button>
+      <Button
+        @click="() => submit(true)"
+        @keydown.stop="handleSubmitKeydown"
+        v-if="allowRememberMethod !== false"
+        >{{ $t('dialog.always') }}</Button
+      >
       <Button @click="() => submit(false)" @keydown.stop="handleSubmitKeydown">{{ $t('dialog.once') }}</Button>
     </template>
   </ContentDialog>


### PR DESCRIPTION
This ensures that the connection method can always be selected. When position-area is not supported, the menu with the option to choose a different connection method (connect via...) is unavailable.

**Tested on:**

- [ ] Chrome/Edge
- [ ] Firefox
- [ ] Safari technical preview
- [ ] Safari

**Preview**

https://github.com/user-attachments/assets/4a32ee4f-3fc7-432c-931f-1ab17765c6d6

Resolves #116
Resolves #117 