### PR TITLE
For registry RemoteApps, use the last modified timestamp from the registry key instead of using the current date and time

### DIFF
--- a/aspx/wwwroot/App_Code/utils/RegistryUtilities.cs
+++ b/aspx/wwwroot/App_Code/utils/RegistryUtilities.cs
@@ -191,6 +191,58 @@ namespace RAWebServer.Utilities {
             }
         }
 
+        [DllImport("advapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        private static extern int RegQueryInfoKey(
+            IntPtr hKey,
+            IntPtr lpClass,
+            IntPtr lpcchClass,
+            IntPtr lpReserved,
+            out int lpcSubKeys,
+            out int lpcbMaxSubKeyLen,
+            out int lpcbMaxClassLen,
+            out int lpcValues,
+            out int lpcbMaxValueNameLen,
+            out int lpcbMaxValueLen,
+            out int lpcbSecurityDescriptor,
+            out long lpftLastWriteTime // FILETIME; convert with `DateTime.FromFileTime(lpftLastWriteTime)`
+        );
+
+        /// <summary>
+        /// Gets the last modified time of a remote app registry key.
+        /// <br /><br />
+        /// See https://learn.microsoft.com/en-us/windows/win32/api/winreg/nf-winreg-regqueryinfokeya
+        /// </summary>
+        /// <param name="keyName"></param>
+        /// <returns></returns>
+        /// <exception cref="Exception"></exception>
+        public static DateTime GetRemoteAppLastModifiedTime(string keyName) {
+            using (var regKey = OpenRemoteAppRegistryKey(keyName)) {
+                int _;
+                long fileTime;
+
+                var result = RegQueryInfoKey(
+                    regKey.Handle.DangerousGetHandle(),
+                    IntPtr.Zero,
+                    IntPtr.Zero,
+                    IntPtr.Zero,
+                    out _,
+                    out _,
+                    out _,
+                    out _,
+                    out _,
+                    out _,
+                    out _,
+                    out fileTime
+                );
+
+                if (result != 0) {
+                    throw new Exception("Failed to query registry key info. Error code: " + result);
+                }
+
+                return DateTime.FromFileTime(fileTime);
+            }
+        }
+
         [DllImport("shell32.dll", CharSet = CharSet.Auto)]
         public static extern uint ExtractIconEx(string lpszFile, int nIconIndex, [Out] IntPtr[] phiconLarge, [Out] IntPtr[] phiconSmall, [In] uint nIcons);
 

--- a/aspx/wwwroot/App_Code/utils/WorkspaceBuilder.cs
+++ b/aspx/wwwroot/App_Code/utils/WorkspaceBuilder.cs
@@ -280,6 +280,15 @@ namespace RAWebServer.Utilities {
                         // get the generated rdp file
                         var rdpFileContents = RegistryReader.ConstructRdpFileFromRegistry(appName);
 
+                        // get the last time that the registry key was modified
+                        DateTime lastUpdated;
+                        try {
+                            lastUpdated = RegistryReader.GetRemoteAppLastModifiedTime(appName);
+                        }
+                        catch {
+                            lastUpdated = DateTime.MinValue;
+                        }
+
                         // create a resource from the registry entry
                         var resource = new Resource(
                             title: displayName,
@@ -287,7 +296,7 @@ namespace RAWebServer.Utilities {
                             appProgram: appProgram,
                             alias: "registry/" + appName,
                             appFileExtCSV: appFileExtCSV,
-                            lastUpdated: DateTime.UtcNow,
+                            lastUpdated: lastUpdated,
                             virtualFolder: "",
                             origin: "registry",
                             source: appName


### PR DESCRIPTION
With this change, we now use `RegQueryInfoKey` to get the `lpftLastWriteTime` `FILETIME` to read when the registry key for a RemoteApp has last changed. This means that webfeeds/workspaces that include RemoteApps from the registry specify the correct timestamp for the app and the overall `Publisher`.

This change resolves #132.