### PR TITLE
Support `vite dev` for the web app, which will make it easier to work on the web app

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 tsconfig.tsbuildinfo
+.env

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,7 @@
 {
   "scripts": {
-    "dev": "vite build --watch",
+    "dev": "vite dev",
+    "build:watch": "vite build --watch",
     "build": "vite build"
   },
   "type": "module",


### PR DESCRIPTION
With this change, it is now possible to use the fast reload/HMR features from vite while developing the frontend.

The vite config will now emulate the HTML handling behavior of IIS.

- It determines the RAWeb installation path .
- It sets the `%raweb.servername%` and `%raweb.basetag%` values.
- It serves exact html files when there is an exact match.
- It serves other assets related to the app.
- It serves the equivalent of `index.html` when a 404 error would otherwise occur.
- It proxies requests to the API, webfeed.aspx, or auth/login.aspx from the vite development server to the RAWeb server so that the relative paths in `fetch` still work.

This change does not affect the standard build process used when generating distributable version of RAWeb. The changes detect development mode vs production mode and only apply during development mode.