### PR TITLE
Always allow the RDP file editor for `.resource` files

### DIFF
--- a/frontend/lib/dialogs/ManagedResourceCreateDialog.vue
+++ b/frontend/lib/dialogs/ManagedResourceCreateDialog.vue
@@ -735,7 +735,7 @@
             <TextBlock>{{ t('registryApps.properties.key') }}</TextBlock>
             <TextBox v-model:value="formData.identifier"></TextBox>
           </Field>
-          <Field no-label-focus v-if="capabilities.supportsCentralizedPublishing">
+          <Field no-label-focus v-if="isManagedFileResource || capabilities.supportsCentralizedPublishing">
             <TextBlock block>{{ t('registryApps.properties.customizeRdpFile') }}</TextBlock>
             <div>
               <RdpFilePropertiesDialog

--- a/frontend/lib/dialogs/ManagedResourceEditDialog.vue
+++ b/frontend/lib/dialogs/ManagedResourceEditDialog.vue
@@ -773,7 +773,7 @@
             <TextBlock>{{ t('registryApps.properties.key') }}</TextBlock>
             <TextBox v-model:value="formData.identifier"></TextBox>
           </Field>
-          <Field no-label-focus v-if="capabilities.supportsCentralizedPublishing">
+          <Field no-label-focus v-if="isManagedFileResource || capabilities.supportsCentralizedPublishing">
             <TextBlock block>{{ t('registryApps.properties.customizeRdpFile') }}</TextBlock>
             <div>
               <RdpFilePropertiesDialog


### PR DESCRIPTION
Resource files can always have their RDP file be changed. RemoteApps and Desktops stored in the registry require centralized publishing to be enabled because copies of the RDP file string are not stored when only the TSAllowList is in use.

This change makes an adjustment to the create and edit dialogs so that the edit button is also shown if the resource is a managed file resource (`.resource` file).

Fixes #175.