### PR TITLE
Transparently redirect icon paths that point to old versions of a packaged app to the current version

### DIFF
--- a/dotnet/RAWeb.Server.Management.ServiceHost/ManagementService.cs
+++ b/dotnet/RAWeb.Server.Management.ServiceHost/ManagementService.cs
@@ -131,6 +131,12 @@ public class SystemRemoteAppsServiceHost : IManagedResourceService {
     app.DeleteFromRegistry();
   }
 
+  public void RestorePackagedAppIconPaths() {
+    RequireAuthorization();
+
+    new SystemRemoteApps().GetAllRegisteredApps(restorePackagedAppIconPaths: true);
+  }
+
   public InstalledApps ListInstalledApps(string? userSid) {
     RequireAuthorization();
 

--- a/dotnet/RAWeb.Server.Management/src/InstalledApps.cs
+++ b/dotnet/RAWeb.Server.Management/src/InstalledApps.cs
@@ -15,7 +15,7 @@ namespace RAWeb.Server.Management;
 /// Represents information about an installed application on the system.
 /// </summary>
 [DataContract]
-public class InstalledApp(string path, string displayName, string displayFolder, string iconPath, int iconIndex = 0, string commandLineArguments = "", FileTypeAssociationCollection? fileTypeAssociations = null) {
+public class InstalledApp(string path, string displayName, string displayFolder, string iconPath, int iconIndex = 0, string commandLineArguments = "", FileTypeAssociationCollection? fileTypeAssociations = null, string? packageDir = null) {
   [DataMember] public string Path { get; set; } = path;
   [DataMember] public string DisplayName { get; set; } = displayName;
   [DataMember] public string DisplayFolder { get; set; } = displayFolder;
@@ -23,6 +23,10 @@ public class InstalledApp(string path, string displayName, string displayFolder,
   [DataMember] public int IconIndex { get; set; } = iconIndex;
   [DataMember] public string CommandLineArguments { get; set; } = commandLineArguments ?? "";
   [DataMember] public FileTypeAssociationCollection fileTypeAssociations { get; set; } = fileTypeAssociations ?? [];
+  /// <summary>
+  /// The directory of the AppX/MSIX package containing this application, if applicable.
+  /// </summary>
+  [DataMember] public string? PacakgeDirectory { get; set; } = packageDir;
 
   /// <summary>
   /// Translates a shortcut file (.lnk) into an InstalledApp object.
@@ -787,7 +791,8 @@ public class InstalledApps : System.Collections.ObjectModel.Collection<Installed
           iconPath: iconPath ?? "",
           iconIndex: 0,
           commandLineArguments: applicationLaunchUri,
-          fileTypeAssociations: fileTypeAssociations
+          fileTypeAssociations: fileTypeAssociations,
+          packageDir: packageDir
         );
         installedApps.Add(installedApp);
       }

--- a/dotnet/RAWeb.Server.Management/src/ManagedResources/ManagedResources.cs
+++ b/dotnet/RAWeb.Server.Management/src/ManagedResources/ManagedResources.cs
@@ -48,6 +48,13 @@ public interface IManagedResourceService {
   void DeleteRemoteAppFromRegistry(SystemRemoteApps.SystemRemoteApp app);
 
   /// <summary>
+  /// Service implementation of <c>SystemRemoteApps.GetAllRegisteredApps</c>
+  /// with restorePackagedAppIconPaths set to true.
+  /// </summary>
+  [OperationContract]
+  void RestorePackagedAppIconPaths();
+
+  /// <summary>
   /// Service implementation of <c>InstalledApps.FromStartMenu</c> and <c>InstalledApps.FromAppPackages</c>.
   /// </summary>
   [OperationContract]
@@ -286,12 +293,12 @@ public class ManagedResources : Collection<ManagedResource> {
   /// <param name="collectionName"></param>
   /// <param name="resourceFilesDirectory"></param>
   /// <returns></returns>
-  public ManagedResources Populate(string? collectionName, string? resourceFilesDirectory = null) {
+  public ManagedResources Populate(string? collectionName, string? resourceFilesDirectory = null, bool? restorePackagedAppIconPaths = false) {
     Clear();
 
     // load all registry RemoteApps for the specified collection
     var remoteAppsUtil = new SystemRemoteApps(collectionName);
-    var systemRemoteApps = remoteAppsUtil.GetAllRegisteredApps();
+    var systemRemoteApps = remoteAppsUtil.GetAllRegisteredApps(restorePackagedAppIconPaths);
     foreach (var app in systemRemoteApps) {
       Add(app);
     }

--- a/dotnet/RAWeb.Server.Utilities/src/RegistryUtilities.cs
+++ b/dotnet/RAWeb.Server.Utilities/src/RegistryUtilities.cs
@@ -74,8 +74,6 @@ public class RegistryReader {
             if (!accessAllowed) {
                 httpStatus = 403;
             }
-            Console.WriteLine("\nkey name: " + string.Join(", ", securityDescriptor
-                .GetAllowedSids(FileSystemRights.ReadData)));
             return accessAllowed;
 
         }

--- a/dotnet/RAWeb.Server.Utilities/src/WorkspaceBuilder.cs
+++ b/dotnet/RAWeb.Server.Utilities/src/WorkspaceBuilder.cs
@@ -247,9 +247,20 @@ public class WorkspaceBuilder {
         // get the registered registry-managed resources
         SystemRemoteApps.SystemRemoteAppCollection managedResources;
         try {
-            managedResources = remoteApps.GetAllRegisteredApps();
+            managedResources = remoteApps.GetAllRegisteredApps(restorePackagedAppIconPaths: true);
         }
-        catch {
+        catch (UnauthorizedAccessException) {
+            if (_managedResourceService is null) {
+                throw;
+            }
+
+            // UnauthorizedAccessException means that either the registry paths are missing or an icon path needs to be restored
+            _managedResourceService.InitializeRegistryPaths(supportsCentralizedPublishing ? centralizedPublishingCollectionName : null);
+            _managedResourceService.InitializeDesktopRegistryPaths(supportsCentralizedPublishing ? centralizedPublishingCollectionName : null);
+            _managedResourceService.RestorePackagedAppIconPaths();
+            managedResources = remoteApps.GetAllRegisteredApps(restorePackagedAppIconPaths: false);
+        }
+        catch (Exception) {
             managedResources = [];
         }
 

--- a/dotnet/RAWebServer/src/api/resource-management/GetRegisteredApps.cs
+++ b/dotnet/RAWebServer/src/api/resource-management/GetRegisteredApps.cs
@@ -34,20 +34,21 @@ namespace RAWebServer.Api {
       var resources = new ManagedResources();
 
       try {
-        resources.Populate(collectionName, Constants.ManagedResourcesFolderPath);
-        return resources;
+        resources.Populate(collectionName, Constants.ManagedResourcesFolderPath, restorePackagedAppIconPaths: true);
       }
       catch (UnauthorizedAccessException) {
         try {
           SystemRemoteAppsClient.Proxy.InitializeRegistryPaths(collectionName);
           SystemRemoteAppsClient.Proxy.InitializeDesktopRegistryPaths(collectionName);
+          SystemRemoteAppsClient.Proxy.RestorePackagedAppIconPaths();
           resources.Populate(collectionName, Constants.ManagedResourcesFolderPath);
-          return resources;
         }
         catch (EndpointNotFoundException) {
           throw new Exception("The RAWeb Management Service is not running.");
         }
       }
+
+      return resources;
     }
   }
 }


### PR DESCRIPTION
This PR ensures that the icon paths for packaged apps are updated whenever RAWeb detects that the exisitng path is missing. This usually occurs when a package has been updated, resulting the the folder name for the package using a different version number.

For example:
* A few months ago, a RemoteApp was added to RAWeb that points to a packaged app. The icon path was automatically populated with the default icon for the packaged app: `C:\Program Files\WindowsApps\Microsoft.4297127D64EC6_2.2.2.0_x64__8wekyb3d8bbwe\SmallLogo.scale-400.png`
* Today, the packaged app received an update to a new version, causing the folder with the packaged app to change to the new version number. The icon is now stored at `C:\Program Files\WindowsApps\Microsoft.4297127D64EC6_2.3.0.0_x64__8wekyb3d8bbwe\SmallLogo.scale-400.png`, but RAWeb still looks at the old path because the old path is version stored in the registry.

Resolves #182.