### PR TITLE
Do not immediately redirect to logout page when user needs to sign in again

### DIFF
--- a/frontend/lib/App.vue
+++ b/frontend/lib/App.vue
@@ -243,13 +243,12 @@
       <InfoBar
         severity="critical"
         v-if="coreAppData.needsSignInAgain"
-        :title="t('needsSignInAgain.title')"
+        :title="t('needsSignInAgain.title') + '.'"
         style="border-radius: 0"
       >
         {{ t('needsSignInAgain.message') }}
         <Button
           variant="hyperlink"
-          :href="securityErrorHelpHref"
           style="margin: -6px 0 -6px -3px"
           target="_blank"
           @click.prevent="openSignInPagePopup('sign-in-again', () => refresh())"

--- a/frontend/lib/App.vue
+++ b/frontend/lib/App.vue
@@ -9,6 +9,7 @@
   import {
     combineTerminalServersModeEnabled,
     openInfoBarPopup,
+    openSignInPagePopup,
     registerServiceWorker,
     removeSplashScreen,
     simpleModeEnabled,
@@ -239,6 +240,24 @@
   <div id="appContent">
     <NavigationRail v-if="!simpleModeEnabled" :hidden="router.currentRoute.value.name === 'webGuacd'" />
     <main :class="{ simple: simpleModeEnabled }">
+      <InfoBar
+        severity="critical"
+        v-if="coreAppData.needsSignInAgain"
+        :title="t('needsSignInAgain.title')"
+        style="border-radius: 0"
+      >
+        {{ t('needsSignInAgain.message') }}
+        <Button
+          variant="hyperlink"
+          :href="securityErrorHelpHref"
+          style="margin: -6px 0 -6px -3px"
+          target="_blank"
+          @click.prevent="openSignInPagePopup('sign-in-again', () => refresh())"
+        >
+          {{ t('needsSignInAgain.action') }}
+        </Button>
+      </InfoBar>
+
       <InfoBar severity="caution" v-if="sslError" :title="t('securityError503.title')" style="border-radius: 0">
         {{ t('securityError503.message') }}
         <br />

--- a/frontend/lib/Login.vue
+++ b/frontend/lib/Login.vue
@@ -94,7 +94,15 @@
     // if the credentials were valid, the server should have set the auth cookie,
     // so redirect to the return URL or the main application page
     const redirectUrl = returnUrl ? decodeURIComponent(returnUrl) : base;
-    window.location.href = redirectUrl;
+    if (!window.opener) {
+      window.location.href = redirectUrl;
+    } else {
+      submitting.value = true;
+      window.opener.postMessage({ type: 'authentication-success', redirectUrl }, window.location.origin);
+      setTimeout(() => {
+        window.close();
+      }, 1000);
+    }
   }
 
   type InvalidCredentialsResponse = {
@@ -173,6 +181,7 @@
   }
 
   const hidePasswordChange = policies.passwordChangeEnabled === false;
+  const hasOpener = window.opener != null;
 </script>
 
 <template>
@@ -271,7 +280,12 @@
             <p class="access">
               {{ t('poweredBy') }}
               <br />
-              <Button href="https://github.com/kimmknight/raweb" variant="hyperlink" class="unindent">
+              <Button
+                href="https://github.com/kimmknight/raweb"
+                variant="hyperlink"
+                class="unindent"
+                :target="hasOpener ? '_blank' : '_self'"
+              >
                 {{ t('poweredByLearnMore') }}
               </Button>
             </p>

--- a/frontend/lib/pages/DeviceClient.vue
+++ b/frontend/lib/pages/DeviceClient.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
+  import { TextBlock } from '$components';
   import { requestCredentials as _requestCredentials, showConfirm } from '$dialogs';
   import { useCoreDataStore } from '$stores';
-  import { debounce, getAppsAndDevices, openHelpPopup, useWebfeedData } from '$utils';
+  import { debounce, getAppsAndDevices, openHelpPopup, openSignInPagePopup, useWebfeedData } from '$utils';
   import Guacamole from 'guacamole-common-js';
   import { useTranslation } from 'i18next-vue';
   import { computed, onMounted, onUnmounted, ref } from 'vue';
@@ -21,7 +22,7 @@
   const { t } = useTranslation();
   const route = useRoute();
   const router = useRouter();
-  const { iisBase, appBase, docsUrl } = useCoreDataStore();
+  const { iisBase, appBase, docsUrl, needsSignInAgain } = useCoreDataStore();
 
   function goBackOrClose() {
     route.meta.isDeviceCancelButton = true;
@@ -1056,6 +1057,23 @@
     <NotFound :title="t('client.resourceNotFound')" :message="message404" />
   </div>
 
+  <div v-else-if="needsSignInAgain" class="full-page-notice">
+    <TextBlock variant="subtitle">{{ t('needsSignInAgain.title') }}</TextBlock>
+    <TextBlock block>{{ t('needsSignInAgain.message') }}</TextBlock>
+    <div class="button-row">
+      <Button
+        variant="accent"
+        @click.prevent="
+          openSignInPagePopup('sign-in-again', () => {
+            refreshWorkspace();
+            reconnect();
+          })
+        "
+        >{{ t('needsSignInAgain.action') }}</Button
+      >
+    </div>
+  </div>
+
   <div id="display-wrapper" v-else>
     <div id="display"></div>
 
@@ -1144,5 +1162,25 @@
 
   main:has(#display-wrapper) {
     border-top-left-radius: 0;
+  }
+
+  .full-page-notice {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    block-size: calc(100% - 52px);
+    gap: 8px;
+    padding: 24px 16px;
+    background-color: var(--wui-subtle-transparent);
+    border-radius: var(--wui-control-corner-radius);
+    box-sizing: border-box;
+    text-align: center;
+  }
+  .full-page-notice .button-row {
+    display: flex;
+    flex-direction: row;
+    gap: 8px;
+    margin-top: 12px;
   }
 </style>

--- a/frontend/lib/pages/Favorites.vue
+++ b/frontend/lib/pages/Favorites.vue
@@ -221,7 +221,7 @@
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    block-size: 100%;
+    block-size: calc(100% - 52px);
     gap: 16px;
     padding: 24px 16px;
     background-color: var(--wui-subtle-transparent);

--- a/frontend/lib/pages/Policies.vue
+++ b/frontend/lib/pages/Policies.vue
@@ -2,11 +2,11 @@
   import { Button, PolicyDialog, TextBlock } from '$components';
   import { ManagedResourceListDialog, showConfirm } from '$dialogs';
   import { useCoreDataStore } from '$stores';
-  import { isUrl, notEmpty, useWebfeedData } from '$utils';
+  import { isUrl, notEmpty, openSignInPagePopup, useWebfeedData } from '$utils';
   import { useTranslation } from 'i18next-vue';
   import { onMounted, ref } from 'vue';
 
-  const { iisBase, capabilities } = useCoreDataStore();
+  const { iisBase, capabilities, needsSignInAgain } = useCoreDataStore();
   const { t } = useTranslation();
 
   const props = defineProps<{
@@ -1098,9 +1098,12 @@
 <template>
   <div class="titlebar-row">
     <TextBlock variant="title">{{ t('policies.title') }}</TextBlock>
-    <div class="header-actions" v-if="isSecureContext">
+    <div class="header-actions" v-if="isSecureContext && !needsSignInAgain">
       <div class="actions">
-        <ManagedResourceListDialog @app-or-desktop-change="props.refreshWorkspace" v-if="isSecureContext">
+        <ManagedResourceListDialog
+          @app-or-desktop-change="props.refreshWorkspace"
+          v-if="isSecureContext && !needsSignInAgain"
+        >
           <template #default="{ open }">
             <Button @click="open">{{ t('registryApps.manager.open') }}</Button>
           </template>
@@ -1109,7 +1112,24 @@
     </div>
   </div>
 
-  <div class="wrapper">
+  <div v-if="needsSignInAgain" class="full-page-notice">
+    <TextBlock variant="subtitle">{{ t('needsSignInAgain.title') }}</TextBlock>
+    <TextBlock block>{{ t('needsSignInAgain.message-policies') }}</TextBlock>
+    <div class="button-row">
+      <Button
+        variant="accent"
+        @click.prevent="
+          openSignInPagePopup('sign-in-again', () => {
+            refreshWorkspace();
+            fetchPolicies();
+          })
+        "
+        >{{ t('needsSignInAgain.action') }}</Button
+      >
+    </div>
+  </div>
+
+  <div v-else class="wrapper" :class="{ subtractHeaderActions: isSecureContext && !needsSignInAgain }">
     <div role="table" class="compact">
       <div role="rowgroup" class="thead">
         <div role="row">
@@ -1212,8 +1232,11 @@
     box-shadow: 0 0 0 1px var(--wui-divider-stroke-default);
     border-radius: var(--wui-control-corner-radius);
     width: 100%;
-    height: calc(100% - 94px);
+    height: calc(100% - 52px);
     overflow: auto;
+  }
+  div.wrapper.subtractHeaderActions {
+    height: calc(100% - 94px);
   }
 
   div[role='table'] {
@@ -1287,5 +1310,25 @@
 
   span[role='cell'].rightPadding {
     padding-right: 10px;
+  }
+
+  .full-page-notice {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    block-size: calc(100% - 52px);
+    gap: 8px;
+    padding: 24px 16px;
+    background-color: var(--wui-subtle-transparent);
+    border-radius: var(--wui-control-corner-radius);
+    box-sizing: border-box;
+    text-align: center;
+  }
+  .full-page-notice .button-row {
+    display: flex;
+    flex-direction: row;
+    gap: 8px;
+    margin-top: 12px;
   }
 </style>

--- a/frontend/lib/public/locales/en.json
+++ b/frontend/lib/public/locales/en.json
@@ -977,6 +977,11 @@
     "message": "The service worker failed to install because the SSL certificate is not trusted by your device. Add the certificate to the trusted root certification authorities store on this computer or configure RAWeb to use a trusted certificate. Performance and functionality may be limited. Offline feaures are unavailable.",
     "action": "Learn more"
   },
+  "needsSignInAgain": {
+    "title": "Your credentials have expired.",
+    "message": "Sign in again to continue accessing your resources.",
+    "action": "Sign in"
+  },
   "tsError517": {
     "title": "This terminal server does accept connections.",
     "message": "This resource will be hidden from the web interface and other workspace clients.",

--- a/frontend/lib/public/locales/en.json
+++ b/frontend/lib/public/locales/en.json
@@ -978,8 +978,9 @@
     "action": "Learn more"
   },
   "needsSignInAgain": {
-    "title": "Your credentials have expired.",
+    "title": "Your credentials have expired",
     "message": "Sign in again to continue accessing your resources.",
+    "message-policies": "Sign in again to manage policies and resources.",
     "action": "Sign in"
   },
   "tsError517": {

--- a/frontend/lib/public/service-worker.js
+++ b/frontend/lib/public/service-worker.js
@@ -97,7 +97,8 @@ async function fetchWithCache(event, mode = 'swr') {
   return cachedResponse;
 }
 
-let fetchQueueInterval = null;
+/** @type {number | undefined} */
+let fetchQueueInterval = undefined;
 
 /**
  * @param {FetchEvent} event
@@ -154,10 +155,11 @@ function handleFetch(event) {
   start(event.request.url);
   event.respondWith(fetchWithCache(event, shouldUseOfflineCache ? 'offline' : 'swr'));
 
-  // wait fetchStatus map has at least one entry and all are false
-  // before running the background fetches
-  clearInterval(fetchQueueInterval);
-  fetchQueueInterval = setInterval(() => {
+  processFetchQueue();
+}
+
+function processFetchQueue() {
+  const notifyClientsOfQueueLength = () => {
     clients.matchAll().then((clientList) => {
       clientList.forEach((client) => {
         client.postMessage({
@@ -166,6 +168,13 @@ function handleFetch(event) {
         });
       });
     });
+  };
+
+  // wait fetchStatus map has at least one entry and all are false
+  // before running the background fetches
+  clearInterval(fetchQueueInterval);
+  fetchQueueInterval = setInterval(() => {
+    notifyClientsOfQueueLength();
 
     if (fetchStatus.size > 0 && [...fetchStatus.values()].every((v) => !v)) {
       clearInterval(fetchQueueInterval);
@@ -177,14 +186,7 @@ function handleFetch(event) {
     }
   }, 1000);
 
-  clients.matchAll().then((clientList) => {
-    clientList.forEach((client) => {
-      client.postMessage({
-        type: 'fetch-queue',
-        backgroundFetchQueueLength: backgroundFetchQueue.length,
-      });
-    });
-  });
+  notifyClientsOfQueueLength();
 }
 
 /**
@@ -235,5 +237,11 @@ const variables = {};
 self.addEventListener('message', (event) => {
   if (event.data.type === 'variable') {
     variables[event.data.key] = event.data.value;
+  }
+
+  if (event.data.type === 'add-to-fetch-queue') {
+    const request = new Request(event.data.url);
+    backgroundFetchQueue.push(request);
+    processFetchQueue();
   }
 });

--- a/frontend/lib/public/service-worker.js
+++ b/frontend/lib/public/service-worker.js
@@ -3,11 +3,14 @@ const CURRENT_CACHE = `app-cache-v${SERVICE_WORKER_VERSION}`;
 
 // only cache these path prefixes for offline use
 // (require a fresh response when online)
-const offlineOnlyPathnamePrefixes = ['api/app-init-details', 'manifest.webmanifest'];
+const offlineOnlyPathnamePrefixes = ['manifest.webmanifest'];
 
 // skip caching for these paths (e.g., unbundled dev mode paths)
 // const omiitedPathnamePrefixes = ['node_modules/', '@vite/', '@id/'];
-const omiitedPathnamePrefixes = [];
+const omiitedPathnamePrefixes = [
+  // we cache app-init-details separately in coreDateStore.ts
+  'api/app-init-details',
+];
 
 // these are the HTML entry points of the app
 // and should immediately be cached for offline use

--- a/frontend/lib/stores/coreDataStore.ts
+++ b/frontend/lib/stores/coreDataStore.ts
@@ -1,8 +1,18 @@
 import { isBrowser } from '$utils/environment.ts';
+import { parse, stringify } from 'devalue';
 import { defineStore } from 'pinia';
+import { toRaw } from 'vue';
 
 interface State extends EmptyState {
   userNamespace: string;
+
+  /**
+   * When this is true, the app should show a warning that the user needs to sign in again.
+   * It usually means that the server thinks the user is unauthenticated, but the web app
+   * is continuing to show the last authenticate user's information until they manually
+   * sign out.
+   */
+  needsSignInAgain: boolean;
 
   /** The base path of the IIS application. It will always start and end with a forward slash. @example `/RAWeb/` */
   iisBase: string;
@@ -79,6 +89,41 @@ interface EmptyState {
   initializing?: boolean;
 }
 
+const _srr_data = {
+  initialized: true,
+  needsSignInAgain: true,
+  appBase: '/',
+  iisBase: '/',
+  userNamespace: 'SSR',
+  authUser: {
+    username: 'SSRUser',
+    domain: 'SSRDomain',
+    fullName: 'SSR User',
+    isLocalAdministrator: false,
+  },
+  terminalServerAliases: {},
+  policies: {
+    combineTerminalServersModeEnabled: false,
+    favoritesEnabled: true,
+    flatModeEnabled: false,
+    hidePortsEnabled: false,
+    iconBackgroundsEnabled: false,
+    simpleModeEnabled: false,
+    passwordChangeEnabled: false,
+    anonymousAuthentication: 'never',
+    signedInUserGlobalAlerts: null,
+    workspaceAuthBlocked: null,
+    connectionMethods: null,
+    openConnectionsInNewWindowEnabled: null,
+  },
+  machineName: 'SSR-Machine',
+  envMachineName: 'SSR-Machine',
+  coreVersion: 'SSR-Version',
+  webVersion: 'SSR-Web-Version',
+  capabilities: {},
+  docsUrl: '',
+} satisfies State;
+
 /**
  * Fetches the app-init-data from the server.
  *
@@ -101,45 +146,90 @@ async function fetchInitialData(): Promise<State> {
       });
   }
 
-  return Promise.resolve({
-    initialized: true,
-    appBase: '/',
-    iisBase: '/',
-    userNamespace: 'SSR',
-    authUser: {
-      username: 'SSRUser',
-      domain: 'SSRDomain',
-      fullName: 'SSR User',
-      isLocalAdministrator: false,
-    },
-    terminalServerAliases: {},
-    policies: {
-      combineTerminalServersModeEnabled: false,
-      favoritesEnabled: true,
-      flatModeEnabled: false,
-      hidePortsEnabled: false,
-      iconBackgroundsEnabled: false,
-      simpleModeEnabled: false,
-      passwordChangeEnabled: false,
-      anonymousAuthentication: 'never',
-      signedInUserGlobalAlerts: null,
-      workspaceAuthBlocked: null,
-      connectionMethods: null,
-      openConnectionsInNewWindowEnabled: null,
-    },
-    machineName: 'SSR-Machine',
-    envMachineName: 'SSR-Machine',
-    coreVersion: 'SSR-Version',
-    webVersion: 'SSR-Web-Version',
-    capabilities: {},
-    docsUrl: '',
-  } satisfies State);
+  return Promise.resolve(_srr_data);
 }
 
 export const useCoreDataStore = defineStore('coreData', {
-  state: (): State =>
-    ({ initialized: false, capabilities: {}, policies: {}, authUser: {}, terminalServerAliases: {} }) as State, // cast because we will pre-fetch the data before the app is mounted
+  state: (): State => {
+    // If there is state stored in localStorage, restore it.
+    // We make sure that initialized and initializing are always false
+    // so that the app knows to try to get the latest data from the API.
+    const storedData = isBrowser ? localStorage.getItem(STORAGE_KEY) : null;
+    if (storedData && typeof storedData === 'string') {
+      try {
+        const deserialized = parse(storedData);
+        if (
+          Array.isArray(deserialized) &&
+          deserialized.length > 0 &&
+          typeof deserialized[0] === 'object' &&
+          deserialized[0] !== null
+        ) {
+          return {
+            ...deserialized[0],
+            initialized: false,
+            initializing: false,
+            needsSignInAgain: true,
+          } as State;
+        }
+      } catch {
+        // if there is an error parsing the stored data, clear it because it is invalid
+        if (isBrowser) {
+          localStorage.removeItem(STORAGE_KEY);
+        }
+      }
+    }
+
+    return { ..._srr_data, userNamespace: '', initialized: false, initializing: false }; // default data values
+  },
   actions: {
+    /**
+     * Returns the current state of the store.
+     */
+    getCurrentState() {
+      if (!this.initialized && !this.initializing) {
+        throw new Error('coreDataStore state is not initialized');
+      }
+
+      // converthing this.$state to a plain object only preserves the properties in
+      // the state that are objects, so we need to manually copy the others
+      const snapshot = structuredClone(toRaw(this.$state));
+      for (const key of Object.keys(this)) {
+        if (key.startsWith('$') || key.startsWith('_') || key in snapshot) {
+          continue;
+        }
+
+        const value = (this as any)[key];
+        if (typeof value === 'function') {
+          continue;
+        }
+
+        // @ts-ignore
+        snapshot[key] = value;
+      }
+
+      return snapshot as State;
+    },
+    storeCurrentState() {
+      if (!isBrowser || !this.userNamespace || this.userNamespace === 'RAWEB:UNAUTHENTICATED') {
+        return;
+      }
+
+      const currentStorage = localStorage.getItem(STORAGE_KEY);
+      let currentData: State[] | null | boolean | string | number = currentStorage
+        ? parse(currentStorage)
+        : null;
+      if (!Array.isArray(currentData)) {
+        currentData = [] as State[];
+      }
+
+      localStorage.setItem(
+        STORAGE_KEY,
+        stringify([
+          ...currentData.filter((item) => item.userNamespace !== this.userNamespace),
+          this.getCurrentState(),
+        ])
+      );
+    },
     async fetchData() {
       // only fetch once
       if (this.initialized || this.initializing) {
@@ -152,8 +242,21 @@ export const useCoreDataStore = defineStore('coreData', {
           if (typeof data !== 'object' || data === null) {
             throw new Error('Invalid data');
           }
-          Object.assign(this, data);
 
+          // In the case that the user is unauthenticated, we only want to use that
+          // user information if there is no existing userNamespace in the store.
+          const isUnauthenticated = data.userNamespace === 'RAWEB:UNAUTHENTICATED';
+          const storedUserInfo = {
+            userNamespace: this.userNamespace,
+            authUser: this.authUser,
+          };
+          Object.assign(this, data);
+          if (isUnauthenticated && storedUserInfo.userNamespace !== 'RAWEB:UNAUTHENTICATED') {
+            this.userNamespace = storedUserInfo.userNamespace;
+            this.authUser = storedUserInfo.authUser;
+          }
+
+          this.needsSignInAgain = isUnauthenticated;
           this.initialized = true;
         })
         .catch((error) => {
@@ -165,7 +268,16 @@ export const useCoreDataStore = defineStore('coreData', {
         })
         .finally(() => {
           this.initializing = false;
+
+          // store in localStorage
+          this.storeCurrentState();
         });
+    },
+    async __refetchCoreData() {
+      this.initialized = false;
+      this.fetchData();
     },
   },
 });
+
+const STORAGE_KEY = 'coreDataStore:data';

--- a/frontend/lib/stores/coreDataStore.ts
+++ b/frontend/lib/stores/coreDataStore.ts
@@ -1,4 +1,5 @@
 import { isBrowser } from '$utils/environment.ts';
+import { offline } from '$utils/offline.ts';
 import { parse, stringify } from 'devalue';
 import { defineStore } from 'pinia';
 import { toRaw } from 'vue';
@@ -260,11 +261,14 @@ export const useCoreDataStore = defineStore('coreData', {
           this.initialized = true;
         })
         .catch((error) => {
-          alert(
-            'Catastrophic Error: \n    An error occurred while initializing the application data. \n\nPlease reload the page and try again. \n\nError details: \n' +
-              error.message
-          );
-          window.location.reload();
+          console.log(navigator.onLine, 'Error fetching initial data:', error);
+          if (!offline.value) {
+            alert(
+              'Catastrophic Error: \n    An error occurred while initializing the application data. \n\nPlease reload the page and try again. \n\nError details: \n' +
+                error.message
+            );
+            window.location.reload();
+          }
         })
         .finally(() => {
           this.initializing = false;

--- a/frontend/lib/utils/getAppsAndDevices.ts
+++ b/frontend/lib/utils/getAppsAndDevices.ts
@@ -381,6 +381,59 @@ async function getResources(
       icons.set(url.href, { type: parsedType, url, dimensions });
     }
 
+    // fetch the versions of the icons that we use in the web app in the
+    // background so that the service worker has a cache
+    icons.forEach((icon) => {
+      if (icon.type !== 'ico') {
+        return;
+      }
+
+      if (!('serviceWorker' in navigator)) {
+        return;
+      }
+
+      navigator.serviceWorker.ready.then((registration) => {
+        if (registration.active) {
+          const hrefsToCache = [icon.url.href];
+          const urlToCache = new URL(icon.url.href);
+
+          const hasPcFrame = urlToCache.searchParams.get('frame') === 'pc';
+          if (hasPcFrame) {
+            urlToCache.searchParams.delete('frame');
+          }
+
+          // icon?format=png
+          urlToCache.searchParams.set('format', 'png');
+          hrefsToCache.push(urlToCache.href);
+          // icon?format=png&theme=dark
+          urlToCache.searchParams.set('theme', 'dark');
+          hrefsToCache.push(urlToCache.href);
+
+          // wallpaper?format=png&fallback=resource%3A%2F%2Fstatic%2Flib%2Fassets%2Fwallpaper.png
+          urlToCache.searchParams.delete('theme');
+          urlToCache.searchParams.set('fallback', 'resource://static/lib/assets/wallpaper.png');
+          hrefsToCache.push(urlToCache.href);
+          // wallpaper?format=png&fallback=resource%3A%2F%2Fstatic%2Flib%2Fassets%2Fwallpaper-dark.png&theme=dark
+          urlToCache.searchParams.set('fallback', 'resource://static/lib/assets/wallpaper-dark.png');
+          urlToCache.searchParams.set('theme', 'dark');
+          hrefsToCache.push(urlToCache.href);
+
+          // wallpaper?format=png&frame=pc
+          urlToCache.searchParams.delete('theme');
+          urlToCache.searchParams.delete('fallback');
+          urlToCache.searchParams.set('frame', 'pc');
+          hrefsToCache.push(urlToCache.href);
+          // wallpaper?format=png&frame=pc&theme=dark
+          urlToCache.searchParams.set('theme', 'dark');
+          hrefsToCache.push(urlToCache.href);
+
+          hrefsToCache.forEach((href) => {
+            registration.active?.postMessage({ type: 'add-to-fetch-queue', url: href });
+          });
+        }
+      });
+    });
+
     const folders = new Set<string>();
     for (const element of resource.querySelectorAll('Folders > Folder')) {
       const folder = element.getAttribute('Name');

--- a/frontend/lib/utils/index.mjs
+++ b/frontend/lib/utils/index.mjs
@@ -14,6 +14,7 @@ import { inferUtfEncoding } from './inferUtfEncoding.ts';
 import { isUrl } from './isUrl.ts';
 import { normalizeRdpFileString } from './normalizeRdpFileString.ts';
 import { notEmpty } from './notEmpty.ts';
+import { offline } from './offline.ts';
 import { openConnectionsInNewWindowEnabled } from './openConnectionsInNewWindow.ts';
 import { openHelpPopup } from './openHelpPopup.ts';
 import { openInfoBarPopup } from './openInfoBarPopup.ts';
@@ -59,6 +60,7 @@ export {
   isUrl,
   normalizeRdpFileString,
   notEmpty,
+  offline,
   openConnectionsInNewWindowEnabled,
   openHelpPopup,
   openInfoBarPopup,

--- a/frontend/lib/utils/index.mjs
+++ b/frontend/lib/utils/index.mjs
@@ -17,6 +17,7 @@ import { notEmpty } from './notEmpty.ts';
 import { openConnectionsInNewWindowEnabled } from './openConnectionsInNewWindow.ts';
 import { openHelpPopup } from './openHelpPopup.ts';
 import { openInfoBarPopup } from './openInfoBarPopup.ts';
+import { openSignInPagePopup } from './openSignInPagePopup.ts';
 import { parseRdpFileText } from './parseRdpFileText.ts';
 import { pascalCaseToCamelCase } from './pascalCaseToCamelCase.ts';
 import { pickImageFile } from './pickImageFile.ts';
@@ -61,6 +62,7 @@ export {
   openConnectionsInNewWindowEnabled,
   openHelpPopup,
   openInfoBarPopup,
+  openSignInPagePopup,
   parseRdpFileText,
   pascalCaseToCamelCase,
   pickImageFile,

--- a/frontend/lib/utils/offline.ts
+++ b/frontend/lib/utils/offline.ts
@@ -1,0 +1,14 @@
+import { ref } from 'vue';
+import { isBrowser } from './environment';
+
+export const offline = ref(isBrowser && 'navigator' in window ? !navigator.onLine : false);
+
+if (isBrowser && 'navigator' in window) {
+  window.addEventListener('offline', () => {
+    offline.value = true;
+  });
+
+  window.addEventListener('online', () => {
+    offline.value = false;
+  });
+}

--- a/frontend/lib/utils/openSignInPagePopup.ts
+++ b/frontend/lib/utils/openSignInPagePopup.ts
@@ -1,0 +1,25 @@
+import { useCoreDataStore } from '$stores';
+
+export function openSignInPagePopup(target: string, onSuccess?: () => void) {
+  const { appBase, __refetchCoreData } = useCoreDataStore();
+
+  const popup = window.open(`${appBase}login`, target, 'width=472,height=502,menubar=0,status=0');
+  if (popup) {
+    popup.focus();
+
+    // close the popup and re-check authentication once the popup signals that authentication was successful
+    window.addEventListener('message', (event) => {
+      if (event.origin !== location.origin) return;
+      if (popup && event.source !== popup) return;
+
+      if (event.data.type === 'authentication-success') {
+        popup.close();
+        console.log('re');
+        __refetchCoreData();
+        onSuccess?.();
+      }
+    });
+  } else {
+    alert('Please allow popups for this application');
+  }
+}

--- a/frontend/lib/utils/prefixUserNS.ts
+++ b/frontend/lib/utils/prefixUserNS.ts
@@ -7,5 +7,17 @@ import { useCoreDataStore } from '$stores';
  */
 export function prefixUserNS(key: string) {
   const { userNamespace } = useCoreDataStore();
-  return `${userNamespace}::${key}`;
+
+  const prefix = `${userNamespace ?? ''}::`;
+  const withPrefix = new String(prefix + key);
+
+  Object.defineProperty(withPrefix, 'prefix', { value: prefix });
+  Object.defineProperty(withPrefix, 'key', { value: key });
+  Object.defineProperty(withPrefix, 'userNamespace', { value: userNamespace || undefined });
+
+  return withPrefix as string & {
+    prefix: string;
+    key: string;
+    userNamespace: string | undefined;
+  };
 }

--- a/frontend/lib/utils/useWebfeedData.ts
+++ b/frontend/lib/utils/useWebfeedData.ts
@@ -10,7 +10,7 @@ const trigger = ref(0);
 
 const data = computed<Awaited<ReturnType<typeof getAppsAndDevices>> | null>({
   get: () => {
-    if (!isBrowser) {
+    if (!isBrowser || !prefixUserNS('').userNamespace) {
       return null;
     }
 
@@ -27,7 +27,7 @@ const data = computed<Awaited<ReturnType<typeof getAppsAndDevices>> | null>({
     return null;
   },
   set: (value) => {
-    if (!isBrowser) {
+    if (!isBrowser || !prefixUserNS('').userNamespace) {
       return;
     }
 
@@ -62,7 +62,7 @@ async function getData(
 
   return getAppsAndDevices(base, {
     mergeTerminalServers,
-    redirect: true,
+    redirect: false,
     hidePortsWhenPossible,
     supportsCentralizedPublishing,
   })

--- a/frontend/lib/utils/useWebfeedData.ts
+++ b/frontend/lib/utils/useWebfeedData.ts
@@ -62,7 +62,7 @@ async function getData(
 
   return getAppsAndDevices(base, {
     mergeTerminalServers,
-    redirect: false,
+    redirect: !data.value,
     hidePortsWhenPossible,
     supportsCentralizedPublishing,
   })


### PR DESCRIPTION
Currently, when RAWeb detects that the user needs to sign in again, it immediately signs out and redirects to the sign in screen. This can be a jarring experience.

With this change, RAWeb will show a notice at the top of every page. This notice is similar to the kind of notice you might see in Outlook or Microsoft Teams when you need to sign in again.
<img width="1371" height="807" alt="image" src="https://github.com/user-attachments/assets/5ae1948d-94c2-4368-8d10-6b16b238adf2" />

Click sign in to open a popup window with the sign in page. When the window signs it, it will notify the opener window, and the opener window will refresh the workspace data.
<img width="1362" height="774" alt="image" src="https://github.com/user-attachments/assets/858c8d41-2246-48ac-960a-ff1ae5793277" />

On the policies page, the policies and resources manager will be hidden. These features require a functional, authenticated connection to RAWeb's server.
<img width="1344" height="796" alt="image" src="https://github.com/user-attachments/assets/859c4ea2-8088-40cb-ba22-d3a4d06b3df6" />

As part of this improvement, RAWeb's web app will remember your username. Before this change, the username would change to "UNAUTHENTICATED".

RAWeb's caching has also been tweaked to ensure that common variations of resource icons are cached immediately. Before this change, when we immediately redirected to the sign in page, it did not matter that some icons were broken in the small moment before the redirect.
