### PR TITLE
feat: disable Dark Reader

### DIFF
--- a/frontend/app.html
+++ b/frontend/app.html
@@ -11,6 +11,7 @@
   <meta name="theme-color" content="hsl(122, 39%, 40%)" />
   <link rel="icon" href="%raweb.base%/lib/assets/icon.svg" type="image/svg+xml" />
   <link rel="manifest" href="%raweb.base%/manifest.webmanifest" />
+  <meta name="darkreader-lock" />
   %raweb.head%
 </head>
 


### PR DESCRIPTION
The entire web app has built-in dark theme support. This meta tag tells Dark Reader to not automatically enable itself. On first load, it sometimes does not detect that the web app has built-in dark theme support, but this meta tag helps.

More info: https://github.com/darkreader/darkreader/blob/main/CONTRIBUTING.md#disabling-dark-reader-on-your-site