### PR TITLE
feat: skip reading `.pri` files that cannot be read by `PriFormat.dll`

### DIFF
--- a/dotnet/RAWeb.Server.Management/src/InstalledApps.cs
+++ b/dotnet/RAWeb.Server.Management/src/InstalledApps.cs
@@ -696,7 +696,7 @@ public class InstalledApps : System.Collections.ObjectModel.Collection<Installed
               }
             }
             catch (Exception ex) {
-              throw new Exception($"Failed to read PRI file at path: {appPriPath}", ex);
+              // throw new Exception($"Failed to read PRI file at path: {appPriPath}", ex);
             }
           }
 


### PR DESCRIPTION
In the case of PRI files that are invalid or not supported by [`PriFormat`](https://github.com/chausner/PriTools/tree/master/PriFormat), instead of throwing an exception, we now ignore the error. This ensures that the app discovery process does not completely break whenever a PRI file cannot be read.

This fix is confirmed in #189.

Resolves #189.