### PR TITLE
Generate .wcx (RemoteApp and Desktop Connection Configuration File) for Windows clients

### DIFF
--- a/frontend/lib/public/locales/en.json
+++ b/frontend/lib/public/locales/en.json
@@ -82,7 +82,8 @@
     "workspaceUrl": {
       "title": "Workspace URL",
       "copy": "Copy workspace URL",
-      "copyEmail": "Copy workspace email"
+      "copyEmail": "Copy workspace email",
+      "downloadConnectionFile": "Download connection file"
     },
     "about": {
       "title": "About",

--- a/frontend/lib/vite-env.d.ts
+++ b/frontend/lib/vite-env.d.ts
@@ -2,3 +2,4 @@
 
 declare const __APP_INIT_DETAILS_API_PATH__: string;
 declare const __DOCS_EXCLUDED__: boolean;
+declare const __BUILD_DATE__: string;

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -47,6 +47,7 @@ export default defineConfig(async ({ mode }) => {
     define: {
       __APP_INIT_DETAILS_API_PATH__: JSON.stringify(`./api/app-init-details`),
       __DOCS_EXCLUDED__: JSON.stringify(excludeDocs),
+      __BUILD_DATE__: JSON.stringify(new Date().toISOString()),
     },
     plugins: [
       markdown({


### PR DESCRIPTION
This change adds a button to the **Workspace URL** section on the settings page to download the workspace connection file for the current RAWeb installation. Clicking the download button causes the web app to construct the wcx XML with the current workspace URL and name and the triggers a download prompt.

The button only appears on the web app when the browser is on Windows since only Windows RADC can use .wcx files. Other platforms should continue to use the workspace URL or email address.

<img width="432" height="165" alt="image" src="https://github.com/user-attachments/assets/6cc672cc-5cb4-49c7-a12b-28793b67e1fc" />


https://github.com/user-attachments/assets/0df91e54-7cc0-4f1e-b1e7-78c63dd3d8bb

