### PR TITLE
Remove drop shadows and accent background color from web app splash screen

### DIFF
--- a/frontend/app.html
+++ b/frontend/app.html
@@ -51,12 +51,12 @@
         }
 
         .root-splash-wrapper {
-          background: var(--wui-accent-text-secondary, #ffffff);
+          background: var(--wui-solid-background-base, hsl(0, 0%, 95%));
         }
 
         @media (prefers-color-scheme: dark) {
           .root-splash-wrapper {
-            background: #242424;
+            background: var(--wui-solid-background-base, hsl(0, 0%, 13%));
           }
         }
 
@@ -107,21 +107,18 @@
         .root-splash-app-name {
           height: 40px;
           margin: 8px;
-          color: rgb(250, 249, 248);
-          filter: drop-shadow(rgb(210 208 206 / 60%) 0px 0px 8px) drop-shadow(rgb(11 4 36 / 60%) 0px 0px 4px);
+          color: var(--wui-text-secondary);
         }
 
         .root-splash-app-logo {
-          fill: rgb(250, 249, 248);
           height: 100px;
           width: auto;
-          filter: drop-shadow(rgb(11 4 36 / 60%) 0px 0px 4px);
         }
 
         .root-splash-note {
           font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell,
             'Open Sans', 'Helvetica Neue', sans-serif;
-          color: rgba(250, 249, 248, 0.3);
+          color: var(--wui-text-tertiary);
           display: flex;
           flex-direction: column;
           gap: 10px;
@@ -131,7 +128,7 @@
 
         .root-splash-note circle {
           fill: none;
-          stroke: var(--wui-text-on-accent-primary);
+          stroke: var(--wui-accent-default);
           stroke-width: 1.5;
           stroke-linecap: round;
           stroke-dasharray: 43.97;
@@ -139,12 +136,6 @@
           transform-origin: 50% 50%;
           transition: all var(--wui-control-normal-duration) linear;
           animation: root-splash-progress-ring-indeterminate 2s linear infinite;
-        }
-
-        @media (prefers-color-scheme: dark) {
-          .root-splash-note circle {
-            stroke: var(--wui-accent-default);
-          }
         }
 
         @keyframes root-splash-progress-ring-indeterminate {


### PR DESCRIPTION
This change aligns RAWeb's splash screen design with the splash screen present on newer versons of Windows.

<img width="2157" height="1507" alt="image" src="https://github.com/user-attachments/assets/ec7cfb64-1dd5-4f68-8713-e496132fca08" />

<img width="2158" height="1502" alt="image" src="https://github.com/user-attachments/assets/8ec34349-daf3-49e0-999a-737684eb8203" />
