### PR TITLE
Include docs/help button on every policy dialog

### DIFF
--- a/frontend/docs/(administration)/policies/alert-banners/index.md
+++ b/frontend/docs/(administration)/policies/alert-banners/index.md
@@ -1,6 +1,8 @@
 ---
 title: $t{{ policies.App.Alerts.SignedInUser.title }}
 nav_title: User and group folders
+redirects:
+  - policies/App.Alerts.SignedInUser
 ---
 
 <PolicyDetails translationKeyPrefix="policies.App.Alerts.SignedInUser" open />

--- a/frontend/docs/(administration)/policies/block-workspace-auth/index.md
+++ b/frontend/docs/(administration)/policies/block-workspace-auth/index.md
@@ -1,6 +1,8 @@
 ---
 title: $t{{ policies.WorkspaceAuth.Block.title }}
 nav_title: Block workspace authentication
+redirects:
+  - policies/WorkspaceAuth.Block
 ---
 
 Enable this policy to prevent workspace clients (such as Windows App) from authenticating to RAWeb. When enabled, users will be unable to add RAWeb's resources to workspace clients or refresh them if they have already been added.

--- a/frontend/docs/(administration)/policies/centralized-publishing/index.md
+++ b/frontend/docs/(administration)/policies/centralized-publishing/index.md
@@ -1,6 +1,8 @@
 ---
 title: $t{{ policies.RegistryApps.Enabled.title }}
 nav_title: Centralized publishing (registry)
+redirects:
+  - policies/RegistryApps.Enabled
 ---
 
 Enable this policy to store published RemoteApps and desktops in their own collection in the registry. If you have RAWeb and RDWeb running on the same server or multiple installations of RAWeb, enabling the policy ensures that visibility settings for RemoteApps and desktops do not conflict between the installations.

--- a/frontend/docs/(administration)/policies/change-password/index.md
+++ b/frontend/docs/(administration)/policies/change-password/index.md
@@ -1,6 +1,8 @@
 ---
 title: $t{{ policies.PasswordChange.Enabled.title }}
 nav_title: Change passwords via RAWeb
+redirects:
+  - policies/PasswordChange.Enabled
 ---
 
 RAWeb allows users to change their passwords directly through the web interface. This feature can be enabled or disabled based on your organization's policies.

--- a/frontend/docs/(administration)/policies/combine-alike-apps/index.md
+++ b/frontend/docs/(administration)/policies/combine-alike-apps/index.md
@@ -1,6 +1,8 @@
 ---
 title: $t{{ policies.App.CombineTerminalServersModeEnabled.title }}
 nav_title: Combine alike apps
+redirects:
+  - policies/App.CombineTerminalServersModeEnabled
 ---
 
 <PolicyDetails translationKeyPrefix="policies.App.CombineTerminalServersModeEnabled" open />

--- a/frontend/docs/(administration)/policies/configure-aliases/index.md
+++ b/frontend/docs/(administration)/policies/configure-aliases/index.md
@@ -1,6 +1,8 @@
 ---
 title: Configure hosting server and terminal server aliases
 nav_title: Configure aliases
+redirects:
+  - policies/TerminalServerAliases
 ---
 
 If you want to customize the name of the hosting server that appears in RAWeb or any of the remote desktop clients, or you want to customize the names of the terminal servers for your remote apps and desktops, follow the instructions after the example section.

--- a/frontend/docs/(administration)/policies/connection-method-rdpFile/index.md
+++ b/frontend/docs/(administration)/policies/connection-method-rdpFile/index.md
@@ -1,6 +1,8 @@
 ---
 title: $t{{ policies.App.ConnectionMethod.RdpFileDownload.Enabled.title }}
 nav_title: RDP file connection method
+redirects:
+  - policies/App.ConnectionMethod.RdpFileDownload.Enabled
 ---
 
 This policy controls whether the option to download an RDP file is available to users when connecting to resources.

--- a/frontend/docs/(administration)/policies/connection-method-rdpProtocolUrl/index.md
+++ b/frontend/docs/(administration)/policies/connection-method-rdpProtocolUrl/index.md
@@ -1,6 +1,8 @@
 ---
 title: $t{{ policies.App.ConnectionMethod.RdpProtocol.Enabled.title }}
 nav_title: RDP URI connection method
+redirects:
+  - policies/App.ConnectionMethod.RdpProtocol.Enabled
 ---
 
 This policy controls whether the option to launch a resources via its rdp:// URI is available to users when connecting to resources.

--- a/frontend/docs/(administration)/policies/duo-mfa/index.md
+++ b/frontend/docs/(administration)/policies/duo-mfa/index.md
@@ -1,6 +1,8 @@
 ---
 title: $t{{ policies.App.Auth.MFA.Duo.title }}
 nav_title: Duo Universal Prompt
+redirects:
+  - policies/App.Auth.MFA.Duo
 ---
 
 Enable this policy to require users to provide a second factor of authentication via Duo Security's Universal Prompt when signing in to RAWeb.

--- a/frontend/docs/(administration)/policies/favorites/index.md
+++ b/frontend/docs/(administration)/policies/favorites/index.md
@@ -1,6 +1,8 @@
 ---
 title: $t{{ policies.App.FavoritesEnabled.title }}
 nav_title: Favorites
+redirects:
+  - policies/App.FavoritesEnabled
 ---
 
 <PolicyDetails translationKeyPrefix="policies.App.FavoritesEnabled" open />

--- a/frontend/docs/(administration)/policies/flatten-folders/index.md
+++ b/frontend/docs/(administration)/policies/flatten-folders/index.md
@@ -1,6 +1,8 @@
 ---
 title: $t{{ policies.App.FlatModeEnabled.title }}
 nav_title: Flatten folders
+redirects:
+  - policies/App.FlatModeEnabled
 ---
 
 <PolicyDetails translationKeyPrefix="policies.App.FlatModeEnabled" open />

--- a/frontend/docs/(administration)/policies/fulladdress-override/index.md
+++ b/frontend/docs/(administration)/policies/fulladdress-override/index.md
@@ -1,6 +1,8 @@
 ---
 title: $t{{ policies.RegistryApps.FullAddressOverride.title }}
 nav_title: Override full address
+redirects:
+  - policies/RegistryApps.FullAddressOverride
 ---
 
 <PolicyDetails translationKeyPrefix="policies.RegistryApps.FullAddressOverride" open />

--- a/frontend/docs/(administration)/policies/hide-ports/index.md
+++ b/frontend/docs/(administration)/policies/hide-ports/index.md
@@ -1,6 +1,8 @@
 ---
 title: $t{{ policies.App.HidePortsEnabled.title }}
 nav_title: Hide ports
+redirects:
+  - policies/App.HidePortsEnabled
 ---
 
 <PolicyDetails translationKeyPrefix="policies.App.HidePortsEnabled" open />

--- a/frontend/docs/(administration)/policies/icon-backgrounds/index.md
+++ b/frontend/docs/(administration)/policies/icon-backgrounds/index.md
@@ -1,6 +1,8 @@
 ---
 title: $t{{ policies.App.IconBackgroundsEnabled.title }}
 nav_title: Icon backgrounds
+redirects:
+  - policies/App.IconBackgroundsEnabled
 ---
 
 <PolicyDetails translationKeyPrefix="policies.App.IconBackgroundsEnabled" open />

--- a/frontend/docs/(administration)/policies/inject-rdp-properties/index.md
+++ b/frontend/docs/(administration)/policies/inject-rdp-properties/index.md
@@ -1,6 +1,8 @@
 ---
 title: $t{{ policies.RegistryApps.AdditionalProperties.title }}
 nav_title: Additional RemoteApp properties
+redirects:
+  - policies/RegistryApps.AdditionalProperties
 ---
 
 <PolicyDetails translationKeyPrefix="policies.RegistryApps.AdditionalProperties" open />

--- a/frontend/docs/(administration)/policies/show-multiuser-names/index.md
+++ b/frontend/docs/(administration)/policies/show-multiuser-names/index.md
@@ -1,6 +1,8 @@
 ---
 title: $t{{ policies.Workspace.ShowMultiuserResourcesUserAndGroupNames.title }}
 nav_title: User and group folders
+redirects:
+  - policies/Workspace.ShowMultiuserResourcesUserAndGroupNames
 ---
 
 <PolicyDetails translationKeyPrefix="policies.Workspace.ShowMultiuserResourcesUserAndGroupNames" open />

--- a/frontend/docs/(administration)/policies/simple-mode/index.md
+++ b/frontend/docs/(administration)/policies/simple-mode/index.md
@@ -1,6 +1,8 @@
 ---
 title: $t{{ policies.App.SimpleModeEnabled.title }}
 nav_title: Simple mode
+redirects:
+  - policies/App.SimpleModeEnabled
 ---
 
 <PolicyDetails translationKeyPrefix="policies.App.SimpleModeEnabled" open />

--- a/frontend/docs/(administration)/policies/user-cache/index.md
+++ b/frontend/docs/(administration)/policies/user-cache/index.md
@@ -1,6 +1,9 @@
 ---
 title: Configure the user cache
 nav_title: User cache
+redirects:
+  - policies/UserCache.Enabled
+  - policies/UserCache.StaleWhileRevalidate
 ---
 
 ## Enable the user cache

--- a/frontend/lib/components/Navigation/NavigationRail.vue
+++ b/frontend/lib/components/Navigation/NavigationRail.vue
@@ -1,25 +1,12 @@
 <script setup lang="ts">
   import RailButton from '$components/Navigation/RailButton.vue';
   import { useCoreDataStore } from '$stores';
-  import { favoritesEnabled } from '$utils';
+  import { favoritesEnabled, openHelpPopup } from '$utils';
 
-  const { authUser, coreVersion } = useCoreDataStore();
+  const { authUser, docsUrl } = useCoreDataStore();
 
   // TODO [Anchors]: Remove this when all major browsers support CSS Anchor Positioning
   const supportsAnchorPositions = CSS.supports('position-area', 'center center');
-
-  const base = document.querySelector('base')?.getAttribute('href') || '/';
-  const docsUrl = __DOCS_EXCLUDED__
-    ? `https://kimmknight.github.io/raweb/wiki-redirect?coreVersion=${encodeURIComponent(coreVersion)}`
-    : base + 'docs';
-  function openHelpPopup() {
-    const popup = window.open(docsUrl, 'help', 'width=1000,height=600,menubar=0,status=0');
-    if (popup) {
-      popup.focus();
-    } else {
-      alert('Please allow popups for this application');
-    }
-  }
 </script>
 
 <template>
@@ -160,7 +147,7 @@
       </RouterLink>
 
       <!-- Wiki (external link, not router) -->
-      <RailButton :href="docsUrl" target="_blank" @click.prevent="openHelpPopup">
+      <RailButton :href="docsUrl" target="_blank" @click.prevent="openHelpPopup(docsUrl)">
         <template v-slot:icon>
           <svg width="24" height="24" fill="none" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
             <path

--- a/frontend/lib/components/PolicyDialog/PolicyDialog.vue
+++ b/frontend/lib/components/PolicyDialog/PolicyDialog.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
   import { Button, IconButton, RadioButton, TextBlock, TextBox } from '$components';
-  import { raw, raw as unproxify } from '$utils';
+  import { useCoreDataStore } from '$stores';
+  import { openHelpPopup, raw, raw as unproxify } from '$utils';
   import { useTranslation } from 'i18next-vue';
   import { computed, ref, useTemplateRef, watchEffect } from 'vue';
   import ContentDialog from '../ContentDialog/ContentDialog.vue';
@@ -41,6 +42,7 @@
   }>();
 
   const { t } = useTranslation();
+  const { docsUrl } = useCoreDataStore();
 
   const state = defineModel<'disabled' | 'enabled' | 'unset'>('state', {
     default: 'unset',
@@ -389,9 +391,13 @@
       </section>
     </div>
 
-    <template v-slot:footer>
+    <template #footer>
       <Button @click="handleSave" :loading="saving">{{ t('dialog.ok') }}</Button>
       <Button @click="closeDialog">{{ t('dialog.cancel') }}</Button>
+    </template>
+
+    <template #footer-left>
+      <Button @click="openHelpPopup(`${docsUrl}/policies/${name}`)">{{ t('dialog.help') }}</Button>
     </template>
   </ContentDialog>
 </template>

--- a/frontend/lib/docs-entry.dist.mjs
+++ b/frontend/lib/docs-entry.dist.mjs
@@ -38,7 +38,10 @@ const docsMarkdownRoutes = await Promise.all(
       }
     }
 
-    return {
+    /**
+     * @satisfies {import('vue-router').RouteRecordRaw}
+     */
+    const route = {
       path:
         '/docs/' +
         (name === 'index'
@@ -54,8 +57,26 @@ const docsMarkdownRoutes = await Promise.all(
       },
       component: Component || NotFound,
     };
+
+    const redirects =
+      Array.isArray(frontmatter.redirects) && frontmatter.redirects.every((path) => typeof path === 'string')
+        ? frontmatter.redirects
+        : [];
+    const redirectRoutes = redirects.map((redirectPath) => {
+      const pathWithoutLeadingSlash = redirectPath.replace(/^\//, '');
+
+      /** @satisfies {import('vue-router').RouteRecordRaw} */
+      const redirectRoute = {
+        path: `/docs/${pathWithoutLeadingSlash}`,
+        redirect: route.path,
+      };
+
+      return redirectRoute;
+    });
+
+    return [route, ...redirectRoutes];
   })
-);
+).then((routes) => routes.flat());
 
 const history = createWebHistory();
 

--- a/frontend/lib/public/locales/en.json
+++ b/frontend/lib/public/locales/en.json
@@ -7,6 +7,7 @@
   "pleaseWait": "Please wait…",
   "unknownError": "An unexpected error occurred.",
   "dialog": {
+    "help": "Help",
     "close": "Close",
     "cancel": "Cancel",
     "ok": "OK",

--- a/frontend/lib/stores/coreDataStore.ts
+++ b/frontend/lib/stores/coreDataStore.ts
@@ -61,6 +61,9 @@ interface State extends EmptyState {
      * to the `envFQDN` value. The client MUST check whether the envFQDN can be reached. */
     supportsFqdnRedirect?: boolean;
   };
+
+  /** The URL to the documentation site, or the wiki-redirect page if docs are excluded */
+  docsUrl: string;
 }
 
 interface EmptyState {
@@ -85,6 +88,15 @@ export const useCoreDataStore = defineStore('coreData', {
             throw new Error('Invalid data');
           }
           Object.assign(this, data);
+
+          const base = document.querySelector('base')?.getAttribute('href') || '/';
+          const docsUrl = __DOCS_EXCLUDED__
+            ? `https://kimmknight.github.io/raweb/wiki-redirect?coreVersion=${encodeURIComponent(
+                this.coreVersion
+              )}`
+            : base + 'docs';
+          this.docsUrl = docsUrl;
+
           this.initialized = true;
         })
         .finally(() => {

--- a/frontend/lib/utils/index.mjs
+++ b/frontend/lib/utils/index.mjs
@@ -13,6 +13,7 @@ import { inferUtfEncoding } from './inferUtfEncoding.ts';
 import { isUrl } from './isUrl.ts';
 import { normalizeRdpFileString } from './normalizeRdpFileString.ts';
 import { notEmpty } from './notEmpty.ts';
+import { openHelpPopup } from './openHelpPopup.ts';
 import { parseRdpFileText } from './parseRdpFileText.ts';
 import { pascalCaseToCamelCase } from './pascalCaseToCamelCase.ts';
 import { pickImageFile } from './pickImageFile.ts';
@@ -53,6 +54,7 @@ export {
   isUrl,
   normalizeRdpFileString,
   notEmpty,
+  openHelpPopup,
   parseRdpFileText,
   pascalCaseToCamelCase,
   pickImageFile,

--- a/frontend/lib/utils/openHelpPopup.ts
+++ b/frontend/lib/utils/openHelpPopup.ts
@@ -1,0 +1,8 @@
+export function openHelpPopup(docsUrl: string) {
+  const popup = window.open(docsUrl, 'help', 'width=1000,height=600,menubar=0,status=0');
+  if (popup) {
+    popup.focus();
+  } else {
+    alert('Please allow popups for this application');
+  }
+}


### PR DESCRIPTION
This PR adds a button to the bottom-left corner of the policy dialog that opens the policy's wiki page.
This should make it easier for administrators to discover documentation related to a policy.


https://github.com/user-attachments/assets/cc9d29e5-cd97-4c0a-9ba5-d7d28d308561

