### PR TITLE
fix: do not allow button content to wrap to new lines

### DIFF
--- a/frontend/lib/components/Button/StandardButton.vue
+++ b/frontend/lib/components/Button/StandardButton.vue
@@ -47,9 +47,7 @@
   >
     <slot name="icon"></slot>
     <ProgressRing v-if="$slots.default && loading" style="position: absolute" :size="16" />
-    <span v-if="$slots.default" :style="`opacity: ${loading ? 0 : 1}; text-box: trim-both cap alphabetic`"
-      ><slot></slot
-    ></span>
+    <span v-if="$slots.default" class="content" :class="{ loading }"><slot></slot></span>
     <span
       class="icon-end-wrapper"
       v-if="$slots['icon-end']"
@@ -137,6 +135,16 @@
   .button.style-accent.disabled {
     background-color: var(--wui-accent-disabled);
     color: var(--wui-text-on-accent-disabled);
+  }
+
+  .button .content {
+    opacity: 1;
+    transition: opacity var(--wui-control-faster-duration) ease;
+    white-space: nowrap;
+    text-box: trim-both cap alphabetic;
+  }
+  .button .content.loading {
+    opacity: 0;
   }
 </style>
 

--- a/frontend/lib/pages/Settings.ResourcesManager.vue
+++ b/frontend/lib/pages/Settings.ResourcesManager.vue
@@ -632,6 +632,7 @@
   .actions {
     display: flex;
     flex-direction: row;
+    flex-wrap: wrap;
     gap: 8px;
   }
 
@@ -640,7 +641,6 @@
     grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
     gap: 12px;
     max-height: 600px;
-    overflow: auto;
   }
 
   .apps-list :deep(> .button) {


### PR DESCRIPTION
With wrapping enabled, weird visuals like this occur:

<img width="581" height="203" alt="Image" src="https://github.com/user-attachments/assets/d0645ded-edff-4d7e-add6-c305abb59002" />

With `white-space: no-wrap` on Button spans:

<img width="569" height="231" alt="Image" src="https://github.com/user-attachments/assets/8445fac4-076d-4370-a366-8c2eb2acbcc0" />