### PR TITLE
Expose router and all RAWeb components to App_Data/inject/index.js

### DIFF
--- a/dotnet/RAWebServer/src/api/inject/Controller.cs
+++ b/dotnet/RAWebServer/src/api/inject/Controller.cs
@@ -1,0 +1,7 @@
+using System.Web.Http;
+
+namespace RAWebServer.Api {
+  [RoutePrefix("api/inject")]
+  public partial class InjectFolderFilesController : ApiController {
+  }
+}

--- a/dotnet/RAWebServer/src/api/inject/GetFile.cs
+++ b/dotnet/RAWebServer/src/api/inject/GetFile.cs
@@ -1,0 +1,44 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Web;
+using System.Web.Http;
+using RAWeb.Server.Utilities;
+
+namespace RAWebServer.Api {
+  public partial class InjectFolderFilesController : ApiController {
+    [HttpGet]
+    [Route("file/{*relativeFilePath}")]
+    [RequireAuthentication]
+    public IHttpActionResult GetImage(string relativeFilePath) {
+      // get authentication information
+      var userInfo = UserInformation.FromHttpRequestSafe(HttpContext.Current.Request);
+
+      if (string.IsNullOrEmpty(relativeFilePath) || string.IsNullOrEmpty(relativeFilePath)) {
+        return BadRequest("Missing relative file path parameter.");
+      }
+
+      var rootedFilePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "App_Data", "inject", "filestore", relativeFilePath);
+      if (!File.Exists(rootedFilePath)) {
+        return NotFound();
+      }
+
+      // check whether the user has access to the file
+      var hasPermission = FileAccessInfo.CanAccessPath(rootedFilePath, userInfo, out var permissionHttpStatus);
+      if (!hasPermission) {
+        return ResponseMessage(Request.CreateResponse(permissionHttpStatus));
+      }
+
+      // serve the file with the correct content type
+      var fileBytes = File.ReadAllBytes(rootedFilePath);
+      var contentType = MimeMapping.GetMimeMapping(rootedFilePath);
+      var result = new HttpResponseMessage(HttpStatusCode.OK) {
+        Content = new ByteArrayContent(fileBytes)
+      };
+      result.Content.Headers.ContentType = new MediaTypeHeaderValue(contentType);
+      return ResponseMessage(result);
+    }
+  }
+}

--- a/dotnet/RAWebServer/src/api/inject/ListFiles.cs
+++ b/dotnet/RAWebServer/src/api/inject/ListFiles.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.IO;
+using System.Linq;
+using System.Web;
+using System.Web.Http;
+using Microsoft.Win32;
+using RAWeb.Server.Management;
+using RAWeb.Server.Utilities;
+
+namespace RAWebServer.Api {
+  public partial class InjectFolderFilesController : ApiController {
+    [HttpGet]
+    [Route("list-files")]
+    [RequireAuthentication]
+    public IHttpActionResult ListFiles() {
+      var userInfo = UserInformation.FromHttpRequestSafe(HttpContext.Current.Request);
+
+      var filestoreFolderPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "App_Data", "inject", "filestore");
+      if (!Directory.Exists(filestoreFolderPath)) {
+        return Ok(new object[0]);
+      }
+
+      var controllerPathname = new Uri(Url.Content("~/api/inject/file/"), UriKind.Absolute).AbsolutePath;
+
+      var files = Directory.GetFiles(filestoreFolderPath, "*", SearchOption.AllDirectories)
+        .Where(filePath => FileAccessInfo.CanAccessPath(filePath, userInfo))
+        .Select(filePath => {
+          var relativePath = filePath
+            .Substring(filestoreFolderPath.Length)
+            .TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+            .Replace('\\', '/');
+          var url = controllerPathname + relativePath.Replace('\\', '/');
+
+          var mimeType = MimeMapping.GetMimeMapping(filePath);
+          var mimeTypeLabel = GetFileTypeLabel(filePath);
+
+          var dateModified = File.GetLastWriteTimeUtc(filePath);
+
+          // Use the URL from .url files instead of the URL to the file path
+          if (mimeType == "application/octet-stream" && Path.GetExtension(filePath).Equals(".url", StringComparison.OrdinalIgnoreCase)) {
+            try {
+              var lines = File.ReadAllLines(filePath);
+              var urlLine = lines.FirstOrDefault(line => line.StartsWith("URL=", StringComparison.OrdinalIgnoreCase));
+              if (urlLine != null) {
+                url = urlLine.Substring(4).Trim();
+                mimeType = "text/url";
+              }
+            }
+            catch {
+            }
+          }
+
+          return new {
+            name = Path.GetFileNameWithoutExtension(filePath),
+            url,
+            mimeType,
+            fileType = mimeTypeLabel,
+            dateModified,
+            icon = GetShellIconDataUrl(filePath)
+          };
+        })
+        .ToArray();
+
+      return Ok(files);
+    }
+
+    private static string GetShellIconDataUrl(string filePath) {
+      try {
+        using (var icon = Icon.ExtractAssociatedIcon(filePath))
+        using (var bitmap = icon.ToBitmap())
+        using (var stream = new MemoryStream()) {
+          bitmap.Save(stream, ImageFormat.Png);
+          return "data:image/png;base64," + Convert.ToBase64String(stream.ToArray());
+        }
+      }
+      catch {
+        return null;
+      }
+    }
+
+    private string GetFileTypeLabel(string filePath) {
+      var ext = Path.GetExtension(filePath).ToLower();
+
+      using var key = Registry.ClassesRoot.OpenSubKey(ext);
+      if (key?.GetValue(null) is not string progId) {
+        return ext;
+      }
+
+      using var progKey = Registry.ClassesRoot.OpenSubKey(progId);
+      return progKey?.GetValue(null) as string ?? progId;
+    }
+  }
+}

--- a/frontend/docs/(development)/custom-content/index.md
+++ b/frontend/docs/(development)/custom-content/index.md
@@ -10,6 +10,7 @@ RAWeb allows administrators to inject custom CSS and JavaScript into the web app
 </InfoBar>
 
 To inject custom content, create the following files in the `App_Data/inject` folder:
+
 - `index.css`: This file can contain custom CSS styles that will be applied to the RAWeb web application.
 - `index.js`: This file can contain custom JavaScript code that will be executed in the context of the RAWeb web application.
 
@@ -17,20 +18,27 @@ Once these files are placed in the `App_Data/inject` folder, RAWeb will automati
 
 For example, you could use `index.css` to change the color scheme of the RAWeb interface, or use `index.js` to add custom functionality such as additional logging or user interface enhancements.
 
-## Example: Hide the wiki button from the navigation bar
+### Jump to an example
+
+- [Hide the wiki button from the navigation bar](#ex-hide-wiki-button)
+- [Use iris spring accent color](#ex-accent-color)
+- [Add Google Analytics tracking](#ex-analytics)
+- [Replace the titlebar logo](#ex-titlebar-logo)
+- [Add a list of files and links that change based on user permissions](#ex-filestore)
+
+## Example: Hide the wiki button from the navigation bar {#ex-hide-wiki-button}
 
 To hide the "Docs" button from the navigation bar, you can create an `index.css` file in the `App_Data/inject` folder with the following content:
 
 ```css
-.nav-rail a[href="/docs"] {
+.nav-rail a[href='/docs'] {
   display: none;
 }
 ```
 
 This CSS rule targets the anchor element that links to the documentation page and sets its display property to `none`, effectively hiding it from view.
 
-
-## Example: Use iris spring accent color
+## Example: Use iris spring accent color {#ex-accent-color}
 
 To change the accent color of RAWeb to match the iris spring theme, create an `index.css` file in the `App_Data/inject` folder with the following content:
 
@@ -60,7 +68,7 @@ To change the accent color of RAWeb to match the iris spring theme, create an `i
 }
 ```
 
-## Example: Add Google Analytics tracking
+## Example: Add Google Analytics tracking {#ex-analytics}
 
 To add Google Analytics tracking to RAWeb, create an `index.js` file in the `App_Data/inject` folder with the following content, replacing `G-XXXXXXXXXX` with your actual Google Analytics tag ID:
 
@@ -94,13 +102,13 @@ function injectGoogleAnalytics(tag) {
 injectGoogleAnalytics('G-XXXXXXXXXX');
 ```
 
-## Example: Replace the titlebar logo
+## Example: Replace the titlebar logo {#ex-titlebar-logo}
 
 To replace the RAWeb logo in the titlebar with a custom logo, create an `index.css` file in the `App_Data/inject` folder with the following content, replacing the URL with the path to your custom logo image:
 
 ```css
 :root {
-  --logo-url: url("/lib/assets/default.ico");
+  --logo-url: url('/lib/assets/default.ico');
 }
 
 /* replace header logo */
@@ -108,7 +116,7 @@ To replace the RAWeb logo in the titlebar with a custom logo, create an `index.c
   display: none;
 }
 .app-header .left::before {
-  content: "";
+  content: '';
   display: inline-block;
   width: 16px;
   height: 16px;
@@ -129,5 +137,245 @@ To replace the RAWeb logo in the titlebar with a custom logo, create an `index.c
   background-repeat: no-repeat;
   background-position: center;
 }
+```
 
+## Example: Add a list of files and links that change based on user permissions {#ex-filestore}
+
+To add a page that shows a list of files and links that change based on user permissions, you can create an `index.js` file in the `App_Data/inject` folder with the following code snippet.
+
+This example uses RAWeb's component library and router to create a new page at the `/filestore` route and adds a link to that page in the navigation rail. It uses the same header, filter & search UI, and grid item components that are used in the built-in **Apps** and **Devices** pages to ensure a consistent user experience.
+
+The files and links shown on the page are fetched from the filestore API endpoint (`/api/inject/list-files`) that lists files from the **App_Data/inject/filestore** folder on the server. You can customize the files shown to different users by controlling Windows file system permissions on the **filestore** folder and its contents.
+
+```javascript
+window.addEventListener('RAWebReady', async ({ detail: raweb }) => {
+  // Add a new route for out custom page.
+  const FilesAndShortcuts = createFilesAndShortcutsPageComponent(raweb);
+  raweb.router.addRoute('/', {
+    path: '/filestore',
+    component: FilesAndShortcuts,
+  });
+
+  // Re-evaluate the current route to ensure the new route is recognized if we're already on the page
+  raweb.router.replace(raweb.router.currentRoute.value.fullPath);
+});
+
+window.addEventListener('RAWebAppMounted', async ({ detail: raweb }) => {
+  // Inject a link in the navigation rail
+  const navRailElement = document.querySelector('.nav-rail > nav > ul');
+  if (navRailElement) {
+    const container = document.createElement('li');
+    const Component = createFilesAndShortcutsNavRailLinkComponent(raweb);
+    const subApp = raweb.vue.createApp(Component);
+    subApp.use(raweb.router);
+    subApp.mount(container);
+    navRailElement.appendChild(container);
+  }
+});
+
+function createFilesAndShortcutsPageComponent(raweb) {
+  const { createHeaderActionModelRefs, GenericCard, HeaderActions, ResourceGrid, TextBlock } = raweb.components;
+  const { h, ref, computed } = raweb.vue;
+  const { useCoreDataStore, usePopupWindow } = raweb.stores;
+
+  return {
+    setup() {
+      const {
+        mode, // the view mode (list, card, etc)
+        sortName, // Name or Date modified
+        sortOrder, // asc or desc
+        query, // the search query
+      } = createHeaderActionModelRefs({
+        defaults: { mode: 'tile' },
+        persist: 'files', // preferences for this page will be stored under "files" key in localStorage
+      });
+
+      const coreAppData = useCoreDataStore();
+      const { openWindow } = usePopupWindow();
+
+      // fetch a list of files from the server and store in state
+      const files = ref([]);
+      const fetchError = ref(null);
+      const fetching = ref(true);
+      fetch(coreAppData.iisBase + 'api/inject/list-files')
+        .then((res) => res.json())
+        .then((data) => {
+          files.value = data;
+        })
+        .catch((error) => {
+          fetchError.value = 'Failed to fetch files';
+          console.error('Error fetching files:', error);
+        })
+        .finally(() => {
+          fetching.value = false;
+        });
+
+      // adjusted list of files based on the current sort and search query
+      const sortedAndFilteredFiles = computed(() => {
+        let result = [...files.value];
+        if (query.value) {
+          const lowerQuery = query.value.toLowerCase();
+          result = result.filter(
+            (file) =>
+              file.name.toLowerCase().includes(lowerQuery) || file.fileType.toLowerCase().includes(lowerQuery)
+          );
+        }
+        if (sortName.value === 'Name' || sortName.value === '') {
+          result.sort((a, b) => {
+            const aValue = a.name || '';
+            const bValue = b.name || '';
+            if (aValue < bValue) return sortOrder.value === 'asc' ? -1 : 1;
+            if (aValue > bValue) return sortOrder.value === 'asc' ? 1 : -1;
+            return 0;
+          });
+        }
+        if (sortName.value === 'Date modified') {
+          result.sort((a, b) => {
+            const aValue = new Date(a.dateModified).getTime();
+            const bValue = new Date(b.dateModified).getTime();
+            if (aValue < bValue) return sortOrder.value === 'asc' ? -1 : 1;
+            if (aValue > bValue) return sortOrder.value === 'asc' ? 1 : -1;
+            return 0;
+          });
+        }
+        return result;
+      });
+
+      return {
+        mode,
+        sortName,
+        sortOrder,
+        query,
+        openWindow,
+        files: {
+          data: sortedAndFilteredFiles,
+          loading: fetching,
+          error: fetchError,
+        },
+      };
+    },
+    render() {
+      return h('div', { style: { userSelect: 'none' } }, [
+        h('div', [
+          h(TextBlock, { variant: 'title', tag: 'h1' }, 'Files & shortcuts'),
+          h(HeaderActions, {
+            mode: this.mode,
+            'onUpdate:mode': (val) => (this.mode = val),
+            sortName: this.sortName,
+            'onUpdate:sortName': (val) => (this.sortName = val),
+            sortOrder: this.sortOrder,
+            'onUpdate:sortOrder': (val) => (this.sortOrder = val),
+            query: this.query,
+            'onUpdate:query': (val) => (this.query = val),
+            searchPlaceholder: 'Search files and shortcuts',
+          }),
+        ]),
+        h('section', { style: { margin: '24px 0 8px 0', paddingBottom: '36px' } }, [
+          this.files.loading.value
+            ? h(TextBlock, 'Loading files...')
+            : this.files.error.value
+              ? h(TextBlock, { style: { color: 'var(--color-error)' } }, this.files.error)
+              : h(ResourceGrid, { mode: this.mode, style: { gap: '16px' } }, [
+                  this.files.data.value?.map((file) => {
+                    const isExternal = file.url.startsWith('http://') || file.url.startsWith('https://');
+
+                    return h(
+                      'a',
+                      {
+                        href: file.url,
+                        target: isExternal ? '_blank' : '_self',
+                        style: {
+                          textDecoration: 'none',
+                          borderRadius: 'var(--wui-control-corner-radius)',
+                        },
+                        onclick: (evt) => {
+                          if (!isExternal) {
+                            evt.preventDefault();
+                            this.openWindow(file.url, file.name, 'width=1200,height=1000,menubar=0,status=0');
+                          }
+                        },
+                      },
+                      h(GenericCard, {
+                        mode: this.mode,
+                        title: file.name,
+                        caption: file.fileType,
+                        icon: file.icon,
+                        style: { height: '100%' },
+                      })
+                    );
+                  }),
+                ]),
+        ]),
+      ]);
+    },
+  };
+}
+
+function createFilesAndShortcutsNavRailLinkComponent(raweb) {
+  const { RailButton, RouterLink } = raweb.components;
+  const { h } = raweb.vue;
+
+  return {
+    render() {
+      return h(
+        RouterLink,
+        {
+          to: '/filestore',
+          custom: true,
+        },
+
+        ({ href, isActive, navigate }) =>
+          h(
+            RailButton,
+            {
+              href,
+              active: isActive,
+              onClick: navigate,
+            },
+            {
+              icon: () =>
+                h(
+                  'svg',
+                  {
+                    width: '24',
+                    height: '24',
+                    fill: 'none',
+                    viewBox: '0 0 24 24',
+                    xmlns: 'http://www.w3.org/2000/svg',
+                  },
+                  h('path', {
+                    d: 'M12.04 6.017a4.75 4.75 0 1 0 .335-.012h-.01a1.35 1.35 0 0 0-.326.012Zm-1.622 1.835c-.226.677-.368 1.506-.407 2.398h-1.1a3.5 3.5 0 0 1 1.507-2.398Zm-.374 3.898a8.43 8.43 0 0 0 .379 1.91 3.507 3.507 0 0 1-1.405-1.91h1.026Zm3.966 2.1.003-.008c.22-.587.373-1.306.443-2.092h1.276a3.51 3.51 0 0 1-1.722 2.1Zm-1.061-2.1c-.065.618-.187 1.154-.34 1.565-.118.313-.24.514-.336.623a.914.914 0 0 1-.023.025.914.914 0 0 1-.023-.025c-.097-.11-.218-.31-.335-.623-.154-.41-.276-.947-.341-1.565h1.398Zm.039-1.5h-1.476c.042-.828.185-1.547.38-2.065.117-.313.238-.514.335-.623a.79.79 0 0 1 .023-.025.79.79 0 0 1 .023.025c.097.11.218.31.335.623.195.518.338 1.237.38 2.065Zm1.501 0c-.043-.978-.21-1.88-.475-2.588a3.503 3.503 0 0 1 1.825 2.588h-1.35Zm-2.182-2.76-.004.002.004-.003Zm-.113 0 .003.002a.014.014 0 0 0-.004-.003l.001.001Z',
+                    fill: 'currentColor',
+                  }),
+                  h('path', {
+                    d: 'M6.5 2A2.5 2.5 0 0 0 4 4.5v15A2.5 2.5 0 0 0 6.5 22h13.25a.75.75 0 0 0 0-1.5H6.5a1 1 0 0 1-1-1h14.25a.75.75 0 0 0 .75-.75V4.5A2.5 2.5 0 0 0 18 2H6.5ZM19 4.5V18H5.5V4.5a1 1 0 0 1 1-1H18a1 1 0 0 1 1 1Z',
+                    fill: 'currentColor',
+                  })
+                ),
+              'icon-active': () =>
+                h(
+                  'svg',
+                  {
+                    width: '24',
+                    height: '24',
+                    fill: 'none',
+                    viewBox: '0 0 24 24',
+                    xmlns: 'http://www.w3.org/2000/svg',
+                  },
+                  h('path', {
+                    d: 'M12.04 6.017a4.75 4.75 0 1 0 .335-.012h-.01a1.35 1.35 0 0 0-.326.012Zm-1.622 1.835c-.226.677-.368 1.506-.407 2.398h-1.1a3.5 3.5 0 0 1 1.507-2.398Zm-.374 3.898a8.43 8.43 0 0 0 .379 1.91 3.507 3.507 0 0 1-1.405-1.91h1.026Zm3.966 2.1.003-.008c.22-.587.373-1.306.443-2.092h1.276a3.51 3.51 0 0 1-1.722 2.1Zm-1.061-2.1c-.065.618-.187 1.154-.34 1.565-.118.313-.24.514-.336.623a.914.914 0 0 1-.023.025.914.914 0 0 1-.023-.025c-.097-.11-.218-.31-.335-.623-.154-.41-.276-.947-.341-1.565h1.398Zm.039-1.5h-1.476c.042-.828.185-1.547.38-2.065.117-.313.238-.514.335-.623a.79.79 0 0 1 .023-.025.79.79 0 0 1 .023.025c.097.11.218.31.335.623.195.518.338 1.237.38 2.065Zm1.501 0c-.043-.978-.21-1.88-.475-2.588a3.503 3.503 0 0 1 1.825 2.588h-1.35Zm-2.182-2.76-.004.002.004-.003Zm-.113 0 .003.002a.014.014 0 0 0-.004-.003l.001.001Z',
+                    fill: 'currentColor',
+                  }),
+                  h('path', {
+                    d: 'M6.5 2A2.5 2.5 0 0 0 4 4.5v15A2.5 2.5 0 0 0 6.5 22h13.25a.75.75 0 0 0 0-1.5H6.5a1 1 0 0 1-1-1h14.25a.75.75 0 0 0 .75-.75V4.5A2.5 2.5 0 0 0 18 2H6.5ZM19 4.5V18H5.5V4.5a1 1 0 0 1 1-1H18a1 1 0 0 1 1 1Z',
+                    fill: 'currentColor',
+                  })
+                ),
+              default: () => 'Files & shortcuts',
+            }
+          )
+      );
+    },
+  };
+}
 ```

--- a/frontend/lib/components/ItemCard/GenericCard.vue
+++ b/frontend/lib/components/ItemCard/GenericCard.vue
@@ -1,115 +1,33 @@
 <script setup lang="ts">
-  import { useCoreDataStore } from '$stores';
-  import { raw } from '$utils';
-  import { computed, onMounted, onUnmounted, ref, useTemplateRef } from 'vue';
-  import GenericCard from './GenericCard.vue';
-  import GenericResourceCardMenuButton from './GenericResourceCardMenuButton.vue';
+  import { TextBlock } from '$components';
+  import { iconBackgroundsEnabled } from '$utils';
 
-  const { terminalServerAliases } = useCoreDataStore();
-
-  type Resource = NonNullable<
-    Awaited<ReturnType<typeof import('$utils').getAppsAndDevices>>
-  >['resources'][number];
-
-  const { resource, mode = 'card' } = defineProps<{
-    resource: Resource;
+  const { mode = 'card' } = defineProps<{
     mode?: 'card' | 'list' | 'grid' | 'tile';
-  }>();
-
-  const theme = ref(window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
-  const updateTheme = () => {
-    theme.value = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-  };
-  onMounted(() => {
-    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
-    mediaQuery.addEventListener('change', updateTheme);
-  });
-  onUnmounted(() => {
-    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
-    mediaQuery.removeEventListener('change', updateTheme);
-  });
-
-  const icon = computed(() => {
-    const icons = resource.icons.filter((icon) => icon.type === 'png');
-    if (icons.length > 0) {
-      const url = new URL(icons[0].url.href);
-      url.searchParams.set('format', 'png'); // ensure we get the highest quality png icon
-      if (theme.value === 'dark') {
-        url.searchParams.set('theme', 'dark');
-      }
-      return url.href;
-    }
-  });
-
-  const hostname = computed(() => {
-    if (resource.hosts.length > 1) {
-      return 'Multiple devices';
-    }
-    return resource.hosts[0]?.name || 'Unknown device';
-  });
-
-  const _menu = useTemplateRef<typeof GenericResourceCardMenuButton>('menu');
-  const connect = computed(() => raw(_menu.value)?.connect);
-
-  function handleRightClick(evt: MouseEvent) {
-    evt.preventDefault();
-    const actualMenuButton = (evt.currentTarget as HTMLElement | undefined)?.querySelector(
-      '.actual-menu-button'
-    );
-    if (actualMenuButton) {
-      // @ts-expect-error pointerType is valid in many browsers
-      const pointerType = evt.pointerType || 'mouse';
-      // @ts-expect-error pointerType is valid in many browsers
-      actualMenuButton.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, pointerType }));
-    }
-  }
-
-  const cardElem = ref<HTMLElement | null>(null);
-  function handleKeyDown(evt: KeyboardEvent) {
-    if (evt.target !== cardElem.value) {
-      return;
-    }
-
-    if (evt.key === 'Enter' || evt.key === ' ') {
-      evt.preventDefault();
-      connect.value();
-    }
-  }
-
-  function requestWorkspaceRefresh() {
-    emit('requestWorkspaceRefresh');
-  }
-
-  const emit = defineEmits<{
-    (e: 'requestWorkspaceRefresh'): void;
+    icon?: string;
+    title: string;
+    caption: string;
   }>();
 </script>
 
 <template>
-  <GenericCard
-    :mode="mode"
-    :icon="icon"
-    :title="resource.title"
-    :caption="terminalServerAliases[hostname] ?? hostname"
-    @click.stop="connect"
-    @keydown="handleKeyDown"
-    tabIndex="0"
-    @contextmenu="handleRightClick"
-    ref="cardElem"
-  >
-    <template #menu>
-      <div :class="`menu-button mode-${mode}`">
-        <GenericResourceCardMenuButton
-          :resource="resource"
-          placement="bottom"
-          ref="menu"
-          @click.stop
-          class="actual-menu-button"
-          @requestWorkspaceRefresh="requestWorkspaceRefresh"
-        />
+  <article :class="`mode-${mode}`">
+    <div class="icon-wrapper" :class="`mode-${mode}`">
+      <div class="banner-background-wrapper">
+        <div class="banner-background" :style="`background-image: url('${icon}')`"></div>
       </div>
-    </template>
-  </GenericCard>
+      <img :src="icon" alt="" :class="{ withBackground: mode === 'card' && iconBackgroundsEnabled }" />
+    </div>
+    <div class="bottom-area" :class="`mode-${mode}`">
+      <div class="labels">
+        <TextBlock tag="h1" variant="bodyStrong" class="app-name">{{ title }}</TextBlock>
+        <TextBlock variant="caption">
+          {{ caption }}
+        </TextBlock>
+      </div>
+    </div>
+    <slot name="menu"></slot>
+  </article>
 </template>
 
 <style scoped>
@@ -329,16 +247,5 @@
   }
   :where(.icon-wrapper.mode-list, .icon-wrapper.mode-tile) img.withBackground {
     inline-size: 24px;
-  }
-
-  .menu-button.mode-card,
-  .menu-button.mode-grid {
-    position: absolute !important;
-    top: 0;
-    right: 0;
-    opacity: 0;
-  }
-  :is(article:hover) .menu-button {
-    opacity: 1;
   }
 </style>

--- a/frontend/lib/components/Layout/HeaderActions.vue
+++ b/frontend/lib/components/Layout/HeaderActions.vue
@@ -24,11 +24,11 @@
 
   const {
     searchPlaceholder = 'Search',
-    data,
+    data: workspaceData,
     resourceTypes = ['RemoteApp', 'Desktop'],
   } = defineProps<{
     searchPlaceholder?: string;
-    data: Awaited<ReturnType<typeof getAppsAndDevices>>;
+    data?: Awaited<ReturnType<typeof getAppsAndDevices>>;
     resourceTypes?: ('RemoteApp' | 'Desktop')[];
   }>();
 
@@ -39,10 +39,10 @@
   const query = defineModel<string>('query', { required: true });
 
   const resourcesOfType = terminalServersFilter
-    ? data.resources.filter((resource) => resourceTypes.includes(resource.type))
+    ? workspaceData?.resources.filter((resource) => resourceTypes.includes(resource.type))
     : [];
   const allTerminalServers = Array.from(
-    new Set(resourcesOfType.map((resource) => resource.hosts.map((host) => host.id)).flat())
+    new Set(resourcesOfType?.map((resource) => resource.hosts.map((host) => host.id)).flat())
   );
 </script>
 
@@ -62,6 +62,7 @@
             {{ $t('actions.sort.name') }}
           </MenuFlyoutItem>
           <MenuFlyoutItem
+            v-if="allTerminalServers.length > 0"
             @click="() => (sortName = 'Terminal server')"
             :selected="sortName === 'Terminal server'"
           >

--- a/frontend/lib/components/Navigation/RailButton.vue
+++ b/frontend/lib/components/Navigation/RailButton.vue
@@ -76,6 +76,7 @@
     flex-direction: column;
     align-items: center;
     justify-content: center;
+    text-align: center;
     gap: 4px;
     color: var(--wui-text-tertiary);
     user-select: none;
@@ -83,7 +84,9 @@
     --font-size: 10px;
     font-size: var(--font-size);
     line-height: var(--font-size);
-    transition: line-height var(--wui-control-normal-duration), color var(--wui-control-normal-duration),
+    transition:
+      line-height var(--wui-control-normal-duration),
+      color var(--wui-control-normal-duration),
       background-color var(--wui-control-fast-duration);
     cursor: default;
     text-decoration: none;

--- a/frontend/lib/components/index.mjs
+++ b/frontend/lib/components/index.mjs
@@ -7,6 +7,7 @@ import { default as FieldSet } from './FieldSet/FieldSet.vue';
 import { default as IconButton } from './IconButton/IconButton.vue';
 import { default as InfoBar } from './InfoBar/InfoBar.vue';
 import { default as DesktopCard } from './ItemCard/DesktopCard.vue';
+import { default as GenericCard } from './ItemCard/GenericCard.vue';
 import { default as GenericResourceCard } from './ItemCard/GenericResourceCard.vue';
 import { createHeaderActionModelRefs } from './Layout/createHeaderActionModelRefs.ts';
 import { default as HeaderActions } from './Layout/HeaderActions.vue';
@@ -14,6 +15,7 @@ import { default as ResourceGrid } from './Layout/ResourceGrid.vue';
 import { default as ListItem } from './ListItem/ListItem.vue';
 import { MenuFlyout, MenuFlyoutDivider, MenuFlyoutItem } from './MenuFlyout/index.mjs';
 import { default as NavigationRail } from './Navigation/NavigationRail.vue';
+import { default as RailButton } from './Navigation/RailButton.vue';
 import { default as NavigationPane } from './NavigationView/NavigationPane.vue';
 import { default as TreeView } from './NavigationView/TreeView.vue';
 import { default as PickerItem } from './PickerItem/PickerItem.vue';
@@ -37,6 +39,7 @@ export {
   DesktopCard,
   Field,
   FieldSet,
+  GenericCard,
   GenericResourceCard,
   HeaderActions,
   IconButton,
@@ -53,6 +56,7 @@ export {
   ProgressBar,
   ProgressRing,
   RadioButton,
+  RailButton,
   ResourceGrid,
   Select,
   TextBlock,

--- a/frontend/lib/entry.dist.mjs
+++ b/frontend/lib/entry.dist.mjs
@@ -28,7 +28,41 @@ app.directive('swap', (el, binding) => {
   }
 });
 
-// showConfirm('hi', 'history', 'hi', 'hi');
-
 await router.isReady();
-app.mount('#app');
+
+// expose globals for use by injected scripts
+if (typeof window !== 'undefined') {
+  const rawebReadyEvent = new CustomEvent('RAWebReady', {
+    detail: {
+      app,
+      router,
+      components: {
+        RouterLink: (await import('vue-router')).RouterLink,
+        ...(await import('$components')),
+      },
+      vue: await import('vue'),
+      stores: await import('./stores/index.mjs'),
+    },
+  });
+  window.dispatchEvent(rawebReadyEvent);
+}
+
+const appInstance = app.mount('#app');
+
+if (typeof window !== 'undefined') {
+  appInstance.$nextTick(async () => {
+    const event = new CustomEvent('RAWebAppMounted', {
+      detail: {
+        app,
+        router,
+        components: {
+          RouterLink: (await import('vue-router')).RouterLink,
+          ...(await import('$components')),
+        },
+        vue: await import('vue'),
+        stores: await import('./stores/index.mjs'),
+      },
+    });
+    window.dispatchEvent(event);
+  });
+}

--- a/frontend/lib/types.d.ts
+++ b/frontend/lib/types.d.ts
@@ -1,7 +1,36 @@
 declare global {
   interface Window {
     __pinia: import('pinia').Pinia;
+
+    addEventListener(
+      event: 'RAWebReady',
+      listener: (this: Window, event: RAWebReadyEvent) => any,
+      options?: boolean | AddEventListenerOptions
+    ): void;
+    removeEventListener(
+      event: 'RAWebReady',
+      listener: (this: Window, event: RAWebReadyEvent) => any,
+      options?: boolean | EventListenerOptions
+    ): void;
+
+    addEventListener(
+      event: 'RAWebAppMounted',
+      listener: (this: Window, event: RAWebAppMountedEvent) => any,
+      options?: boolean | AddEventListenerOptions
+    ): void;
+    removeEventListener(
+      event: 'RAWebAppMounted',
+      listener: (this: Window, event: RAWebAppMountedEvent) => any,
+      options?: boolean | EventListenerOptions
+    ): void;
   }
+
+  interface RAWebReadyEventData {
+    router: import('vue-router').Router;
+  }
+
+  interface RAWebReadyEvent extends CustomEvent<RAWebReadyEventData> {}
+  interface RAWebAppMountedEvent extends CustomEvent<RAWebReadyEventData> {}
 }
 
 export {};


### PR DESCRIPTION
This change makes it possible to inject custom routes into the the main part of the app. This does not affect the authentication parts of the app (login, logoff, password).

This change also adds new API endpoints that expose a list of files. These endpoints are not going to be used for a built-in RAWeb page, but they help make advanced extensions to RAWeb a possibility.

See https://raweb.app/deploy-preview/pr-259/docs/custom-content/#ex-filestore for an advanced example that uses these changes.

The best impact of these changes is that users will be able to implement custom, niche features into their own instances of RAWeb when a feature would not make sense to implement in a main RAWeb release. This also allows those users to stay on the main RAWeb release instead of needing to maintain a fork of RAWeb.

(please excuse the terrible spelling of customizations)