### PR TITLE
Add an option for administrators to pin one or more notices/announcements at the top of the web app

### DIFF
--- a/aspx/wwwroot/lib/controls/AppRoot.ascx
+++ b/aspx/wwwroot/lib/controls/AppRoot.ascx
@@ -268,6 +268,7 @@
         iconBackgroundsEnabled: '<%= System.Configuration.ConfigurationManager.AppSettings["App.IconBackgroundsEnabled"] %>',
         simpleModeEnabled: '<%= System.Configuration.ConfigurationManager.AppSettings["App.SimpleModeEnabled"] %>',
         passwordChangeEnabled: '<%= System.Configuration.ConfigurationManager.AppSettings["PasswordChange.Enabled"] %>',
+        signedInUserGlobalAlerts: `<%= System.Configuration.ConfigurationManager.AppSettings["App.Alerts.SignedInUser"] %>`,
     }
     window.__machineName = '<%= resolver.Resolve(Environment.MachineName) %>';
     window.__envMachineName = '<%= Environment.MachineName %>';

--- a/frontend/lib/components/ContentDialog/ContentDialog.vue
+++ b/frontend/lib/components/ContentDialog/ContentDialog.vue
@@ -1,20 +1,20 @@
 <script setup lang="ts">
   import TextBlock from '$components/TextBlock/TextBlock.vue';
   import { PreventableEvent } from '$utils';
-  import { ref, useTemplateRef, watch } from 'vue';
+  import { ref, useAttrs, useTemplateRef, watch } from 'vue';
 
   const {
     closeOnEscape = true,
     closeOnBackdropClick = true,
     title,
     size = 'standard',
-    ...restProps
   } = defineProps<{
     closeOnEscape?: boolean;
     closeOnBackdropClick?: boolean;
     title?: string;
     size?: 'min' | 'standard' | 'max';
   }>();
+  const restProps = useAttrs();
 
   const emit = defineEmits<{
     (e: 'beforeClose'): void;
@@ -107,6 +107,8 @@
     },
     { immediate: true }
   );
+
+  console.log(restProps);
 </script>
 
 <template>

--- a/frontend/lib/components/InfoBar/InfoBar.vue
+++ b/frontend/lib/components/InfoBar/InfoBar.vue
@@ -78,7 +78,7 @@
   }
 
   .info-bar.severity-information {
-    background-color: var(--wui-card-secondary-background);
+    background-color: var(--wui-card-background-secondary);
   }
   .info-bar.severity-attention {
     background-color: var(--wui-system-attention-background);

--- a/frontend/lib/pages/Policies.vue
+++ b/frontend/lib/pages/Policies.vue
@@ -123,11 +123,7 @@
           },
         },
       ],
-      onApply: async (
-        closeDialog,
-        state: boolean | null,
-        extraFieldsState?: Record<string, string | [string, string][]>
-      ) => {
+      onApply: async (closeDialog, state, extraFieldsState) => {
         if (!state || !extraFieldsState) {
           await setPolicy('TerminalServerAliases', null);
           closeDialog();
@@ -137,7 +133,14 @@
         if (
           !extraFieldsState.aliases ||
           !Array.isArray(extraFieldsState.aliases) ||
-          extraFieldsState.aliases.length === 0
+          extraFieldsState.aliases.length === 0 ||
+          !extraFieldsState.aliases.every(
+            (pair: unknown): pair is [string, string] =>
+              Array.isArray(pair) &&
+              pair.length === 2 &&
+              typeof pair[0] === 'string' &&
+              typeof pair[1] === 'string'
+          )
         ) {
           await setPolicy('TerminalServerAliases', '');
           closeDialog();
@@ -207,11 +210,7 @@
           type: 'string',
         },
       ],
-      onApply: async (
-        closeDialog,
-        state: boolean | null,
-        extraFieldsState?: Record<string, string | [string, string][]>
-      ) => {
+      onApply: async (closeDialog, state, extraFieldsState) => {
         if (!state || !extraFieldsState) {
           await setPolicy('RegistryApps.FullAddressOverride', null);
           closeDialog();
@@ -239,11 +238,7 @@
           },
         },
       ],
-      onApply: async (
-        closeDialog,
-        state: boolean | null,
-        extraFieldsState?: Record<string, string | [string, string][]>
-      ) => {
+      onApply: async (closeDialog, state, extraFieldsState) => {
         if (!state || !extraFieldsState) {
           await setPolicy('RegistryApps.AdditionalProperties', null);
           closeDialog();
@@ -283,6 +278,52 @@
       onApply: async (closeDialog, state: boolean | null) => {
         await setPolicy('PasswordChange.Enabled', state);
         closeDialog();
+      },
+    },
+    {
+      key: 'App.Alerts.SignedInUser',
+      appliesTo: ['Web client'],
+      extraFields: [
+        {
+          key: 'alerts',
+          label: 'Alerts',
+          type: 'json',
+          multiple: true,
+          interpret: (value: string) => {
+            const json = value ? JSON.parse(value) : null;
+            if (!json || !Array.isArray(json)) {
+              return [];
+            }
+            return json;
+          },
+          jsonFields: {
+            title: 'Title',
+            message: 'Message',
+            linkText: 'Link text',
+            linkHref: 'Link URL',
+          },
+        },
+      ],
+      onApply: async (closeDialog, state, extraFieldsState) => {
+        if (!state || !extraFieldsState) {
+          await setPolicy('App.Alerts.SignedInUser', null);
+          closeDialog();
+          return;
+        }
+
+        if (
+          !extraFieldsState.alerts ||
+          !Array.isArray(extraFieldsState.alerts) ||
+          extraFieldsState.alerts.length === 0
+        ) {
+          await setPolicy('App.Alerts.SignedInUser', '');
+          closeDialog();
+          return;
+        }
+
+        await setPolicy('App.Alerts.SignedInUser', JSON.stringify(extraFieldsState.alerts));
+        closeDialog();
+        return;
       },
     },
   ] satisfies Array<{

--- a/frontend/lib/public/locales/en.json
+++ b/frontend/lib/public/locales/en.json
@@ -164,6 +164,10 @@
     "PasswordChange.Enabled": {
       "title": "Allow users to change their password via RAWeb",
       "help": "Controls whether users can change their password via RAWeb. \n\nThis feature does not work if a user does not have the ability in Active Directory to change their password. It will also not work if the raweb application pool does not have permission to access user principals or directory entries. This feature is only supported for local accounts and accounts in the same domain as the machine with RAWeb installed. \n\nThis feature does not control a user's ability to change their password by pressing Ctrl + Alt + End once connected to a remote session. \n\nIf enabled or not configured, users will be able to change their password via the 'Change a password' page. \n\nIf disabled, the 'Change a password' page will not be available."
+    },
+    "App.Alerts.SignedInUser": {
+      "title": "Configure alerts or announcements at the top of every route for signed-in users",
+      "help": "Configure custom alerts to be displayed at the top of the web client. \n\nIf enabled, alerts will be shown to users if they are sign in. \n\nIf disabled or not configured, no alerts will be shown. \n\nAlerts may contain a title, message, and hyperlink. Multiple alerts may be displayed. The link will appear at the end of the alert message on a new line and will open in a popup window or new tab. The link will not appear unless the text and URL are specified."
     }
   },
   "wiki": {

--- a/frontend/lib/types.d.ts
+++ b/frontend/lib/types.d.ts
@@ -28,6 +28,7 @@ declare global {
       iconBackgroundsEnabled: string;
       simpleModeEnabled: string;
       passwordChangeEnabled: string;
+      signedInUserGlobalAlerts: string;
     };
     /** The machine name (`Environment.MachineName`). If it has an alias, it is used instead. */
     __machineName: string;


### PR DESCRIPTION
This PR resolves #123 [(Feature request: Space for notice or announcement)](https://github.com/kimmknight/raweb/issues/123).

There is now a policy that allows specifying one or more notices/announcements at the top of the web app. Announcements are composed of a title, message, and link button. The annoucements do not appear on the sign in page.

The policy is stored in `App_Data\appSettings.config` as JSON stored in the key `App.Alerts.SignedInUser`. It is recommended that the policy is edited with the policy editor in the web app instead of directly in `appSettings.config`. The en-US policy name in the web app is "Configure alerts or announcements at the top of every route for signed-in users". Notices/announcements cannot be hidden by users.

The component for displaying these announcements is the same as the one used for Security Error 5003.

See the following screenshot for a preview of how the notices appear:

<img width="2158" height="1520" alt="image" src="https://github.com/user-attachments/assets/7bd666a8-deaf-4f7a-a7be-dc2552cb739a" />
