### PR TITLE
Include `workspace id:s:` in downloaded RDP files

### DIFF
--- a/aspx/wwwroot/App_Code/utils/RegistryUtilities.cs
+++ b/aspx/wwwroot/App_Code/utils/RegistryUtilities.cs
@@ -169,6 +169,7 @@ namespace RAWebServer.Utilities {
                 rdpBuilder.AppendLine("remoteapplicationmode:i:1");
                 rdpBuilder.AppendLine("remoteapplicationfileextensions:s:" + appFileExtCSV);
                 rdpBuilder.AppendLine("disableremoteappcapscheck:i:1");
+                rdpBuilder.AppendLine("workspace id:s:" + new AliasResolver().Resolve(Environment.MachineName));
 
                 var additionalProperties = System.Configuration.ConfigurationManager.AppSettings["RegistryApps.AdditionalProperties"] ?? "";
 

--- a/frontend/lib/components/ItemCard/TerminalServerPickerDialog.vue
+++ b/frontend/lib/components/ItemCard/TerminalServerPickerDialog.vue
@@ -88,6 +88,7 @@
         ...host.rdp,
         domain: host.rdp.domain || maybeDomainNetBios,
         username,
+        'workspace id': host.name, // shown by Windows in parenthesis after the app name in the taskbar (instead of "(Remote)")
       });
 
       return rdpFileText;


### PR DESCRIPTION
While reviewing some old issues, I came across a mention of workspace id (https://github.com/kimmknight/raweb/issues/6#issuecomment-834184281). I did some research on it, and it appears to be used to customize the label that appears in parenthesis after the app name in the Windows once the RemoteApp is connected. This is undocumented by Microsoft.

This PR adds `workspace id:s:` and populates its value with the name of the terminal server when downloading an RDP file from the web interface. On the server side, it is always added to registry RDP files, but it can be overriden with the `RegistryApps.AdditionalProperties` policy.

With workspace id:
<img width="395" height="75" alt="image" src="https://github.com/user-attachments/assets/10507a4c-c333-465c-a591-70666c6fa550" />


Without workspace id:
<img width="401" height="74" alt="image" src="https://github.com/user-attachments/assets/3d699961-0f5e-48b6-a4a5-b967343e0b87" />

