### PR TITLE
Ensure resource manager page and dialogs always show fresh content

### DIFF
--- a/frontend/lib/components/ContentDialog/ContentDialog.vue
+++ b/frontend/lib/components/ContentDialog/ContentDialog.vue
@@ -4,7 +4,7 @@
   import { useCoreDataStore } from '$stores';
   import { PreventableEvent } from '$utils';
   import { useTranslation } from 'i18next-vue';
-  import { computed, nextTick, ref, useAttrs, useTemplateRef, watch, watchEffect } from 'vue';
+  import { computed, nextTick, onWatcherCleanup, ref, useAttrs, useTemplateRef, watch, watchEffect } from 'vue';
 
   const {
     closeOnEscape = true,
@@ -120,24 +120,33 @@
   const wasLoading = ref(false);
   watch(
     () => [loading, isOpen.value],
-    ([isLoading]) => {
+    ([$isLoading, $isOpen]) => {
+      if (!$isOpen) {
+        // dialog is closed, so reset loading state immediately
+        wasLoading.value = false;
+        return;
+      }
+
       let timeout: number | undefined;
-      if (isLoading && isOpen.value) {
+      if ($isLoading) {
         timeout = window.setTimeout(() => {
           wasLoading.value = true;
-        }, 500);
-      } else {
+        }, 100); // after 100ms, it is noticeable that the content is missing
+      } else if (wasLoading.value) {
         // do not immediately set wasLoading to false
         // so there is time to animate in the content
         timeout = window.setTimeout(() => {
           wasLoading.value = false;
         }, 500);
       }
-      return () => {
+
+      onWatcherCleanup(() => {
         if (timeout) {
           clearTimeout(timeout);
+        } else {
+          wasLoading.value = false;
         }
-      };
+      });
     },
     { immediate: true }
   );
@@ -176,12 +185,12 @@
         dialogElement.addEventListener('focusin', handleFocusIn);
         dialogElement.addEventListener('focusout', handleFocusOut);
       }
-      return () => {
+      onWatcherCleanup(() => {
         if (dialogElement) {
           dialogElement.removeEventListener('focusin', handleFocusIn);
           dialogElement.removeEventListener('focusout', handleFocusOut);
         }
-      };
+      });
     },
     { immediate: true }
   );
@@ -230,11 +239,11 @@
       if ($closeOnBackdropClick && dialogElement) {
         dialogElement.addEventListener('click', handleBackdropClick);
       }
-      return () => {
+      onWatcherCleanup(() => {
         if (dialogElement) {
           dialogElement.removeEventListener('click', handleBackdropClick);
         }
-      };
+      });
     },
     { immediate: true }
   );
@@ -271,9 +280,9 @@
       const marginBottom = parseFloat(style.marginBottom) || 0;
       titleHeight.value = element.offsetHeight + marginTop + marginBottom;
 
-      return () => {
+      onWatcherCleanup(() => {
         resizeObserver.disconnect();
-      };
+      });
     },
     { immediate: true }
   );
@@ -301,11 +310,11 @@
       if ($isOpen && dialogElement) {
         dialogElement.addEventListener('keydown', handleSaveShortcut);
       }
-      return () => {
+      onWatcherCleanup(() => {
         if (dialogElement) {
           dialogElement.removeEventListener('keydown', handleSaveShortcut);
         }
-      };
+      });
     },
     { immediate: true }
   );

--- a/frontend/lib/components/ContentDialog/ContentDialog.vue
+++ b/frontend/lib/components/ContentDialog/ContentDialog.vue
@@ -89,20 +89,25 @@
     if (dialog.value && isOpen.value) {
       emit('beforeClose');
 
-      const closeEvent = new PreventableEvent({ close: dialog.value.close.bind(dialog.value) });
+      const requestClose = (returnValue?: string | undefined) => {
+        // TODO: requestClose: always use requestClose once all browsers have supported it for a while
+        try {
+          dialog.value?.requestClose(returnValue);
+        } catch (error) {
+          dialog.value?.close(returnValue);
+        }
+
+        console.log('dialog closed');
+        isOpen.value = false;
+
+        emit('afterClose');
+      };
+      const closeEvent = new PreventableEvent({ close: requestClose.bind(dialog.value) });
       emit('close', closeEvent);
 
       if (closeEvent.defaultPrevented) return;
 
-      // TODO: requestClose: always use requestClose once all browsers have supported it for a while
-      try {
-        dialog.value.requestClose();
-      } catch (error) {
-        dialog.value.close();
-      }
-      isOpen.value = false;
-
-      emit('afterClose');
+      requestClose();
     }
   }
 

--- a/frontend/lib/dialogs/ManagedResourceCreateDialog.vue
+++ b/frontend/lib/dialogs/ManagedResourceCreateDialog.vue
@@ -25,6 +25,7 @@
     normalizeRdpFileString,
     openInfoBarPopup,
     pickImageFile,
+    PreventableEvent,
     ResourceManagementSchemas,
     useObjectUrl,
   } from '$utils';
@@ -94,7 +95,7 @@
   );
 
   const emit = defineEmits<{
-    (e: 'afterSave'): void;
+    (e: 'afterSave', event: PreventableEvent<{ next: () => void }>): void;
     (e: 'onClose'): void;
   }>();
 
@@ -201,14 +202,23 @@
         }
       })
       .then(() => {
-        // discard working copy
-        formData.value = null;
-        saveError.value = null;
-        uploadedLightIconBlob.value = null;
-        uploadedDarkIconBlob.value = null;
+        const next = () => {
+          // discard working copy
+          formData.value = null;
+          saveError.value = null;
+          uploadedLightIconBlob.value = null;
+          uploadedDarkIconBlob.value = null;
 
-        emit('afterSave');
-        close();
+          close();
+
+          saving.value = false;
+        };
+
+        const event = new PreventableEvent({ next });
+        emit('afterSave', event);
+        if (!event.defaultPrevented) {
+          next();
+        }
       })
       .catch((err) => {
         if (err instanceof Error) {
@@ -222,8 +232,6 @@
           saveError.value = new Error('An unknown error occurred while saving.');
         }
         console.error(err);
-      })
-      .finally(() => {
         saving.value = false;
       });
   }

--- a/frontend/lib/dialogs/ManagedResourceCreateDiscoveryDialog.vue
+++ b/frontend/lib/dialogs/ManagedResourceCreateDiscoveryDialog.vue
@@ -3,7 +3,7 @@
   import { TreeItem } from '$components/NavigationView/NavigationTypes';
   import { ManagedResourceCreateDialog, showConfirm } from '$dialogs';
   import { useCoreDataStore } from '$stores';
-  import { hashString, pickRDPFile, ResourceManagementSchemas } from '$utils';
+  import { hashString, pickRDPFile, PreventableEvent, ResourceManagementSchemas } from '$utils';
   import { CommandLineMode } from '$utils/schemas/ResourceManagementSchemas';
   import { useQuery } from '@tanstack/vue-query';
   import { useTranslation } from 'i18next-vue';
@@ -140,7 +140,7 @@
   });
 
   const emit = defineEmits<{
-    (e: 'afterSave'): void;
+    (e: 'afterSave', event: PreventableEvent<{ next: () => void }>): void;
     (e: 'onClose'): void;
   }>();
 
@@ -230,8 +230,15 @@
             :is-remote-app="uploadedRdpFileData?.isRemoteApp"
             @after-save="
               () => {
-                emit('afterSave');
-                close();
+                const next = () => {
+                  close();
+                };
+
+                const event = new PreventableEvent({ next });
+                emit('afterSave', event);
+                if (!event.defaultPrevented) {
+                  next();
+                }
               }
             "
           >
@@ -304,8 +311,15 @@
         :is-managed-file-resource="false"
         @after-save="
           () => {
-            close();
-            emit('afterSave');
+            const next = () => {
+              close();
+            };
+
+            const event = new PreventableEvent({ next });
+            emit('afterSave', event);
+            if (!event.defaultPrevented) {
+              next();
+            }
           }
         "
       />

--- a/frontend/lib/dialogs/ManagedResourceCreateDiscoveryDialog.vue
+++ b/frontend/lib/dialogs/ManagedResourceCreateDiscoveryDialog.vue
@@ -16,7 +16,9 @@
   const { isPending, isFetching, isError, data, error, refetch, dataUpdatedAt } = useQuery({
     queryKey: ['remote-app-registry--discovery-available'],
     queryFn: async () => {
-      return fetch(`${iisBase}api/management/resources/available`)
+      return fetch(`${iisBase}api/management/resources/available`, {
+        headers: { 'Cache-Control': 'no-cache' },
+      })
         .then(async (res) => {
           if (!res.ok) {
             await res.json().then((err) => {

--- a/frontend/lib/dialogs/ManagedResourceEditDialog.vue
+++ b/frontend/lib/dialogs/ManagedResourceEditDialog.vue
@@ -24,6 +24,7 @@
     normalizeRdpFileString,
     openInfoBarPopup,
     pickImageFile,
+    PreventableEvent,
     ResourceManagementSchemas,
     useObjectUrl,
   } from '$utils';
@@ -72,8 +73,8 @@
   });
 
   const emit = defineEmits<{
-    (e: 'afterSave'): void;
-    (e: 'afterDelete'): void;
+    (e: 'afterSave', event: PreventableEvent<{ next: () => void }>): void;
+    (e: 'afterDelete', event: PreventableEvent<{ next: () => void }>): void;
     (e: 'onClose'): void;
   }>();
 
@@ -259,15 +260,22 @@
         return res.json();
       })
       .then(() => {
-        // reset the working copy
-        formData.value = null;
-        saveError.value = null;
-        uploadedLightIconBlob.value = null;
-        uploadedDarkIconBlob.value = null;
+        const next = () => {
+          // reset the working copy
+          formData.value = null;
+          saveError.value = null;
+          uploadedLightIconBlob.value = null;
+          uploadedDarkIconBlob.value = null;
+
+          close();
+        };
 
         // emit save event and close dialog
-        emit('afterSave');
-        close();
+        const afterSaveEvent = new PreventableEvent({ next });
+        emit('afterSave', afterSaveEvent);
+        if (!afterSaveEvent.defaultPrevented) {
+          next();
+        }
       })
       .catch((err) => {
         if (err instanceof Error) {
@@ -295,26 +303,32 @@
         method: 'DELETE',
       }).then(async (res) => {
         if (res.ok) {
-          emit('afterDelete');
-          close();
-          return done();
-        }
-
-        const errorJson = await res.json().catch((e) => '(no json body)');
-        if (
-          errorJson &&
-          typeof errorJson === 'object' &&
-          ('Message' in errorJson || 'ExceptionMessage' in errorJson || 'detail' in errorJson)
-        ) {
-          done(new Error(errorJson.ExceptionMessage || errorJson.Message || errorJson.detail));
+          const next = () => {
+            close();
+            done();
+          };
+          const afterDeleteEvent = new PreventableEvent({ next });
+          emit('afterDelete', afterDeleteEvent);
+          if (!afterDeleteEvent.defaultPrevented) {
+            return next();
+          }
         } else {
-          done(
-            new Error(
-              `Error deleting registered RemoteApp ${identifier}: ${res.status} ${
-                res.statusText
-              } ${JSON.stringify(errorJson)}`
-            )
-          );
+          const errorJson = await res.json().catch((e) => '(no json body)');
+          if (
+            errorJson &&
+            typeof errorJson === 'object' &&
+            ('Message' in errorJson || 'ExceptionMessage' in errorJson || 'detail' in errorJson)
+          ) {
+            done(new Error(errorJson.ExceptionMessage || errorJson.Message || errorJson.detail));
+          } else {
+            done(
+              new Error(
+                `Error deleting registered RemoteApp ${identifier}: ${res.status} ${
+                  res.statusText
+                } ${JSON.stringify(errorJson)}`
+              )
+            );
+          }
         }
       });
     });

--- a/frontend/lib/dialogs/ManagedResourceEditDialog.vue
+++ b/frontend/lib/dialogs/ManagedResourceEditDialog.vue
@@ -45,7 +45,9 @@
   const { isPending, isFetching, isError, data, error, refetch, dataUpdatedAt } = useQuery({
     queryKey: ['remote-app-registry', identifier],
     queryFn: async () => {
-      return fetch(`${iisBase}api/management/resources/registered/${identifier}`)
+      return fetch(`${iisBase}api/management/resources/registered/${identifier}`, {
+        headers: { 'Cache-Control': 'no-cache' },
+      })
         .then(async (res) => {
           if (!res.ok) {
             await res.json().then((err) => {
@@ -457,7 +459,7 @@
     max-height="760px"
     fill-height
     :updating="isFetching"
-    :loading="isPending"
+    :loading="isPending || !formData"
     :error="isError && error !== null ? error : false"
   >
     <template #opener="{ close, open, popoverId }">

--- a/frontend/lib/dialogs/PickIconIndexDialog.vue
+++ b/frontend/lib/dialogs/PickIconIndexDialog.vue
@@ -22,7 +22,12 @@
         throw new Error('Icon path is empty');
       }
 
-      return fetch(`${iisBase}api/management/resources/icon/indices?path=${encodeURIComponent(staticIconPath)}`)
+      return fetch(
+        `${iisBase}api/management/resources/icon/indices?path=${encodeURIComponent(staticIconPath)}`,
+        {
+          headers: { 'Cache-Control': 'no-cache' },
+        }
+      )
         .then(async (res) => {
           if (!res.ok) {
             await res.json().then((err) => {

--- a/frontend/lib/dialogs/SelectUsersOrGroupsDialog.vue
+++ b/frontend/lib/dialogs/SelectUsersOrGroupsDialog.vue
@@ -14,7 +14,9 @@
   const { isPending, isFetching, isError, data, error, refetch, dataUpdatedAt } = useQuery({
     queryKey: ['security-locations'],
     queryFn: async () => {
-      return fetch(`${iisBase}api/management/security/locations`)
+      return fetch(`${iisBase}api/management/security/locations`, {
+        headers: { 'Cache-Control': 'no-cache' },
+      })
         .then(async (res) => {
           if (!res.ok) {
             await res.json().then((err) => {

--- a/frontend/lib/pages/Settings.ResourcesManager.vue
+++ b/frontend/lib/pages/Settings.ResourcesManager.vue
@@ -11,6 +11,7 @@
     buildManagedIconPath,
     openSignInPagePopup,
     pickRDPFile,
+    PreventableEvent,
     ResourceManagementSchemas,
     useWebfeedData,
   } from '$utils';
@@ -25,7 +26,7 @@
   const { t } = useTranslation();
 
   const { refreshWorkspace } = defineProps<{
-    refreshWorkspace: () => ReturnType<typeof useWebfeedData>['refresh'];
+    refreshWorkspace: ReturnType<typeof useWebfeedData>['refresh'];
   }>();
 
   const isSecureContext = window.isSecureContext;
@@ -55,9 +56,16 @@
   const uploadedRdpFileData = ref<Awaited<ReturnType<typeof pickRDPFile>>>();
   const uploadedRdpFileKey = ref(0);
 
-  function handleAppOrDesktopChange() {
-    refetch();
-    refreshWorkspace();
+  async function handleAppOrDesktopChange(event: PreventableEvent<{ next: () => void }>) {
+    event.preventDefault();
+    await refetch();
+    await refreshWorkspace();
+
+    // wrap in setTimeout so that the updated resources list can fully render
+    // before the dialog is closed
+    setTimeout(() => {
+      event.detail.next();
+    }, 0);
   }
 </script>
 

--- a/frontend/lib/pages/Settings.ResourcesManager.vue
+++ b/frontend/lib/pages/Settings.ResourcesManager.vue
@@ -33,7 +33,9 @@
   const { isPending, isFetching, isError, data, error, refetch, dataUpdatedAt } = useQuery({
     queryKey: ['remote-app-registry'],
     queryFn: async () => {
-      return fetch(`${iisBase}api/management/resources/registered`)
+      return fetch(`${iisBase}api/management/resources/registered`, {
+        headers: { 'Cache-Control': 'no-cache' },
+      })
         .then(async (res) => {
           if (!res.ok) {
             await res.json().then((err) => {

--- a/frontend/lib/public/service-worker.js
+++ b/frontend/lib/public/service-worker.js
@@ -10,6 +10,9 @@ const offlineOnlyPathnamePrefixes = ['manifest.webmanifest'];
 const omiitedPathnamePrefixes = [
   // we cache app-init-details separately in coreDateStore.ts
   'api/app-init-details',
+  // the management info needs to ALWAYS be fresh to avoid loading stale data
+  // and then overwriting the fresh data with stale data when editing
+  'api/management',
 ];
 
 // these are the HTML entry points of the app


### PR DESCRIPTION
This PR makes changes to ensure that the resource manager page and the related dialogs always show up-to-date content. Key changes:

- The service worker excludes all resource management endpoints. They will no longer exhibit stale-while-revalidate behavior.
- The resource manager page and related dialogs will always include `Cache-Control: no-cache` when requesting data from the server.
- The create, edit, and delete dialogs will not close until the list of resources on the resource manager page has finished refreshing. This ensures that administrators do not briefly see the resource they just deleted or an outdated resource name or icon.
- The `ContentDialog.vue` component correctly tracks whether the dialog is open, which ensures that animations play correctly and consistently. This fixes the weird flicker that could previously occur when a resource loaded faster than 500ms.

Resolves #264.