### PR TITLE
Generate HTML files for each route

### DIFF
--- a/.github/workflows/public.yaml
+++ b/.github/workflows/public.yaml
@@ -172,13 +172,6 @@ jobs:
           pnpm run build --config vite.config.public.ts
           echo "success=true" >> $GITHUB_OUTPUT
 
-      - name: Create 404.html
-        if: steps.build.outcome == 'success'
-        run: |
-          sed -e "s|__REPO_NAME__|${{ github.event.repository.name }}|g" \
-              -e "s|__REPO_OWNER__|${{ github.event.repository.owner.login }}|g" \
-              .github/workflows/404.html > frontend/dist/404.html
-
       - name: Update status
         if: github.event_name == 'pull_request_target'
         uses: peter-evans/create-or-update-comment@v4
@@ -224,14 +217,12 @@ jobs:
 
           if [ "${TARGET_NAME}" = "master" ]; then
             cp -r frontend/dist/* .
-            cp frontend/dist/404.html 404.html
             git add .
             git commit -m "chore: update production site" || echo "No changes"
           else
             mkdir -p "deploy-preview/${TARGET_NAME}"
             cp -r frontend/dist/* "deploy-preview/${TARGET_NAME}/"
-            cp frontend/dist/404.html 404.html
-            git add deploy-preview/${TARGET_NAME} 404.html
+            git add deploy-preview/${TARGET_NAME}
             git commit -m "chore: update deploy preview for ${TARGET_NAME}" || echo "No changes"
           fi
 

--- a/frontend/lib/i18n.ts
+++ b/frontend/lib/i18n.ts
@@ -6,7 +6,7 @@ import { App } from 'vue';
 export const i18nextPromise = i18next
   .use(
     new Backend(null, {
-      loadPath: './' + 'locales/{{lng}}.json',
+      loadPath: '/locales/{{lng}}.json',
     })
   )
   .init({

--- a/frontend/vite.config.public.ts
+++ b/frontend/vite.config.public.ts
@@ -3,14 +3,18 @@ import { defineConfig, mergeConfig, Plugin, ResolvedConfig } from 'vite';
 import baseConfig from './vite.config.ts';
 
 export default defineConfig(async ({ command, mode }) => {
+  process.env.RAWEB_USE_PRETTY_HTML_PATHS = '1';
+
   const resolvedBaseConfig =
     typeof baseConfig === 'function' ? await baseConfig({ command, mode }) : baseConfig;
 
+  const base = process.env.RAWEB_PUBLIC_BASE || resolvedBaseConfig.base;
+
   return mergeConfig(resolvedBaseConfig, {
     define: {
-      __APP_INIT_DETAILS_API_PATH__: JSON.stringify(`./api/app-init-details.json`),
+      __APP_INIT_DETAILS_API_PATH__: JSON.stringify(`/api/app-init-details.json`),
     },
-    base: process.env.RAWEB_PUBLIC_BASE || resolvedBaseConfig.base,
+    base,
     plugins: [
       (() => {
         let viteConfig: ResolvedConfig;
@@ -27,8 +31,8 @@ export default defineConfig(async ({ command, mode }) => {
           // so that the docs portion of the app can work without a backend
           async generateBundle(_, bundle) {
             const json = JSON.stringify({
-              iisBase: viteConfig.base,
-              appBase: viteConfig.base,
+              iisBase: '/',
+              appBase: '/',
               authUser: {
                 username: 'anonymous',
                 domain: 'RAWEB',


### PR DESCRIPTION
Using `404.html` to redirect to the entrypoints made the single-page app (SPA) routing work, but GitHub still responded with a 404 status code. This meant that search engines would not index any of the documentation pages.

With this change, we no longer need `404.html` for GitHub Pages.

Each route points to the same JavaScript and CSS files as the entrypoint for that router. Once the JavaScript is loaded, the router will take over and ensure that the correct content is displayed. The HTML files do not contain route-speciifc HTML.