### PR TITLE
Always use the default wallpaper instead of the default icon for desktops in the resource editor dialog

### DIFF
--- a/frontend/lib/dialogs/ManagedResourceEditDialog.vue
+++ b/frontend/lib/dialogs/ManagedResourceEditDialog.vue
@@ -319,7 +319,7 @@
     // if we want the default icon, get it from the server by passing an empty icon path
     if (useDefault) {
       return `${iisBase}${buildManagedIconPath(
-        { iconPath: '', iconIndex: 0, isRemoteApp: false, isManagedFileResource: false },
+        { iconPath: '', iconIndex: 0, isRemoteApp: isRemoteApp.value, isManagedFileResource: false },
         dataUpdatedAt.value,
         theme
       )}`;
@@ -357,14 +357,14 @@
     return `${iisBase}${buildManagedIconPath(
       isManagedFileResource.value
         ? {
-            identifier: useDefault ? '' : data.value.identifier,
+            identifier: data.value.identifier,
             isRemoteApp: isRemoteApp.value,
             isManagedFileResource: true,
           }
         : {
-            iconPath: useDefault ? '' : formData.value?.iconPath,
+            iconPath: formData.value?.iconPath,
             iconIndex: formData.value.iconIndex,
-            isRemoteApp: !!formData.value.remoteAppProperties,
+            isRemoteApp: isRemoteApp.value,
             isManagedFileResource: false,
           },
       dataUpdatedAt.value,

--- a/frontend/lib/utils/buildManagedIconPath.ts
+++ b/frontend/lib/utils/buildManagedIconPath.ts
@@ -27,15 +27,14 @@ export function buildManagedIconPath(
   }
 
   let fallbackIconPath = '';
-  if (data.isManagedFileResource) {
-    if (data.isRemoteApp) {
-      fallbackIconPath = '../lib/assets/remoteicon.png';
+  if (data.isManagedFileResource && data.isRemoteApp) {
+    fallbackIconPath = '../lib/assets/remoteicon.png';
+  }
+  if (!data.isRemoteApp) {
+    if (theme === 'light') {
+      fallbackIconPath = '../lib/assets/wallpaper.png';
     } else {
-      if (theme === 'light') {
-        fallbackIconPath = '../lib/assets/wallpaper.png';
-      } else {
-        fallbackIconPath = '../lib/assets/wallpaper-dark.png';
-      }
+      fallbackIconPath = '../lib/assets/wallpaper-dark.png';
     }
   }
 


### PR DESCRIPTION
With this change, managed file resources that represent desktops will always show the desktop wallpaper as their default image.

The check for whether the resource indicated a desktop resource vs a RemoteApp resource was not reactive, so if the data was not available as soon as the edit dialog was created, it would use the default case (RemoteApp).

Fixes #179.