### PR TITLE
Omit sourcemaps for production builds of the web app

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -268,7 +268,7 @@ export default defineConfig(async ({ mode }) => {
     build: {
       outDir: path.resolve(__dirname, '../aspx/wwwroot'),
       emptyOutDir: false,
-      sourcemap: true,
+      sourcemap: mode === 'development',
       target: 'es2022',
       rollupOptions: {
         input: {


### PR DESCRIPTION
This reduces the assets folder size from 3.57 MB to 2.13 MB. Sourcemaps were already omitted from the served HTML, but they were still included in the assets folder.