### PR TITLE
feat: show an alert dialog when webfeed.aspx fails to load due to the RAWeb management service not currently running

### DIFF
--- a/dotnet/RAWebServer/src/api/workspace/GetWorkspace.cs
+++ b/dotnet/RAWebServer/src/api/workspace/GetWorkspace.cs
@@ -30,25 +30,30 @@ namespace RAWebServer.Api {
         }
       }
 
-      var resourcesFolder = "resources";
-      var multiuserResourcesFolder = "multiuser-resources";
-      var workspaceXml = new WorkspaceBuilder(
-        schemaVersion,
-        userInfo,
-        HttpContext.Current.Request.Url.Host,
-        mergeTerminalServers == "1",
-        terminalServer,
-        VirtualPathUtility.ToAbsolute("~/"),
-        SystemRemoteAppsClient.Proxy
-      ).GetWorkspaceXmlString(resourcesFolder, multiuserResourcesFolder);
+      try {
+        var resourcesFolder = "resources";
+        var multiuserResourcesFolder = "multiuser-resources";
+        var workspaceXml = new WorkspaceBuilder(
+          schemaVersion,
+          userInfo,
+          HttpContext.Current.Request.Url.Host,
+          mergeTerminalServers == "1",
+          terminalServer,
+          VirtualPathUtility.ToAbsolute("~/"),
+          SystemRemoteAppsClient.Proxy
+        ).GetWorkspaceXmlString(resourcesFolder, multiuserResourcesFolder);
 
-      var contentType = schemaVersion >= WorkspaceBuilder.SchemaVersion.v2 ? "application/x-msts-radc+xml" : "text/xml";
+        var contentType = schemaVersion >= WorkspaceBuilder.SchemaVersion.v2 ? "application/x-msts-radc+xml" : "text/xml";
 
-      var response = new HttpResponseMessage(HttpStatusCode.OK) {
-        Content = new StringContent(workspaceXml, Encoding.UTF8, contentType)
-      };
+        var response = new HttpResponseMessage(HttpStatusCode.OK) {
+          Content = new StringContent(workspaceXml, Encoding.UTF8, contentType)
+        };
 
-      return ResponseMessage(response);
+        return ResponseMessage(response);
+      }
+      catch (System.ServiceModel.EndpointNotFoundException) {
+        throw new Exception("The RAWeb Management Service is not running.");
+      }
     }
   }
 }

--- a/frontend/lib/dialogs/global/Confirm.vue
+++ b/frontend/lib/dialogs/global/Confirm.vue
@@ -74,7 +74,7 @@
         <TextBlock>{{ confirmError.message }}</TextBlock>
       </InfoBar>
 
-      <TextBlock v-else>{{ message }}</TextBlock>
+      <TextBlock v-else style="white-space: pre-wrap">{{ message }}</TextBlock>
     </template>
     <template #footer="{ close }">
       <Button @click="confirm(close)" :loading="confirming" v-if="!confirmError && confirmButtonText">{{

--- a/frontend/lib/public/locales/en.json
+++ b/frontend/lib/public/locales/en.json
@@ -15,6 +15,10 @@
     "yes": "Yes",
     "no": "No"
   },
+  "mgtOffline": {
+    "title": "The RAWeb management service is offline",
+    "message": "RAWeb cannot access any resources because the management service is not running on the RAWeb server.\n\nPlease contact your administrator to resolve this issue."
+  },
   "profile": {
     "changePassword": "Change a password",
     "signOut": "Sign out"


### PR DESCRIPTION
Currently, the splash screen loads forever whenever webfeed.aspx fails to load. 

This change adds an alert dialog that appears whenever webfeed.aspx fails to load due to the management service being offline. The alert will appear even when RAWeb is able to use a cached copy of the workspace resources.

<img width="600" src="https://github.com/user-attachments/assets/8aab0db2-99e0-458a-95ad-9ea96637e5b0" />

Resolves #197.