### PR TITLE
Always show the unsaved changes warning dialog after editing a RemoteApp from the apps page

### DIFF
--- a/dotnet/RAWeb.Server.Management.ServiceHost/ManagementService.cs
+++ b/dotnet/RAWeb.Server.Management.ServiceHost/ManagementService.cs
@@ -23,18 +23,23 @@ public class ManagementService : ServiceBase {
 
 #if RELEASE
     const string endpointName = "SystemRemoteApps";
+    var binding = ManagementServiceBinding.Create();
+    var address = $"net.pipe://localhost/RAWeb/{endpointName}";
 #else
     const string endpointName = "SystemRemoteApps-Dev";
+    var binding = ManagementServiceBinding.CreateHttpForDevelopment();
+    var address = $"http://localhost:8090/RAWeb/{endpointName}";
 #endif
 
     // create the service host
     _host = new ServiceHost(typeof(SystemRemoteAppsServiceHost));
     _host.AddServiceEndpoint(
         typeof(IManagedResourceService),
-        ManagementServiceBinding.Create(),
-        $"net.pipe://localhost/RAWeb/{endpointName}"
+        binding,
+        address
     );
 
+#if RELEASE
     // require Windows authentication
     var authBehavior = _host.Description.Behaviors.Find<ServiceAuthorizationBehavior>();
     if (authBehavior == null) {
@@ -46,6 +51,7 @@ public class ManagementService : ServiceBase {
     authBehavior.PrincipalPermissionMode = PrincipalPermissionMode.UseWindowsGroups;
     _host.Credentials.WindowsAuthentication.AllowAnonymousLogons = false;
     _host.Credentials.WindowsAuthentication.IncludeWindowsGroups = true;
+#endif
 
     // open the service host
     _host.Open();
@@ -77,6 +83,29 @@ public class ManagementServiceBinding {
         MaxArrayLength = MiB,
       },
       TransferMode = TransferMode.Streamed
+    };
+  }
+
+  /// <summary>
+  /// Creates the BasicHttpBinding used for the management service in development
+  /// builds, where we use HTTP instead of named pipes since using SSH into a
+  /// development machine creates non-interactive sessions where named pipes won't work.
+  /// </summary>
+  /// <returns></returns>
+  public static BasicHttpBinding CreateHttpForDevelopment() {
+    const int MiB = 1024 * 1024;
+
+    return new BasicHttpBinding {
+      Security = {
+      Mode = BasicHttpSecurityMode.TransportCredentialOnly,
+      Transport = { ClientCredentialType = HttpClientCredentialType.Windows }
+    },
+      MaxReceivedMessageSize = MiB,
+      ReaderQuotas = new System.Xml.XmlDictionaryReaderQuotas {
+        MaxStringContentLength = MiB,
+        MaxArrayLength = MiB,
+      },
+      TransferMode = TransferMode.Buffered
     };
   }
 }

--- a/dotnet/RAWebServer/src/ServiceClients.cs
+++ b/dotnet/RAWebServer/src/ServiceClients.cs
@@ -1,4 +1,5 @@
 using System.ServiceModel;
+using System.ServiceModel.Channels;
 using RAWeb.Server.Management;
 
 namespace RAWebServer {
@@ -9,10 +10,16 @@ namespace RAWebServer {
     const string EndpointName = "SystemRemoteApps-Dev";
 #endif
 
-    private static readonly NetNamedPipeBinding s_binding = ManagementServiceBinding.Create();
+#if RELEASE
+    private static readonly Binding s_binding = ManagementServiceBinding.Create();
+    private static readonly string s_address = "net.pipe://localhost/RAWeb/" + EndpointName;
+#else
+    private static readonly Binding s_binding = ManagementServiceBinding.CreateHttpForDevelopment();
+    private static readonly string s_address = "http://localhost:8090/RAWeb/" + EndpointName;
+#endif
 
     private static readonly ChannelFactory<IManagedResourceService> s_factory =
-        new ChannelFactory<IManagedResourceService>(s_binding, new EndpointAddress("net.pipe://localhost/RAWeb/" + EndpointName));
+        new ChannelFactory<IManagedResourceService>(s_binding, new EndpointAddress(s_address));
 
     public static IManagedResourceService Proxy {
       get {

--- a/frontend/lib/components/ContentDialog/ContentDialog.vue
+++ b/frontend/lib/components/ContentDialog/ContentDialog.vue
@@ -204,9 +204,9 @@
     event.stopPropagation();
   }
   watch(
-    () => closeOnEscape,
-    ($closeOnEscape) => {
-      if ($closeOnEscape) {
+    () => [isOpen.value, closeOnEscape],
+    ([$isOpen, $closeOnEscape]) => {
+      if ($isOpen && $closeOnEscape) {
         document.addEventListener('keydown', handleEscape);
       } else {
         document.removeEventListener('keydown', handleEscape);

--- a/frontend/lib/components/ItemCard/GenericResourceCard.vue
+++ b/frontend/lib/components/ItemCard/GenericResourceCard.vue
@@ -88,7 +88,7 @@
 <template>
   <article
     @click.stop="connect"
-    @keydown.stop="handleKeyDown"
+    @keydown="handleKeyDown"
     tabIndex="0"
     :class="`mode-${mode}`"
     @contextmenu="handleRightClick"


### PR DESCRIPTION
Before this change, pressing Escape on a keyboard from the resource editor dialog would not show the unsaved changes warning if the dialog was accessed from the apps page instead of the resource manager dialog.
With this change, the keyboard event that detects escape key presses will work.