### PR TITLE
Retrieve the user's display name during sign in

### DIFF
--- a/aspx/wwwroot/App_Code/api/auth/ValidateCredentials.cs
+++ b/aspx/wwwroot/App_Code/api/auth/ValidateCredentials.cs
@@ -25,16 +25,14 @@ namespace RAWebServer.Api {
         domain = SignOn.GetDomainName();
       }
 
-      // check if the username and password are valid for the domain
-      var result = SignOn.ValidateCredentials(username, password, domain);
-      var credentialsAreValid = result.Item1;
-      var errorMessage = result.Item2;
-
-      if (credentialsAreValid) {
-        return Ok(new { success = true, username = username, domain = domain });
+      try {
+        // check if the username and password are valid for the domain
+        using (var userToken = SignOn.ValidateCredentials(username, password, domain)) {
+          return Ok(new { success = true, username = username, domain = domain });
+        }
       }
-      else {
-        return Ok(new { success = false, error = result.Item2, domain = domain });
+      catch (ValidateCredentialsException ex) {
+        return Ok(new { success = false, error = ex.Message, domain = domain });
       }
     }
   }

--- a/aspx/wwwroot/auth/login.aspx
+++ b/aspx/wwwroot/auth/login.aspx
@@ -1,9 +1,9 @@
 <%@ Page language="C#" %>
-<%@ Import Namespace="AuthUtilities" %>
+<%@ Import Namespace="RAWebServer.Utilities" %>
 
 <script runat="server">
     private void Login() {
-        var authCookieHandler = new AuthUtilities.AuthCookieHandler();
+        var authCookieHandler = new AuthCookieHandler();
         authCookieHandler.SetAuthCookie(Request, Response);
     }
 </script>

--- a/aspx/wwwroot/auth/loginfeed.aspx
+++ b/aspx/wwwroot/auth/loginfeed.aspx
@@ -1,9 +1,9 @@
 <%@ Page language="C#" %>
-<%@ Import Namespace="AuthUtilities" %>
+<%@ Import Namespace="RAWebServer.Utilities" %>
 
 <script runat="server">
     private void Login() {
-        string authTicket = AuthUtilities.AuthCookieHandler.CreateAuthTicket(Request);
+        string authTicket = AuthCookieHandler.CreateAuthTicket(Request);
         HttpContext.Current.Response.ContentType = "application/x-msts-webfeed-login; charset=utf-8";
         HttpContext.Current.Response.Write(authTicket);
     }


### PR DESCRIPTION
This change allows the user cache to reflect the actual display name rather than the username. Since use of the user cache sometimes results in bypassing `GetUserInformationFromPrincipalContext`, we need to set the display name in the cache when the rest of the user information is set.

As part of this PR, `AuthCookieHandler.CreateAuthTicket` was refactored to accept an `HttpRequest`, `IntPtr` representing the user login token, `WindowsIdentity` representing the user, or `UserInformation` representing the user.

- When `CreateAuthTicket` is called with `HttpRequest`, the `request.LogonUserIdentity` is passed to the overload accepting the `WindowsIdentity`.
- When `CreateAuthTicket` is called with `IntPtr`, the pointer is converted to a Windows identity is passed to the overload accepting the `WindowsIdentity`.
- When `CreateAuthTicket` is called with `WindowsIdentity`, is is converted to `UserInformation` and is passed to the overload accepting`UserInfromation`.
- When `CreateAuthTicket` is called with `UserInformation`, the information is stored in the user cache (if enanabled) before generating a forms authentication ticket.