### PR TITLE
Show options instead of empty text boxes for RDP properties in the RDP file editor that have known options

### DIFF
--- a/frontend/lib/components/Button/StandardButton.vue
+++ b/frontend/lib/components/Button/StandardButton.vue
@@ -48,7 +48,7 @@
     border: none;
     cursor: default;
     border-radius: var(--wui-control-corner-radius);
-    transition: var(--wui-control-faster-duration) ease background;
+    transition: background var(--wui-control-faster-duration) ease;
     min-height: 30px;
   }
 

--- a/frontend/lib/components/Select/Select.vue
+++ b/frontend/lib/components/Select/Select.vue
@@ -1,0 +1,208 @@
+<script setup lang="ts">
+  const { disabled, alwaysContrastText } = defineProps<{
+    disabled?: boolean;
+    /** Use the visible text styles even when disabled. */
+    alwaysContrastText?: boolean;
+  }>();
+
+  const model = defineModel({ default: '' });
+
+  function update(event: Event) {
+    const newValue = (event.target as HTMLSelectElement).value;
+    model.value = newValue;
+  }
+</script>
+
+<template>
+  <select
+    :disabled="disabled"
+    :value="model"
+    @change="update"
+    class="fluent-select"
+    :class="{ alwaysContrastText }"
+  >
+    <button>
+      <selectedcontent></selectedcontent>
+    </button>
+    <!-- The slot should contain <option> elements. -->
+    <slot></slot>
+  </select>
+</template>
+
+<style scoped>
+  select,
+  ::picker(select) {
+    appearance: base-select;
+    --menu-flyout-transition-offset: -14px;
+  }
+
+  select {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    user-select: none;
+    font-family: var(--wui-font-family-text);
+    font-size: var(--wui-font-size-body);
+    font-weight: normal;
+    color: var(--wui-text-primary);
+    line-height: 20px;
+    position: relative;
+    box-sizing: border-box;
+    padding-block: 4px 6px;
+    padding-inline: 11px;
+    text-decoration: none;
+    border: none;
+    cursor: default;
+    border-radius: var(--wui-control-corner-radius);
+    transition: background var(--wui-control-faster-duration) ease;
+    min-height: 30px;
+
+    box-shadow:
+      inset 0 0 0 1px var(--wui-control-stroke-default),
+      inset 0 -1px 0 0 var(--wui-control-stroke-secondary-overlay);
+    background-color: var(--wui-control-fill-default);
+    color: var(--text-primary);
+    background-clip: padding-box;
+  }
+  select:hover:not(:disabled) {
+    background-color: var(--wui-control-fill-secondary);
+  }
+  select:active:not(:disabled) {
+    background-color: var(--wui-control-fill-tertiary);
+    color: var(--wui-text-secondary);
+  }
+  select:disabled {
+    background-color: var(--wui-control-fill-disabled);
+  }
+  select:not(.alwaysContrastText):disabled {
+    color: var(--wui-text-disabled);
+  }
+  select.alwaysContrastText:disabled {
+    color: light-dark(
+      oklch(from var(--wui-text-primary) calc(l + 0.2) c h),
+      oklch(from var(--wui-text-primary) calc(l - 0.1) c h)
+    );
+  }
+
+  select::picker-icon {
+    transition: rotate 200ms cubic-bezier(0.16, 1, 0.3, 1);
+    flex-shrink: 0;
+    flex-grow: 0;
+    content: '';
+    display: inline-block;
+    width: 12px;
+    height: 12px;
+    background-color: currentColor;
+    mask-image: url("data:image/svg+xml,%3Csvg width='24' height='24' fill='none' viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M4.22 8.47a.75.75 0 0 1 1.06 0L12 15.19l6.72-6.72a.75.75 0 1 1 1.06 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L4.22 9.53a.75.75 0 0 1 0-1.06Z' fill='black'/%3E%3C/svg%3E");
+    mask-size: contain;
+    mask-repeat: no-repeat;
+  }
+  select:disabled::picker-icon {
+    mask-image: none;
+    background-color: transparent;
+  }
+
+  select:open::picker-icon {
+    rotate: 180deg;
+    transition-delay: calc(var(--wui-control-normal-duration) / 2);
+  }
+
+  ::picker(select) {
+    user-select: none;
+    font-family: var(--wui-font-family-text);
+    font-size: var(--wui-font-size-body);
+    font-weight: normal;
+    line-height: 20px;
+    margin: 0;
+    padding: 0;
+    padding-block: 2px;
+    box-sizing: border-box;
+    color: var(--wui-text-primary);
+    border-radius: var(--wui-overlay-corner-radius);
+    border: 1px solid var(--wui-surface-stroke-flyout);
+    background-color: var(--wui-solid-background-quarternary);
+    background-clip: padding-box;
+    opacity: 0;
+    box-shadow: none;
+  }
+  :open::picker(select) {
+    opacity: 1;
+    box-shadow: var(--wui-flyout-shadow);
+    transition:
+      opacity var(--wui-control-normal-duration) var(--wui-control-fast-out-slow-in-easing) allow-discrete,
+      display var(--wui-control-normal-duration) var(--wui-control-fast-out-slow-in-easing) allow-discrete,
+      overlay var(--wui-control-normal-duration) var(--wui-control-fast-out-slow-in-easing) allow-discrete,
+      box-shadow var(--wui-control-normal-duration) var(--wui-control-fast-out-slow-in-easing)
+        calc(var(--wui-control-normal-duration) / 2);
+  }
+  @starting-style {
+    :open::picker(select) {
+      opacity: 0;
+      box-shadow: none;
+      transform: translateY(var(--menu-flyout-transition-offset, -50%));
+    }
+  }
+
+  select :deep(option) {
+    transform: translateY(var(--menu-flyout-transition-offset, -50%));
+  }
+  select:open :deep(option) {
+    transform: translateY(0);
+    transition:
+      transform var(--wui-control-normal-duration) var(--wui-control-fast-out-slow-in-easing),
+      background var(--wui-control-faster-duration) ease;
+  }
+  @starting-style {
+    select:open :deep(option) {
+      transform: translateY(var(--menu-flyout-transition-offset, -50%));
+    }
+  }
+
+  select :deep(option) {
+    display: flex;
+    inline-size: calc(100% - 8px);
+    position: relative;
+    box-sizing: border-box;
+    flex: 0 0 auto;
+    margin: 2px 4px 4px 4px;
+    padding-inline: 12px;
+    border-radius: var(--wui-control-corner-radius);
+    outline: none;
+    background-color: var(--wui-subtle-transparent);
+    color: var(--wui-text-primary);
+    cursor: default;
+    min-block-size: 29px;
+    white-space: normal;
+  }
+
+  select :deep(option):last-child {
+    margin-bottom: 2px;
+  }
+
+  select :deep(option):focus-visible {
+    outline: var(--focus-outline);
+    outline-offset: var(--focus-outline-offset);
+  }
+
+  select :deep(option):hover,
+  select :deep(option):checked {
+    background-color: var(--wui-subtle-secondary);
+  }
+
+  select :deep(option):active {
+    background-color: var(--wui-subtle-tertiary);
+  }
+
+  select :deep(option)::checkmark {
+    content: '';
+    display: inline-block;
+    flex-shrink: 0;
+    flex-grow: 0;
+    width: 16px;
+    height: 16px;
+    background-color: currentColor;
+    mask-image: url("data:image/svg+xml,%3Csvg width='24' height='24' fill='none' viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M4.53 12.97a.75.75 0 0 0-1.06 1.06l4.5 4.5a.75.75 0 0 0 1.06 0l11-11a.75.75 0 0 0-1.06-1.06L8.5 16.94l-3.97-3.97Z' fill='black'/%3E%3C/svg%3E");
+    mask-size: contain;
+    mask-repeat: no-repeat;
+  }
+</style>

--- a/frontend/lib/components/TextBox/TextBox.vue
+++ b/frontend/lib/components/TextBox/TextBox.vue
@@ -8,6 +8,7 @@
     disabled = false,
     textArea = false,
     id = '',
+    alwaysContrastText,
   } = defineProps<{
     containerClass?: string;
     showSubmitButton?: boolean;
@@ -18,6 +19,8 @@
     /** Minimum number of lines for the text area. Only applies when `textArea` is `true`. */
     minLines?: number;
     id?: string;
+    /** Use the visible text styles even when disabled. */
+    alwaysContrastText?: boolean;
   }>();
 
   const restProps = useAttrs();
@@ -128,6 +131,7 @@
     <input
       v-else
       class="text-box"
+      :class="{ alwaysContrastText }"
       :disabled
       v-model="model"
       @keydown="handleKeyDown"
@@ -197,7 +201,9 @@
     align-items: flex-start;
     background-clip: padding-box;
     background-color: var(--wui-control-fill-default);
-    border: 1px solid var(--wui-control-stroke-default);
+    box-shadow:
+      inset 0 0 0 1px var(--wui-control-stroke-default),
+      inset 0 -1px 0 0 var(--wui-control-stroke-secondary-overlay);
     border-radius: var(--wui-control-corner-radius);
     cursor: text;
     display: flex;
@@ -212,6 +218,15 @@
   .text-box-container.disabled {
     background-color: var(--wui-control-fill-disabled);
     cursor: text;
+  }
+  input:not(.alwaysContrastText):disabled {
+    color: var(--wui-text-disabled);
+  }
+  input.alwaysContrastText:disabled {
+    color: light-dark(
+      oklch(from var(--wui-text-primary) calc(l + 0.2) c h),
+      oklch(from var(--wui-text-primary) calc(l - 0.1) c h)
+    );
   }
 
   .text-box-container.disabled .text-box-underline {
@@ -229,11 +244,11 @@
   }
 
   .text-box-underline {
-    block-size: calc(100% + 2px);
+    block-size: calc(100% + 0px);
     border-radius: var(--wui-control-corner-radius);
-    inline-size: calc(100% + 2px);
-    inset-block-start: -1px;
-    inset-inline-start: -1px;
+    inline-size: calc(100% - 2px);
+    inset-block-start: 0px;
+    inset-inline-start: 1px;
     overflow: hidden;
     pointer-events: none;
     position: absolute;

--- a/frontend/lib/components/index.mjs
+++ b/frontend/lib/components/index.mjs
@@ -22,6 +22,7 @@ import { default as PolicyDialog } from './PolicyDialog/PolicyDialog.vue';
 import { default as ProgressBar } from './ProgressBar/ProgressBar.vue';
 import { default as ProgressRing } from './ProgressRing/ProgressRing.vue';
 import { default as RadioButton } from './RadioButton/RadioButton.vue';
+import { default as Select } from './Select/Select.vue';
 import { default as TextBlock } from './TextBlock/TextBlock.vue';
 import { default as TextBox } from './TextBox/TextBox.vue';
 import { default as Titlebar } from './Titlebar/Titlebar.vue';
@@ -53,6 +54,7 @@ export {
   ProgressRing,
   RadioButton,
   ResourceGrid,
+  Select,
   TextBlock,
   TextBox,
   Titlebar,

--- a/frontend/lib/dialogs/RdpFilePropertiesDialog.vue
+++ b/frontend/lib/dialogs/RdpFilePropertiesDialog.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { Button, ContentDialog, Field, NavigationPane, TextBlock, TextBox } from '$components';
+  import { Button, ContentDialog, Field, NavigationPane, Select, TextBlock, TextBox } from '$components';
   import { TreeItem } from '$components/NavigationView/NavigationTypes';
   import { ManagedResourceEditDialog } from '$dialogs';
   import { useCoreDataStore } from '$stores';
@@ -325,6 +325,67 @@
     document.body.removeChild(a);
     URL.revokeObjectURL(url);
   }
+
+  const definedIntegerProperties = {
+    'administrative session:i': [0, 1],
+    'allow desktop composition:i': [0, 1],
+    'allow font smoothing:i': [0, 1],
+    'audiocapturemode:i': [0, 1],
+    'audiomode:i': [0, 1, 2],
+    'audioqualitymode:i': [0, 1, 2],
+    'authentication level:i': [0, 1, 2, 3],
+    'autoreconnection enabled:i': [0, 1],
+    'bandwidthautodetect:i': [0, 1],
+    'bitmapcachepersistenable:i': [0, 1],
+    'compression:i': [0, 1],
+    'connection type:i': [1, 2, 3, 4, 5, 6, 7],
+    'desktop size id:i': [0, 1, 2, 3, 4],
+    'disable ctrl+alt+del:i': [0, 1],
+    'disable full window drag:i': [0, 1],
+    'disable menu anims:i': [0, 1],
+    'disable themes:i': [0, 1],
+    'disable wallpaper:i': [0, 1],
+    'disableconnectionsharing:i': [0, 1],
+    'disableremoteappcapscheck:i': [0, 1],
+    'displayconnectionbar:i': [0, 1],
+    'dynamic resolution:i': [0, 1],
+    'enablecredsspsupport:i': [0, 1],
+    'enablerdsaadauth:i': [0, 1],
+    'enablesuperpan:i': [0, 1],
+    'encode redirected video capture:i': [0, 1],
+    'gatewaycredentialssource:i': [0, 1, 4],
+    'gatewayprofileusagemethod:i': [0, 1],
+    'gatewayusagemethod:i': [0, 1, 2, 3, 4],
+    'keyboardhook:i': [0, 1, 2],
+    'maximizetocurrentdisplays:i': [0, 1],
+    'negotiate security layer:i': [0, 1],
+    'networkautodetect:i': [0, 1],
+    'pinconnectionbar:i': [0, 1],
+    'prompt for credentials on client:i': [0, 1],
+    'prompt for credentials:i': [0, 1],
+    'promptcredentialonce:i': [0, 1],
+    'public mode:i': [0, 1],
+    'redirectclipboard:i': [0, 1],
+    'redirectcomports:i': [0, 1],
+    'redirectdirectx:i': [0, 1],
+    'redirected video capture encoding quality:i': [0, 1, 2],
+    'redirectlocation:i': [0, 1],
+    'redirectposdevices:i': [0, 1],
+    'redirectprinters:i': [0, 1],
+    'redirectsmartcards:i': [0, 1],
+    'redirectwebauthn:i': [0, 1],
+    'remoteapplicationexpandcmdline:i': [0, 1],
+    'remoteapplicationexpandworkingdir:i': [0, 1],
+    'remoteapplicationmode:i': [0, 1],
+    'screen mode id:i': [1, 2],
+    'session bpp:i': [8, 15, 16, 24, 32],
+    'singlemoninwindowedmode:i': [0, 1],
+    'smart sizing:i': [0, 1],
+    'span monitors:i': [0, 1],
+    'targetisaadjoined:i': [0, 1],
+    'use multimon:i': [0, 1],
+    'videoplaybackmode:i': [0, 1],
+  } as const;
 </script>
 
 <template>
@@ -381,8 +442,8 @@
           <template v-if="currentGroup === 'raweb'">
             <Field>
               <TextBlock>{{ t('resource.props.type') }}</TextBlock>
-              <TextBox
-                :value="
+              <p class="current">
+                {{
                   (() => {
                     if (!resourceProperties) {
                       return t('resource.props.unknownType');
@@ -396,15 +457,14 @@
 
                     return capitalize(t('device'));
                   })()
-                "
-                disabled
-              />
+                }}
+              </p>
             </Field>
 
             <Field>
               <TextBlock>{{ t('resource.props.location') }}</TextBlock>
-              <TextBox
-                :value="
+              <p class="current">
+                {{
                   (() => {
                     if (source === ManagedResourceSource.File) {
                       return 'App_Data/managed-resources';
@@ -426,20 +486,19 @@
                     }
                     return '';
                   })()
-                "
-                disabled
-              />
+                }}
+              </p>
             </Field>
 
             <Field v-if="managementIdentifier">
               <TextBlock>{{ t('resource.props.id') }}</TextBlock>
-              <TextBox :value="managementIdentifier" disabled />
+              <p class="current">{{ managementIdentifier }}</p>
             </Field>
 
             <Field>
               <TextBlock>{{ t('resource.props.ts') }}</TextBlock>
-              <TextBox
-                :value="
+              <p class="current">
+                {{
                   terminalServer ||
                   (() => {
                     const address = resourceProperties?.connection['full address:s'] as string | undefined;
@@ -450,15 +509,14 @@
                     const port = resourceProperties?.connection['server port:i'];
                     return port ? `${address}:${port}` : address || '';
                   })()
-                "
-                disabled
-              />
+                }}
+              </p>
             </Field>
           </template>
 
           <template v-else-if="resourceProperties && currentGroup">
             <Field
-              v-for="{ key, label, description } in Object.keys(resourceProperties[currentGroup] || {})
+              v-for="{ key, label, description, options } in Object.keys(resourceProperties[currentGroup] || {})
                 .map((key) => {
                   return {
                     key,
@@ -468,6 +526,14 @@
                     description: t(`resource.props.properties.${key.replace(':', '__')}.description`, {
                       defaultValue: key,
                     }),
+                    options: Object.keys(definedIntegerProperties).includes(key)
+                      ? definedIntegerProperties[key as keyof typeof definedIntegerProperties].map((value) => ({
+                          value: value.toString(),
+                          label: t(`resource.props.properties.${key.replace(':', '__')}.options.${value}`, {
+                            defaultValue: value.toString(),
+                          }),
+                        }))
+                      : undefined,
                   };
                 })
                 .sort((a, b) => a.label.localeCompare(b.label))"
@@ -476,11 +542,40 @@
               <TextBlock :title="description" style="cursor: help">
                 {{ label }}
               </TextBlock>
-              <TextBox
-                v-if="key.endsWith('i')"
-                :disabled="
-                  mode === 'view' || disabledFields.includes(key) || !capabilities.supportsCentralizedPublishing
+
+              <p v-if="mode === 'view'" class="current">
+                <span v-if="options">{{
+                  options.find(
+                    (option) => option.value === resourceProperties?.[currentGroup!][key]?.toString()
+                  )?.label || t('resource.props.defaultPropertyValue')
+                }}</span>
+                <span v-else>{{
+                  resourceProperties[currentGroup][key]?.toString() || t('resource.props.defaultPropertyValue')
+                }}</span>
+              </p>
+
+              <Select
+                v-else-if="options?.length"
+                always-contrast-text
+                :disabled="disabledFields.includes(key) || !capabilities.supportsCentralizedPublishing"
+                :model-value="resourceProperties[currentGroup][key]?.toString()"
+                @update:model-value="
+                  (newValue) => {
+                    if (resourceProperties && currentGroup) {
+                      resourceProperties[currentGroup][key] = options.find(
+                        (option) => option.value.toString() === newValue
+                      )?.value;
+                    }
+                  }
                 "
+              >
+                <option value="">{{ t('resource.props.defaultPropertyValue') }}</option>
+                <option v-for="{ value, label } in options" :value>{{ label }}</option>
+              </Select>
+              <TextBox
+                v-else-if="key.endsWith('i')"
+                always-contrast-text
+                :disabled="disabledFields.includes(key) || !capabilities.supportsCentralizedPublishing"
                 :value="resourceProperties[currentGroup][key]?.toString()"
                 @update:value="
                   (newValue) => {
@@ -492,9 +587,9 @@
                 type="number"
               />
               <TextBox
-                v-if="key.endsWith('s')"
+                v-else-if="key.endsWith('s')"
+                always-contrast-text
                 :disabled="
-                  mode === 'view' ||
                   key === 'signature:s' ||
                   disabledFields.includes(key) ||
                   !capabilities.supportsCentralizedPublishing
@@ -510,9 +605,8 @@
               />
               <TextBox
                 v-else-if="key.endsWith('b')"
-                :disabled="
-                  mode === 'view' || disabledFields.includes(key) || !capabilities.supportsCentralizedPublishing
-                "
+                always-contrast-text
+                :disabled="disabledFields.includes(key) || !capabilities.supportsCentralizedPublishing"
                 :value="
                   uint8ArrayToHexString(
                     isUint8Array(resourceProperties[currentGroup][key])
@@ -590,5 +684,14 @@
 
   .title {
     padding-bottom: calc(var(--inner-padding) / 2);
+  }
+
+  .current {
+    color: var(--wui-text-primary);
+    font-family: var(--wui-font-family-text);
+    font-size: 13px;
+    margin: 0 0 calc(var(--inner-padding) / 2) 0;
+    user-select: all;
+    opacity: 0.84;
   }
 </style>

--- a/frontend/lib/public/locales/en.json
+++ b/frontend/lib/public/locales/en.json
@@ -333,18 +333,31 @@
         "signature": "signature",
         "raweb": "RAWeb"
       },
+      "defaultPropertyValue": "Not set",
       "properties": {
         "administrative session__i": {
           "label": "Use an administrative session",
-          "description": "Connect to the administrative session of the remote computer.\n\n0 - Do not use the administrative session.\n1 - Connect to the administrative session."
+          "description": "Connect to the administrative session of the remote computer.",
+          "options": {
+            "0": "Do not use the administrative session.",
+            "1": "Connect to the administrative session."
+          }
         },
         "allow desktop composition__i": {
           "label": "Allow desktop composition",
-          "description": "Determines whether desktop composition (needed for Aero) is permitted when you log on to the remote computer.\n\n0 - Disable desktop composition in the remote session.\n1 - Desktop composition is permitted."
+          "description": "Determines whether desktop composition (needed for Aero) is permitted when you log on to the remote computer.",
+          "options": {
+            "0": "Disable desktop composition in the remote session.",
+            "1": "Desktop composition is permitted."
+          }
         },
         "allow font smoothing__i": {
           "label": "Allow font smoothing",
-          "description": "Determines whether font smoothing may be used in the remote session.\n\n0 - Disable font smoothing in the remote session.\n1 - Font smoothing is permitted."
+          "description": "Determines whether font smoothing may be used in the remote session.",
+          "options": {
+            "0": "Disable font smoothing in the remote session.",
+            "1": "Font smoothing is permitted."
+          }
         },
         "alternate full address__s": {
           "label": "Terminal server address (alternate)",
@@ -356,19 +369,39 @@
         },
         "audiocapturemode__i": {
           "label": "Send captured audio to the remote computer",
-          "description": "Determines how sounds captured (recorded) on the local computer are handled when you are connected to the remote computer.\n\n0 - Do not capture audio from the local computer.\n1 - Capture audio from the local computer and send to the remote computer."
+          "description": "Determines how sounds captured (recorded) on the local computer are handled when you are connected to the remote computer.",
+          "options": {
+            "0": "Do not capture audio from the local computer.",
+            "1": "Capture audio from the local computer and send to the remote computer."
+          }
         },
         "audiomode__i": {
           "label": "Audio playback mode",
-          "description": "Determines how sounds on a remote computer are handled when you are connected to the remote computer.\n\n0 - Play sounds on the local computer.\n1 - Play sounds on the remote computer.\n2 - Do not play sounds."
+          "description": "Determines how sounds on a remote computer are handled when you are connected to the remote computer.",
+          "options": {
+            "0": "Play sounds on the local computer.",
+            "1": "Play sounds on the remote computer.",
+            "2": "Do not play sounds."
+          }
         },
         "audioqualitymode__i": {
           "label": "Audio quality mode",
-          "description": "Determines the quality of the audio played in the remote session.\n\n0 - Dynamically adjust audio quality based on available bandwidth.\n1 - Always use medium audio quality.\n2 - Always use uncompressed audio quality."
+          "description": "Determines the quality of the audio played in the remote session.",
+          "options": {
+            "0": "Dynamically adjust audio quality based on available bandwidth.",
+            "1": "Always use medium audio quality.",
+            "2": "Always use uncompressed audio quality."
+          }
         },
         "authentication level__i": {
           "label": "Configure authentication failure behavior",
-          "description": "Determines what should happen when server authentication fails.\n\n0 - If server authentication fails, connect without giving a warning.\n1 - If server authentication fails, do not connect.\n2 - If server authentication fails, show a warning and allow the user to connect or not.\n3 - Server authentication is not required."
+          "description": "Determines what should happen when server authentication fails.",
+          "options": {
+            "0": "If server authentication fails, connect without giving a warning.",
+            "1": "If server authentication fails, do not connect.",
+            "2": "If server authentication fails, show a warning and allow the user to choose whether to connect.",
+            "3": "Server authentication is not required."
+          }
         },
         "autoreconnect max retries__i": {
           "label": "Maximum reconnection attempts",
@@ -376,15 +409,27 @@
         },
         "autoreconnection enabled__i": {
           "label": "Automatically reconnect when the connection is dropped",
-          "description": "Determines whether the client computer will automatically try to reconnect to the remote computer if the connection is dropped.\n\n0 - Do not attempt to reconnect.\n1 - Attempt to reconnect."
+          "description": "Determines whether the client computer will automatically try to reconnect to the remote computer if the connection is dropped.",
+          "options": {
+            "0": "Do not attempt to reconnect.",
+            "1": "Attempt to reconnect."
+          }
         },
         "bandwidthautodetect__i": {
           "label": "Automatically detect the network type",
-          "description": "Enables the option for automatic detection of the network type. Used in conjunction with networkautodetect. Also see connection type.\n\n0 - Do not enable the option for automatic network detection.\n1 - Enable the option for automatic network detection."
+          "description": "Enables the option for automatic detection of the network type. Used in conjunction with networkautodetect. Also see connection type.",
+          "options": {
+            "0": "Do not enable the option for automatic network detection.",
+            "1": "Enable the option for automatic network detection."
+          }
         },
         "bitmapcachepersistenable__i": {
           "label": "Enable bitmap cache",
-          "description": "Determines whether bitmaps are cached on the local computer (disk-based cache). Bitmap caching can improve the performance of your remote session.\n\n0 - Do not cache bitmaps.\n1 - Cache bitmaps."
+          "description": "Determines whether bitmaps are cached on the local computer (disk-based cache). Bitmap caching can improve the performance of your remote session.",
+          "options": {
+            "0": "Do not cache bitmaps.",
+            "1": "Cache bitmaps."
+          }
         },
         "bitmapcachesize__i": {
           "label": "Bitmap cache size",
@@ -396,15 +441,35 @@
         },
         "compression__i": {
           "label": "Use bulk compression",
-          "description": "Determines whether the connection should use bulk compression.\n\n0 - Do not use bulk compression.\n1 - Use bulk compression."
+          "description": "Determines whether the connection should use bulk compression.",
+          "options": {
+            "0": "Do not use bulk compression.",
+            "1": "Use bulk compression."
+          }
         },
         "connection type__i": {
           "label": "Connection type",
-          "description": "Specifies pre-defined performance settings for the Remote Desktop session.\n\n1 - Modem (56 Kbps).\n2 - Low-speed broadband (256 Kbps - 2 Mbps).\n3 - Satellite (2 Mbps - 16 Mbps with high latency).\n4 - High-speed broadband (2 Mbps - 10 Mbps).\n5 - WAN (10 Mbps or higher with high latency).\n6 - LAN (10 Mbps or higher).\n7 - Automatic bandwidth detection. Requires bandwidthautodetect.\n\nBy itself, this setting does nothing. When selected in the RDC GUI, this option changes several performance related settings (themes, animation, font smoothing, etcetera). These separate settings always overrule the connection type setting."
+          "description": "Specifies pre-defined performance settings for the Remote Desktop session.\n\nBy itself, this setting does nothing. When selected in the RDC GUI, this option changes several performance related settings (themes, animation, font smoothing, etcetera). These separate settings always overrule the connection type setting.",
+          "options": {
+            "1": "Modem (56 Kbps).",
+            "2": "Low-speed broadband (256 Kbps - 2 Mbps).",
+            "3": "Satellite (2 Mbps - 16 Mbps with high latency).",
+            "4": "High-speed broadband (2 Mbps - 10 Mbps).",
+            "5": "WAN (10 Mbps or higher with high latency).",
+            "6": "LAN (10 Mbps or higher).",
+            "7": "Automatic bandwidth detection. Requires bandwidthautodetect."
+          }
         },
         "desktop size id__i": {
           "label": "Desktop size preset",
-          "description": "Specifies pre-defined dimensions of the remote session desktop.\n\n0 - 640x480.\n1 - 800x600.\n2 - 1024x768.\n3 - 1280x1024.\n4 - 1600x1200.\n\nThis setting is ignored when either /w and /h, or desktopwidth and desktopheight are already specified."
+          "description": "Specifies pre-defined dimensions of the remote session desktop.\n\nThis setting is ignored when either /w and /h, or desktopwidth and desktopheight are already specified.",
+          "options": {
+            "0": "640x480.",
+            "1": "800x600.",
+            "2": "1024x768.",
+            "3": "1280x1024.",
+            "4": "1600x1200."
+          }
         },
         "desktopheight__i": {
           "label": "Display height",
@@ -424,35 +489,67 @@
         },
         "disable ctrl+alt+del__i": {
           "label": "Disable Ctrl+Alt+Delete requirement",
-          "description": "Determines whether you have to press CTRL+ALT+DELETE before entering credentials after you are connected to the remote computer.\n\n0 - CTRL+ALT+DELETE is required before logging in.\n1 - CTRL+ALT+DELETE is not required. You can logon immediately.\n\nNote: When disabled, this setting will also delay the autologin until the user has pressed CTRL+ALT+DELETE."
+          "description": "Determines whether you have to press CTRL+ALT+DELETE before entering credentials after you are connected to the remote computer.\n\nNote: When disabled, this setting will also delay the autologin until the user has pressed CTRL+ALT+DELETE.",
+          "options": {
+            "0": "CTRL+ALT+DELETE is required before logging in.",
+            "1": "CTRL+ALT+DELETE is not required. You can logon immediately."
+          }
         },
         "disable full window drag__i": {
           "label": "Disable full window drag",
-          "description": "Determines whether window content is displayed when you drag the window to a new location.\n\n0 - Show the contents of the window while dragging.\n1 - Show an outline of the window while dragging."
+          "description": "Determines whether window content is displayed when you drag the window to a new location.",
+          "options": {
+            "0": "Show the contents of the window while dragging.",
+            "1": "Show an outline of the window while dragging."
+          }
         },
         "disable menu anims__i": {
           "label": "Disable menu animations",
-          "description": "Determines whether menus and windows can be displayed with animation effects in the remote session.\n\n0 - Menu and window animation is permitted.\n1 - No menu and window animation."
+          "description": "Determines whether menus and windows can be displayed with animation effects in the remote session.",
+          "options": {
+            "0": "Menu and window animation is permitted.",
+            "1": "No menu and window animation."
+          }
         },
         "disable themes__i": {
           "label": "Disable themes",
-          "description": "Determines whether themes are permitted when you log on to the remote computer.\n\n0 - Themes are permitted.\n1 - Disable theme in the remote session."
+          "description": "Determines whether themes are permitted when you log on to the remote computer.",
+          "options": {
+            "0": "Themes are permitted.",
+            "1": "Disable theme in the remote session."
+          }
         },
         "disable wallpaper__i": {
           "label": "Disable wallpaper",
-          "description": "Determines whether the desktop background is displayed in the remote session.\n\n0 - Display the wallpaper.\n1 - Do not show any wallpaper."
+          "description": "Determines whether the desktop background is displayed in the remote session.",
+          "options": {
+            "0": "Display the wallpaper.",
+            "1": "Do not show any wallpaper."
+          }
         },
         "disableconnectionsharing__i": {
           "label": "Disable session sharing for RemoteApps",
-          "description": "Determines whether a new Terminal Server session is started with every launch of a RemoteApp to the same computer and with the same credentials.\n\n0 - No new session is started. The currently active session of the user is shared.\n1 - A new login session is started for the RemoteApp."
+          "description": "Determines whether a new Terminal Server session is started with every launch of a RemoteApp to the same computer and with the same credentials.",
+          "options": {
+            "0": "No new session is started. The currently active session of the user is shared.",
+            "1": "A new login session is started for the RemoteApp."
+          }
         },
         "disableremoteappcapscheck__i": {
           "label": "Disable RemoteApp capabilities check",
-          "description": "Specifies whether the Remote Desktop client should check the remote computer for RemoteApp capabilities.\n0 - Check the remote computer for RemoteApp capabilities before logging in.\n1 - Do not check the remote computer for RemoteApp capabilities.Note: This setting must be set to 1 when connecting to Windows XP SP3, Vista or 7 computers with RemoteApps configured on them."
+          "description": "Specifies whether the Remote Desktop client should check the remote computer for RemoteApp capabilities.\n\nNote: This setting must be set to 1 when connecting to Windows XP SP3, Vista or 7 computers with RemoteApps configured on them.",
+          "options": {
+            "0": "Check the remote computer for RemoteApp capabilities before logging in.",
+            "1": "Do not check the remote computer for RemoteApp capabilities."
+          }
         },
         "displayconnectionbar__i": {
           "label": "Show the connection bar in full screen mode",
-          "description": "Determines whether the connection bar appears when you are in full screen mode.\n\n0 - Do not show the connection bar.\n1 - Show the connection bar."
+          "description": "Determines whether the connection bar appears when you are in full screen mode.",
+          "options": {
+            "0": "Do not show the connection bar.",
+            "1": "Show the connection bar."
+          }
         },
         "domain__s": {
           "label": "Authentication domain",
@@ -464,23 +561,43 @@
         },
         "dynamic resolution__i": {
           "label": "Update session resolution on resize",
-          "description": "Determines whether the resolution of a remote session is automatically updated when the local window is resized.\n\n0 - Session resolution remains static during the session.\n1 - Session resolution updates as the local window resizes."
+          "description": "Determines whether the resolution of a remote session is automatically updated when the local window is resized.",
+          "options": {
+            "0": "Session resolution remains static during the session.",
+            "1": "Session resolution updates as the local window resizes."
+          }
         },
         "enablecredsspsupport__i": {
           "label": "Use CredSSP for authentication when available",
-          "description": "Determines whether Remote Desktop will use CredSSP for authentication if it's available.\n\n0 - Do not use CredSSP, even if the operating system supports it.\n1 - Use CredSSP, if the operating system supports it."
+          "description": "Determines whether Remote Desktop will use CredSSP for authentication if it's available.",
+          "options": {
+            "0": "Do not use CredSSP, even if the operating system supports it.",
+            "1": "Use CredSSP, if the operating system supports it."
+          }
         },
         "enablerdsaadauth__i": {
           "label": "Use Microsoft Entra ID authentication",
-          "description": "Determines whether the client will use Microsoft Entra ID to authenticate to the remote PC. When used with Azure Virtual Desktop, this provides a single sign-on experience. This property replaces the property targetisaadjoined.\n\n0 - Connections won't use Microsoft Entra authentication, even if the remote PC supports it.\n1 - Connections will use Microsoft Entra authentication if the remote PC supports it."
+          "description": "Determines whether the client will use Microsoft Entra ID to authenticate to the remote PC. When used with Azure Virtual Desktop, this provides a single sign-on experience. This property replaces the property targetisaadjoined.",
+          "options": {
+            "0": "Connections won't use Microsoft Entra authentication, even if the remote PC supports it.",
+            "1": "Connections will use Microsoft Entra authentication if the remote PC supports it."
+          }
         },
         "enablesuperpan__i": {
           "label": "Enable SuperPan",
-          "description": "Determines whether SuperPan is enabled or disabled. SuperPan allows the user to navigate a remote desktop in full-screen mode without scroll bars, when the dimensions of the remote desktop are larger than the dimensions of the current client window. The user can point to the window border, and the desktop view will scroll automatically in that direction.\n\n0 - Do not use SuperPan. The remote session window is sized to the client window size.\n1 - Enable SuperPan. The remote session window is sized to the dimensions specified through /w and /h, or through desktopwidth and desktopheight."
+          "description": "Determines whether SuperPan is enabled or disabled. SuperPan allows the user to navigate a remote desktop in full-screen mode without scroll bars, when the dimensions of the remote desktop are larger than the dimensions of the current client window. The user can point to the window border, and the desktop view will scroll automatically in that direction.",
+          "options": {
+            "0": "Do not use SuperPan. The remote session window is sized to the client window size.",
+            "1": "Enable SuperPan. The remote session window is sized to the dimensions specified through /w and /h, or through desktopwidth and desktopheight."
+          }
         },
         "encode redirected video capture__i": {
           "label": "Encode redirected video",
-          "description": "Enables or disables encoding of redirected video.\n\n0 - Disable encoding of redirected video.\n\n1 - Enable encoding of redirected video."
+          "description": "Enables or disables encoding of redirected video.",
+          "options": {
+            "0": "Disable encoding of redirected video.",
+            "1": "Enable encoding of redirected video."
+          }
         },
         "full address__s": {
           "label": "Terminal server address",
@@ -488,7 +605,12 @@
         },
         "gatewaycredentialssource__i": {
           "label": "Gateway credentials source",
-          "description": "Specifies the credentials that should be used to validate the connection with the RD Gateway.\n\n0 - Ask for password (NTLM).\n1 - Use smart card.\n4 - Allow user to select later."
+          "description": "Specifies the credentials that should be used to validate the connection with the RD Gateway.",
+          "options": {
+            "0": "Ask for password (NTLM).",
+            "1": "Use smart card.",
+            "4": "Allow user to select later."
+          }
         },
         "gatewayhostname__s": {
           "label": "Gateway hostname",
@@ -496,11 +618,22 @@
         },
         "gatewayprofileusagemethod__i": {
           "label": "Use explicit gateway settings",
-          "description": "Determines the RD Gateway authentication method to be used.\n\n0 - Use the default profile mode, as specified by the administrator.\n1 - Use explicit settings."
+          "description": "Determines the RD Gateway authentication method to be used.",
+          "options": {
+            "0": "Use the default profile mode, as specified by the administrator.",
+            "1": "Use explicit settings."
+          }
         },
         "gatewayusagemethod__i": {
           "label": "Gateway usage method",
-          "description": "Specifies if and how to use a Remote Desktop Gateway (RD Gateway) server.\n\n0 - Do not use an RD Gateway server.\n1 - Always use an RD Gateway, even for local connections.\n2 - Use the RD Gateway if a direct connection cannot be made to the remote computer (i.e. bypass for local addresses).\n3 - Use the default RD Gateway settings.\n4 - Do not use an RD Gateway server.\n\n0 and 4 have the same effect, but setting the method to 4 also sets the option for bypassing local addresses in the Remote Desktop user interface."
+          "description": "Specifies if and how to use a Remote Desktop Gateway (RD Gateway) server.\n\n0 and 4 have the same effect, but setting the method to 4 also sets the option for bypassing local addresses in the Remote Desktop user interface.",
+          "options": {
+            "0": "Do not use an RD Gateway server.",
+            "1": "Always use an RD Gateway, even for local connections.",
+            "2": "Use the RD Gateway if a direct connection cannot be made to the remote computer (i.e. bypass for local addresses).",
+            "3": "Use the default RD Gateway settings.",
+            "4": "Do not use an RD Gateway server."
+          }
         },
         "kdcproxyname__s": {
           "label": "Kerberos Key Distribution Center proxy fully qualified domain name",
@@ -508,19 +641,36 @@
         },
         "keyboardhook__i": {
           "label": "Windows key combinations behavior",
-          "description": "Determines how Windows key combinations are applied when you are connected to a remote computer.\n\n0 - Windows key combinations are applied on the local computer.\n1 - Windows key combinations are applied on the remote computer.\n2 - Windows key combinations are applied in full-screen mode only."
+          "description": "Determines how Windows key combinations are applied when you are connected to a remote computer.",
+          "options": {
+            "0": "Windows key combinations are applied on the local computer.",
+            "1": "Windows key combinations are applied on the remote computer.",
+            "2": "Windows key combinations are applied in full-screen mode only."
+          }
         },
         "maximizetocurrentdisplays__i": {
           "label": "Dynamically choose display for full screen on maximize",
-          "description": "Determines which display a remote session uses for full screen on when maximizing. Requires use multimon set to 1. Only available on Windows App for Windows and the Remote Desktop app for Windows.\n\n0 - Session is full screen on the displays initially selected when maximizing.\n1 - Session dynamically is full screen on the displays the session window spans when maximizing."
+          "description": "Determines which display a remote session uses for full screen on when maximizing. Requires use multimon set to 1. Only available on Windows App for Windows and the Remote Desktop app for Windows.",
+          "options": {
+            "0": "Session is full screen on the displays initially selected when maximizing.",
+            "1": "Session dynamically is full screen on the displays the session window spans when maximizing."
+          }
         },
         "negotiate security layer__i": {
           "label": "Use security layer negotiation",
-          "description": "Determines whether the level of security is negotiated or not.\n\n0 - Security layer negotiation is not enabled and the session is started by using Secure Sockets Layer (SSL).\n1 - Security layer negotiation is enabled and the session is started by using x.224 encryption."
+          "description": "Determines whether the level of security is negotiated or not.",
+          "options": {
+            "0": "Security layer negotiation is not enabled and the session is started by using Secure Sockets Layer (SSL).",
+            "1": "Security layer negotiation is enabled and the session is started by using x.224 encryption."
+          }
         },
         "networkautodetect__i": {
           "label": "Use automatic network bandwidth detection",
-          "description": "Determines whether to use automatic network bandwidth detection or not. Requires the option bandwidthautodetect to be set and correlates with connection type 7.\n\n0 - Use automatic network bandwitdh detection.\n1 - Do not use automatic network bandwitdh detection."
+          "description": "Determines whether to use automatic network bandwidth detection or not. Requires the option bandwidthautodetect to be set and correlates with connection type 7.",
+          "options": {
+            "0": "Use automatic network bandwitdh detection.",
+            "1": "Do not use automatic network bandwitdh detection."
+          }
         },
         "password 51__b": {
           "label": "Local encrypted password hash",
@@ -528,59 +678,116 @@
         },
         "pinconnectionbar__i": {
           "label": "Pin the connection bar in full screen mode",
-          "description": "Determines whether or not the connection bar should be pinned to the top of the remote session upon connection when in full screen mode.\n\n0 - The connection bar should not be pinned to the top of the remote session.\n1 - The connection bar should be pinned to the top of the remote session."
+          "description": "Determines whether or not the connection bar should be pinned to the top of the remote session upon connection when in full screen mode.",
+          "options": {
+            "0": "The connection bar should not be pinned to the top of the remote session.",
+            "1": "The connection bar should be pinned to the top of the remote session."
+          }
         },
         "prompt for credentials on client__i": {
           "label": "Prompt for credentials on the client when the server does not support server authentication",
-          "description": "Determines whether Remote Desktop Connection will prompt for credentials when connecting to a server that does not support server authentication.\n\n0 - Remote Desktop will not prompt for credentials.\n1 - Remote Desktop will prompt for credentials."
+          "description": "Determines whether Remote Desktop Connection will prompt for credentials when connecting to a server that does not support server authentication.",
+          "options": {
+            "0": "Remote Desktop will not prompt for credentials.",
+            "1": "Remote Desktop will prompt for credentials."
+          }
         },
         "prompt for credentials__i": {
           "label": "Always prompt for credentials on the server",
-          "description": "Determines whether Remote Desktop Connection will prompt for credentials when connecting to a remote computer for which the credentials have been previously saved.\n\n0 - Remote Desktop will use the saved credentials and will not prompt for credentials.\n1 - Remote Desktop will prompt for credentials."
+          "description": "Determines whether Remote Desktop Connection will prompt for credentials when connecting to a remote computer for which the credentials have been previously saved.",
+          "options": {
+            "0": "Remote Desktop will use the saved credentials and will not prompt for credentials.",
+            "1": "Remote Desktop will prompt for credentials."
+          }
         },
         "promptcredentialonce__i": {
           "label": "Use the same credentials for the entire session",
-          "description": "When connecting through an RD Gateway, determines whether RDC should use the same credentials for both the RD Gateway and the remote computer.\n\n0 - Remote Desktop will not use the same credentials .\n1 - Remote Desktop will use the same credentials for both the RD gateway and the remote computer."
+          "description": "When connecting through an RD Gateway, determines whether RDC should use the same credentials for both the RD Gateway and the remote computer.",
+          "options": {
+            "0": "Remote Desktop will not use the same credentials.",
+            "1": "Remote Desktop will use the same credentials for both the RD gateway and the remote computer."
+          }
         },
         "public mode__i": {
           "label": "Start in public mode",
-          "description": "Determines whether Remote Desktop Connection will be started in public mode.\n\n0 - Remote Desktop will not start in public mode .\n1 - Remote Desktop will start in public mode and will not save any user data (credentials, bitmap cache, MRU) on the local machine."
+          "description": "Determines whether Remote Desktop Connection will be started in public mode.",
+          "options": {
+            "0": "Remote Desktop will not start in public mode.",
+            "1": "Remote Desktop will start in public mode and will not save any user data (credentials, bitmap cache, MRU) on the local machine."
+          }
         },
         "redirectclipboard__i": {
           "label": "Redirect clipboard",
-          "description": "Determines whether the clipboard on the client computer will be redirected and available in the remote session and vice versa.\n\n0 - Do not redirect the clipboard.\n1 - Redirect the clipboard."
+          "description": "Determines whether the clipboard on the client computer will be redirected and available in the remote session and vice versa.",
+          "options": {
+            "0": "Do not redirect the clipboard.",
+            "1": "Redirect the clipboard."
+          }
         },
         "redirectcomports__i": {
           "label": "Redirect COM ports from the client computer",
-          "description": "Determines whether the COM (serial) ports on the client computer will be redirected and available in the remote session.\n\n0 - The COM ports on the local computer are not available in the remote session.\n1 - The COM ports on the local computer are available in the remote session."
+          "description": "Determines whether the COM (serial) ports on the client computer will be redirected and available in the remote session.",
+          "options": {
+            "0": "The COM ports on the local computer are not available in the remote session.",
+            "1": "The COM ports on the local computer are available in the remote session."
+          }
         },
         "redirectdirectx__i": {
           "label": "Enable DirectX rendering",
-          "description": "Determines whether DirectX will be enabled for the remote session.\n\n0 - Do not enable DirectX rendering.\n1 - Enable DirectX rendering in the remote session."
+          "description": "Determines whether DirectX will be enabled for the remote session.",
+          "options": {
+            "0": "Do not enable DirectX rendering.",
+            "1": "Enable DirectX rendering in the remote session."
+          }
         },
         "redirected video capture encoding quality__i": {
           "label": "Video capture encoding quality",
-          "description": "Controls the quality of encoded video.\n\n0 - High compression video. Quality may suffer when there's a lot of motion.\n1 - Medium compression.\n2 - Low compression video with high picture quality."
+          "description": "Controls the quality of encoded video.",
+          "options": {
+            "0": "High compression video. Quality may suffer when there's a lot of motion.",
+            "1": "Medium compression.",
+            "2": "Low compression video with high picture quality."
+          }
         },
         "redirectlocation__i": {
           "label": "Redirect location (address/coordinates) from the client computer",
-          "description": "Determines whether the location of the local device will be redirected and available in the remote session.\n\n0 - The remote session uses the location of the remote computer.\n1 - The remote session uses the location of the local device."
+          "description": "Determines whether the location of the local device will be redirected and available in the remote session.",
+          "options": {
+            "0": "The remote session uses the location of the remote computer.",
+            "1": "The remote session uses the location of the local device."
+          }
         },
         "redirectposdevices__i": {
-          "label": "Redirect Microosft Point of Service devices from the client computer",
-          "description": "Determines whether Microsoft Point of Service (POS) for .NET devices connected to the client computer will be redirected and available in the remote session.\n\n0 - The POS devices from the local computer are not available in the remote session.\n1 - The POS devices from the local computer are available in the remote session."
+          "label": "Redirect Microsoft Point of Service devices from the client computer",
+          "description": "Determines whether Microsoft Point of Service (POS) for .NET devices connected to the client computer will be redirected and available in the remote session.",
+          "options": {
+            "0": "The POS devices from the local computer are not available in the remote session.",
+            "1": "The POS devices from the local computer are available in the remote session."
+          }
         },
         "redirectprinters__i": {
           "label": "Redirect printers from the client computer",
-          "description": "Determines whether printers configured on the client computer will be redirected and available in the remote session.\n\n0 - The printers on the local computer are not available in the remote session.\n1 - The printers on the local computer are available in the remote session."
+          "description": "Determines whether printers configured on the client computer will be redirected and available in the remote session.",
+          "options": {
+            "0": "The printers on the local computer are not available in the remote session.",
+            "1": "The printers on the local computer are available in the remote session."
+          }
         },
         "redirectsmartcards__i": {
           "label": "Redirect smart cards from the client computer",
-          "description": "Determines whether smart card devices on the client computer will be redirected and available in the remote session.\n\n0 - The smart card device on the local computer is not available in the remote session.\n1 - The smart card device on the local computer is available in the remote session."
+          "description": "Determines whether smart card devices on the client computer will be redirected and available in the remote session.",
+          "options": {
+            "0": "The smart card device on the local computer is not available in the remote session.",
+            "1": "The smart card device on the local computer is available in the remote session."
+          }
         },
         "redirectwebauthn__i": {
           "label": "Redirect WebAuthn requests to the local computer",
-          "description": "Determines whether WebAuthn requests on the remote computer will be redirected to the local computer allowing the use of local authenticators (such as Windows Hello for Business and security key).\n\n0 - WebAuthn requests from the remote session aren't sent to the local computer for authentication and must be completed in the remote session.\n1 - WebAuthn requests from the remote session are sent to the local computer for authentication."
+          "description": "Determines whether WebAuthn requests on the remote computer will be redirected to the local computer allowing the use of local authenticators (such as Windows Hello for Business and security key).",
+          "options": {
+            "0": "WebAuthn requests from the remote session aren't sent to the local computer for authentication and must be completed in the remote session.",
+            "1": "WebAuthn requests from the remote session are sent to the local computer for authentication."
+          }
         },
         "remoteapplicationcmdline__s": {
           "label": "Command-line parameters",
@@ -588,11 +795,19 @@
         },
         "remoteapplicationexpandcmdline__i": {
           "label": "Command-line parameters environment variable expansion mode",
-          "description": "Determines whether environment variables contained in the RemoteApp command line parameter should be expanded locally or remotely.\n\n0 - Environment variables should be expanded to the values of the local computer.\n1 - Environment variables should be expanded on the remote computer to the values of the remote computer."
+          "description": "Determines whether environment variables contained in the RemoteApp command line parameter should be expanded locally or remotely.",
+          "options": {
+            "0": "Environment variables should be expanded to the values of the local computer.",
+            "1": "Environment variables should be expanded on the remote computer to the values of the remote computer."
+          }
         },
         "remoteapplicationexpandworkingdir__i": {
           "label": "Working directory environment variable expansion mode",
-          "description": "Determines whether environment variables contained in the RemoteApp working directory parameter should be expanded locally or remotely.\n\n0 - Environment variables should be expanded to the values of the local computer.\n1 - Environment variables should be expanded on the remote computer to the values of the remote computer.\n\nNote: The RemoteApp working directory is specified through the shell working directory parameter."
+          "description": "Determines whether environment variables contained in the RemoteApp working directory parameter should be expanded locally or remotely.\n\nNote: The RemoteApp working directory is specified through the shell working directory parameter.",
+          "options": {
+            "0": "Environment variables should be expanded to the values of the local computer.",
+            "1": "Environment variables should be expanded on the remote computer to the values of the remote computer."
+          }
         },
         "remoteapplicationfile__s": {
           "label": "Launch file",
@@ -608,7 +823,11 @@
         },
         "remoteapplicationmode__i": {
           "label": "Use RemoteApp",
-          "description": "Determines whether a RemoteApp shoud be launched when connecting to the remote computer.\n\n0 - Use a normal session and do not start a RemoteApp.\n1 - Connect and launch a RemoteApp."
+          "description": "Determines whether a RemoteApp shoud be launched when connecting to the remote computer.",
+          "options": {
+            "0": "Use a normal session and do not start a RemoteApp.",
+            "1": "Connect and launch a RemoteApp."
+          }
         },
         "remoteapplicationname__s": {
           "label": "Display name",
@@ -620,7 +839,11 @@
         },
         "screen mode id__i": {
           "label": "Screen mode",
-          "description": "Determines whether the remote session window appears full screen when you connect to the remote computer.\n\n1 - The remote session will appear in a window.\n2 - The remote session will appear full screen."
+          "description": "Determines whether the remote session window appears full screen when you connect to the remote computer.",
+          "options": {
+            "1": "The remote session will appear in a window.",
+            "2": "The remote session will appear full screen."
+          }
         },
         "selectedmonitors__s": {
           "label": "Selected monitor for multi-monitor support",
@@ -632,7 +855,14 @@
         },
         "session bpp__i": {
           "label": "Color depth (bits per pixel)",
-          "description": "Determines the color depth (in bits) on the remote computer when you connect.\n\n8 - 256 colors (8 bit).\n15 - High color (15 bit).\n16 - High color (16 bit).\n24 - True color (24 bit).\n32 - Highest quality (32 bit)."
+          "description": "Determines the color depth (in bits) on the remote computer when you connect.",
+          "options": {
+            "8": "256 colors (8 bit).",
+            "15": "High color (15 bit).",
+            "16": "High color (16 bit).",
+            "24": "True color (24 bit).",
+            "32": "Highest quality (32 bit)."
+          }
         },
         "shell working directory__s": {
           "label": "Alternate shell working directory",
@@ -648,23 +878,39 @@
         },
         "singlemoninwindowedmode__i": {
           "label": "Switch to single-monitor mode when exiting full screen",
-          "description": "Determines whether a multi display remote session automatically switches to single display when exiting full screen. Requires use multimon set to 1. Only available on Windows App for Windows and the Remote Desktop app for Windows.\n\n0 - A remote session retains all displays when exiting full screen.\n1 - A remote session switches to a single display when exiting full screen."
+          "description": "Determines whether a multi display remote session automatically switches to single display when exiting full screen. Requires use multimon set to 1. Only available on Windows App for Windows and the Remote Desktop app for Windows.",
+          "options": {
+            "0": "A remote session retains all displays when exiting full screen.",
+            "1": "A remote session switches to a single display when exiting full screen."
+          }
         },
         "smart sizing__i": {
           "label": "Enable smart sizing",
-          "description": "Determines whether the client computer should scale the content on the remote computer to fit the window size of the client computer when the window is resized.\n\n0 - The client window display will not be scaled when resized.\n1 - The client window display will be scaled when resized."
+          "description": "Determines whether the client computer should scale the content on the remote computer to fit the window size of the client computer when the window is resized.",
+          "options": {
+            "0": "The client window display will not be scaled when resized.",
+            "1": "The client window display will be scaled when resized."
+          }
         },
         "span monitors__i": {
           "label": "Allow spanning multiple monitors",
-          "description": "Determines whether the remote session window will be spanned across multiple monitors when you connect to the remote computer.\n\n0 - Monitor spanning is not enabled.\n1 - Monitor spanning is enabled.\n\nNote: When using Remote Desktop Connection 7 (Windows 7/2008), the use multimon setting is recommended."
+          "description": "Determines whether the remote session window will be spanned across multiple monitors when you connect to the remote computer.\n\nNote: When using Remote Desktop Connection 7 (Windows 7/2008), the use multimon setting is recommended.",
+          "options": {
+            "0": "Monitor spanning is not enabled.",
+            "1": "Monitor spanning is enabled."
+          }
         },
         "superpanaccelerationfactor__i": {
           "label": "SuperPan mode acceleration factor",
           "description": "Specifies the number of pixels that the screen view scrolls in a given direction for every pixel of mouse movement by the client when in SuperPan mode"
         },
         "targetisaadjoined__i": {
-          "label": "Allow connections to Microosft Entra-joined session hosts (legacy)",
-          "description": "Allows connections to Microsoft Entra joined session hosts using a username and password. This property is only applicable to non-Windows clients and local Windows devices that aren't joined to Microsoft Entra.\n\n0 - Connections to Microsoft Entra joined session hosts will succeed for Windows devices that meet the requirements, but other connections will fail.\n1 - Connections to Microsoft Entra joined hosts will succeed but are restricted to entering user name and password credentials when connecting to session hosts.\n\nNote: This property is being replaced by enablerdsaadauth."
+          "label": "Allow connections to Microsoft Entra-joined session hosts (legacy)",
+          "description": "Allows connections to Microsoft Entra joined session hosts using a username and password. This property is only applicable to non-Windows clients and local Windows devices that aren't joined to Microsoft Entra.\n\nNote: This property is being replaced by enablerdsaadauth.",
+          "options": {
+            "0": "Connections to Microsoft Entra joined session hosts will succeed for Windows devices that meet the requirements, but other connections will fail.",
+            "1": "Connections to Microsoft Entra joined hosts will succeed but are restricted to entering user name and password credentials when connecting to session hosts."
+          }
         },
         "usbdevicestoredirect__s": {
           "label": "RemoteFX USB device support mode",
@@ -672,7 +918,11 @@
         },
         "use multimon__i": {
           "label": "Support multiple monitors",
-          "description": "Determines whether the session should use true multiple monitor support when connecting to the remote computer.\n\n0 - Do not enable multiple monitor support.\n1 - Enable multiple monitor support."
+          "description": "Determines whether the session should use true multiple monitor support when connecting to the remote computer.",
+          "options": {
+            "0": "Do not enable multiple monitor support.",
+            "1": "Enable multiple monitor support."
+          }
         },
         "username__s": {
           "label": "Username",
@@ -680,7 +930,11 @@
         },
         "videoplaybackmode__i": {
           "label": "Video playback mode",
-          "description": "Determines whether RDC will use RDP efficient multimedia streaming for video playback.\n\n0 - Do not use RDP efficient multimedia streaming for video playback.\n1 - Use RDP efficient multimedia streaming for video playback when possible."
+          "description": "Determines whether RDC will use RDP efficient multimedia streaming for video playback.",
+          "options": {
+            "0": "Do not use RDP efficient multimedia streaming for video playback.",
+            "1": "Use RDP efficient multimedia streaming for video playback when possible."
+          }
         },
         "winposstr__s": {
           "label": "Session window position string",


### PR DESCRIPTION
For RDP properties that only accept specific integer values, we now provide a dropdown with the value descriptions rather than an empty text box. The dropdowns will still set the numerical values in the file. This makes it easier to change these values with confidence.

<img width="600" height="536" alt="" src="https://github.com/user-attachments/assets/c39394a1-11fe-40fa-baba-cf36cf93b6a5" />