### PR TITLE
Handle case where no headers are included in workspace request

### DIFF
--- a/aspx/wwwroot/App_Code/api/workspace/GetWorkspace.cs
+++ b/aspx/wwwroot/App_Code/api/workspace/GetWorkspace.cs
@@ -18,9 +18,12 @@ namespace RAWebServer.Api {
       var authCookieHandler = new AuthCookieHandler();
       var userInfo = authCookieHandler.GetUserInformationSafe(HttpContext.Current.Request);
 
+      var authTicket = authCookieHandler.GetAuthTicket(HttpContext.Current.Request);
+
       var schemaVersion = WorkspaceBuilder.SchemaVersion.v1;
-      var acceptHeader = request.Headers["accept"].ToLower();
+      var acceptHeader = request.Headers["accept"];
       if (!string.IsNullOrEmpty(acceptHeader)) {
+        acceptHeader = acceptHeader.ToLowerInvariant();
         if (acceptHeader.Contains("radc_schema_version=2.0")) {
           schemaVersion = WorkspaceBuilder.SchemaVersion.v2;
         }


### PR DESCRIPTION
This resolves errors with using the workspace/webfeed via Thincast's RD WebAccess Client. The client does not include any HTTP headers. Previously, we attempted to convert the `accept` HTTP header to lowercase even when the header was not present.

Closes #159.