### PR TITLE
Do not show hidden managed resources in the workspace/webfeed

### DIFF
--- a/dotnet/RAWeb.Server.Utilities/src/WorkspaceBuilder.cs
+++ b/dotnet/RAWeb.Server.Utilities/src/WorkspaceBuilder.cs
@@ -439,6 +439,10 @@ public class WorkspaceBuilder {
                 continue; // skip if the RDP file string is missing
             }
 
+            if (managedResource.IncludeInWorkspace != true) {
+                continue; // skip if the resource is not configured to be included in the workspace
+            }
+
             var relativeFilePath = managedResource.RootedFilePath.Replace(root + Path.DirectorySeparatorChar, "").Replace("\\", "/");
 
             // ensure that there is a full address in the RDP file


### PR DESCRIPTION
With this change, resources that should not appear in the workspace/webfeed (and the RAWeb web interface) will no longer appear. The managed file resources part of `WorkspaceBuilder.cs` was missing a check for `IncludeInWorkspace`.

Fixes #178.