### PR TITLE
feat: do not hash 404 page icon/image

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -280,7 +280,13 @@ export default defineConfig(async ({ mode }) => {
         output: {
           entryFileNames: 'lib/assets/[name]-[hash].js',
           chunkFileNames: 'lib/assets/[name]-[hash].js',
-          assetFileNames: 'lib/assets/[name]-[hash].[ext]',
+          assetFileNames: (info: any) => {
+            const skipHashFIles = ['thinking_face_animated.webp'];
+            if (skipHashFIles.includes(info.name)) {
+              return 'lib/assets/[name].[ext]';
+            }
+            return 'lib/assets/[name]-[hash].[ext]';
+          },
           manualChunks: (id: any) => {
             const shared = [
               'node_modules',


### PR DESCRIPTION
This reduces the assets folder size from 2.13 MB to 1.67 MB.

THis image is unlikely to change much, so we do not need to also include a version witha  hashed file name in the generated assets folder. If we do change the icon, we will likely have a different file name for the icon.