### PR TITLE
feat: check for _msradc DNS TXT record and show an email address as a connection option in the webfeed section of settings if the record exists and matches the current URL

### DIFF
--- a/frontend/lib/pages/Settings.vue
+++ b/frontend/lib/pages/Settings.vue
@@ -51,7 +51,7 @@
       return null;
     }
 
-    return await fetch(`https://cloudflare-dns.com/dns-query?name=_radc.${hostname}&type=TXT`, {
+    return await fetch(`https://cloudflare-dns.com/dns-query?name=_msradc.${hostname}&type=TXT`, {
       headers: {
         Accept: 'application/dns-json',
       },
@@ -68,12 +68,14 @@
           return {
             hostname,
             ...json.Answer[0],
+            data: json.Answer[0].data.slice(1, -1), // remove quotes from TXT record value
           };
         }
         throw new Error('No TXT record found');
       })
       .catch(async () => {
-        // if the request fails, that means the record does not exist
+        // if the request fails, that usually means the record
+        // does not exist, so we try the parent (sub)domain
         return await findRadcTxtRecord(hostname.split('.').slice(1).join('.'));
       });
   }

--- a/frontend/lib/public/locales/en.json
+++ b/frontend/lib/public/locales/en.json
@@ -81,7 +81,8 @@
     },
     "workspaceUrl": {
       "title": "Workspace URL",
-      "copy": "Copy workspace URL"
+      "copy": "Copy workspace URL",
+      "copyEmail": "Copy workspace email"
     },
     "about": {
       "title": "About",


### PR DESCRIPTION
This PR adds support for showing and copying a workspace email on the Settings page.

- Looks up _radc TXT DNS records via Cloudflare DNS.
- If the record matches the current workspace URL, builds an email in the form username@hostname.
- Updates the UI to display the email (when available) and provides a “Copy workspace email” button.
- Updated translations to include the new button label.

This makes it easier for users to quickly find and use their workspace email.

See https://learn.microsoft.com/en-us/windows-server/remote/remote-desktop-services/rds-email-discovery for information about workspace discovery via email address.

### Screenshot/preview

<img width="557" height="190" alt="image" src="https://github.com/user-attachments/assets/5f6ed78e-e1d0-495f-8947-21dab096bde4" />

## Install

Run as an administrator in PowerShell to install this branch:
```
iwr -UseBasicParsing install.raweb.app/preview/jackbuehner/msradc-email | iex
```

## Checklist

Tested cases:

- [x] App on subdmain and _msradc not (e.g. _msradc.example.com TXT record and subdomain.example.com web app)
- [x] App on subdomain and _msradc on same subdomain (e.g. _msradc.subdomain.example.com TXT record and subdomain.example.com web app)
- [x] Found _msradc that does not match the current workspace URL - should not show email
- [x] No connection to DNS over HTTPS service  - should not crash page/app

