### PR TITLE
feat: Add RDP signature stripping and improve anonymous auth UI

### DIFF
--- a/add_translations.js
+++ b/add_translations.js
@@ -1,0 +1,20 @@
+const fs = require('fs');
+
+const trPath = './frontend/lib/public/locales/tr.json';
+const enPath = './frontend/lib/public/locales/en.json';
+
+const tr = JSON.parse(fs.readFileSync(trPath, 'utf8'));
+const en = JSON.parse(fs.readFileSync(enPath, 'utf8'));
+
+tr.policies['App.RDP.StripSignatures'] = {
+  title: 'RDP İmzalarını Temizle (Pano ve Sürücüleri Serbest Bırak)',
+  help: 'Etkinleştirildiğinde, merkezi yayımlama sunucusundan (RDS Broker) gelen RDP bağlantılarındaki dijital imzalar silinir. Bu sayede kullanıcılar bağlantı öncesinde Pano (Kopyala/Yapıştır), Yazıcılar ve Yerel Sürücüler gibi seçenekleri özgürce seçip değiştirebilirler.'
+};
+
+en.policies['App.RDP.StripSignatures'] = {
+  title: 'Strip RDP Signatures (Unlock Clipboard and Drives)',
+  help: 'When enabled, digital signatures from Centralized Publishing (RDS Broker) are stripped from the RDP connection. This allows users to freely check and uncheck options like Clipboard, Printers, and Local Drives before connecting.'
+};
+
+fs.writeFileSync(trPath, JSON.stringify(tr, null, 2));
+fs.writeFileSync(enPath, JSON.stringify(en, null, 2));

--- a/dotnet/RAWeb.Server.Management.ServiceHost/packages.lock.json
+++ b/dotnet/RAWeb.Server.Management.ServiceHost/packages.lock.json
@@ -2,11 +2,25 @@
   "version": 1,
   "dependencies": {
     ".NETFramework,Version=v4.6.2": {
+      "Microsoft.NETFramework.ReferenceAssemblies": {
+        "type": "Direct",
+        "requested": "[1.0.3, )",
+        "resolved": "1.0.3",
+        "contentHash": "vUc9Npcs14QsyOD01tnv/m8sQUnGTGOw1BCmKcv77LBJY7OxhJ+zJF7UD/sCL3lYNFuqmQEVlkfS4Quif6FyYg==",
+        "dependencies": {
+          "Microsoft.NETFramework.ReferenceAssemblies.net462": "1.0.3"
+        }
+      },
       "PolySharp": {
         "type": "Direct",
         "requested": "[1.15.0, )",
         "resolved": "1.15.0",
         "contentHash": "FbU0El+EEjdpuIX4iDbeS7ki1uzpJPx8vbqOzEtqnl1GZeAGJfq+jCbxeJL2y0EPnUNk8dRnnqR2xnYXg9Tf+g=="
+      },
+      "Microsoft.NETFramework.ReferenceAssemblies.net462": {
+        "type": "Transitive",
+        "resolved": "1.0.3",
+        "contentHash": "IzAV30z22ESCeQfxP29oVf4qEo8fBGXLXSU6oacv/9Iqe6PzgHDKCaWfwMBak7bSJQM0F5boXWoZS+kChztRIQ=="
       },
       "Newtonsoft.Json": {
         "type": "Transitive",

--- a/dotnet/RAWeb.Server.Management/packages.lock.json
+++ b/dotnet/RAWeb.Server.Management/packages.lock.json
@@ -2,6 +2,15 @@
   "version": 1,
   "dependencies": {
     ".NETFramework,Version=v4.6.2": {
+      "Microsoft.NETFramework.ReferenceAssemblies": {
+        "type": "Direct",
+        "requested": "[1.0.3, )",
+        "resolved": "1.0.3",
+        "contentHash": "vUc9Npcs14QsyOD01tnv/m8sQUnGTGOw1BCmKcv77LBJY7OxhJ+zJF7UD/sCL3lYNFuqmQEVlkfS4Quif6FyYg==",
+        "dependencies": {
+          "Microsoft.NETFramework.ReferenceAssemblies.net462": "1.0.3"
+        }
+      },
       "Newtonsoft.Json": {
         "type": "Direct",
         "requested": "[13.0.4, )",
@@ -19,6 +28,11 @@
         "requested": "[4.6.1, )",
         "resolved": "4.6.1",
         "contentHash": "+RJT4qaekpZ7DDLhf+LTjq+E48jieKiY9ulJ+BoxKmZblIJfIJT8Ufcaa/clQqnYvWs8jugfGSMu8ylS0caG0w=="
+      },
+      "Microsoft.NETFramework.ReferenceAssemblies.net462": {
+        "type": "Transitive",
+        "resolved": "1.0.3",
+        "contentHash": "IzAV30z22ESCeQfxP29oVf4qEo8fBGXLXSU6oacv/9Iqe6PzgHDKCaWfwMBak7bSJQM0F5boXWoZS+kChztRIQ=="
       }
     },
     "net10.0-windows7.0": {

--- a/dotnet/RAWeb.Server.Utilities/packages.lock.json
+++ b/dotnet/RAWeb.Server.Utilities/packages.lock.json
@@ -12,6 +12,15 @@
           "System.Text.Json": "9.0.0"
         }
       },
+      "Microsoft.NETFramework.ReferenceAssemblies": {
+        "type": "Direct",
+        "requested": "[1.0.3, )",
+        "resolved": "1.0.3",
+        "contentHash": "vUc9Npcs14QsyOD01tnv/m8sQUnGTGOw1BCmKcv77LBJY7OxhJ+zJF7UD/sCL3lYNFuqmQEVlkfS4Quif6FyYg==",
+        "dependencies": {
+          "Microsoft.NETFramework.ReferenceAssemblies.net462": "1.0.3"
+        }
+      },
       "PolySharp": {
         "type": "Direct",
         "requested": "[1.15.0, )",
@@ -25,6 +34,11 @@
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
+      },
+      "Microsoft.NETFramework.ReferenceAssemblies.net462": {
+        "type": "Transitive",
+        "resolved": "1.0.3",
+        "contentHash": "IzAV30z22ESCeQfxP29oVf4qEo8fBGXLXSU6oacv/9Iqe6PzgHDKCaWfwMBak7bSJQM0F5boXWoZS+kChztRIQ=="
       },
       "Newtonsoft.Json": {
         "type": "Transitive",

--- a/dotnet/RAWeb.Server.Utilities/src/RegistryUtilities.cs
+++ b/dotnet/RAWeb.Server.Utilities/src/RegistryUtilities.cs
@@ -143,6 +143,19 @@ public class RegistryReader {
         }
 
         var rdpFileContent = rdpBuilder.ToString();
+
+        if (PoliciesManager.RawPolicies["App.RDP.StripSignatures"] == "true") {
+            var lines = rdpFileContent.Split(new[] { "\r\n", "\n" }, StringSplitOptions.None);
+            var newRdpBuilder = new StringBuilder();
+            foreach (var line in lines) {
+                if (line.StartsWith("signscope:s:", StringComparison.OrdinalIgnoreCase) || line.StartsWith("signature:s:", StringComparison.OrdinalIgnoreCase)) {
+                    continue;
+                }
+                newRdpBuilder.AppendLine(line);
+            }
+            rdpFileContent = newRdpBuilder.ToString().TrimEnd() + Environment.NewLine;
+        }
+
         return rdpFileContent;
     }
 

--- a/dotnet/RAWebServer/packages.lock.json
+++ b/dotnet/RAWebServer/packages.lock.json
@@ -2,6 +2,15 @@
   "version": 1,
   "dependencies": {
     ".NETFramework,Version=v4.6.2": {
+      "Microsoft.NETFramework.ReferenceAssemblies": {
+        "type": "Direct",
+        "requested": "[1.0.3, )",
+        "resolved": "1.0.3",
+        "contentHash": "vUc9Npcs14QsyOD01tnv/m8sQUnGTGOw1BCmKcv77LBJY7OxhJ+zJF7UD/sCL3lYNFuqmQEVlkfS4Quif6FyYg==",
+        "dependencies": {
+          "Microsoft.NETFramework.ReferenceAssemblies.net462": "1.0.3"
+        }
+      },
       "PolySharp": {
         "type": "Direct",
         "requested": "[1.15.0, )",
@@ -30,6 +39,11 @@
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
+      },
+      "Microsoft.NETFramework.ReferenceAssemblies.net462": {
+        "type": "Transitive",
+        "resolved": "1.0.3",
+        "contentHash": "IzAV30z22ESCeQfxP29oVf4qEo8fBGXLXSU6oacv/9Iqe6PzgHDKCaWfwMBak7bSJQM0F5boXWoZS+kChztRIQ=="
       },
       "Newtonsoft.Json": {
         "type": "Transitive",

--- a/dotnet/RAWebServer/src/api/auth/Authenticate.cs
+++ b/dotnet/RAWebServer/src/api/auth/Authenticate.cs
@@ -195,7 +195,10 @@ namespace RAWebServer.Api {
 
     private bool ShouldAuthenticateAnonymously(string username) {
       var anonSetting = PoliciesManager.RawPolicies["App.Auth.Anonymous"];
-      return anonSetting == "always" || (anonSetting == "allow" && username == "RAWEB\\anonymous");
+      if (anonSetting == "always" || anonSetting == "allow") {
+        return username == "RAWEB\\anonymous" || string.IsNullOrEmpty(username);
+      }
+      return false;
     }
 
     private class ParsedCredentialsBody {

--- a/dotnet/RAWebServer/src/handlers/GuacdTunnel.cs
+++ b/dotnet/RAWebServer/src/handlers/GuacdTunnel.cs
@@ -844,7 +844,7 @@ public class GuacdTunnel : HttpTaskAsyncHandler {
                                 "ignore-cert" => shouldIgnoreTermServCertificateErrors ? "true" : "false",
                                 // session settings
                                 "client-name" => "RAWeb",
-                                "console" => "true",
+                                "console" => "false",
                                 "timezone" => timezone,
                                 // display settings
                                 "color-depth" => colorDepth.ToString(),

--- a/frontend/lib/Login.vue
+++ b/frontend/lib/Login.vue
@@ -24,8 +24,10 @@
     }
     window.history.replaceState({}, '', window.location.pathname); // remove the query string from the URL
 
+    const forceAdmin = searchParams.get('admin') === 'true';
+
     // use anonymous authentication if it is enabled in always mode
-    if (policies.anonymousAuthentication === 'always') {
+    if (policies.anonymousAuthentication === 'always' && !forceAdmin) {
       proceedAsAnonymous();
     }
 

--- a/frontend/lib/appRouter.ts
+++ b/frontend/lib/appRouter.ts
@@ -71,6 +71,12 @@ router.afterEach((to, from) => {
 });
 
 router.beforeEach((to, from, next) => {
+  if (to.path === '/admin') {
+    const base = new URL(document.baseURI.replace('/index.html', '/')).pathname;
+    window.location.href = base + 'login?admin=true';
+    return next(false);
+  }
+
   if (!simpleModeEnabled.value && to.path === '/simple') {
     return next('/favorites');
   }
@@ -86,6 +92,13 @@ router.beforeEach((to, from, next) => {
   const coreAppData = useCoreDataStore();
   if (!coreAppData.authUser.isLocalAdministrator && to.path === '/policies') {
     return next('/favorites');
+  }
+
+  if (
+    (coreAppData.authUser.username === 'anonymous' || coreAppData.authUser.username === 'UNAUTHENTICATED') &&
+    to.path === '/settings'
+  ) {
+    return next(goHome());
   }
 
   const { capabilities } = useCoreDataStore();

--- a/frontend/lib/components/Navigation/NavigationRail.vue
+++ b/frontend/lib/components/Navigation/NavigationRail.vue
@@ -43,7 +43,7 @@
         </li>
 
         <!-- Devices -->
-        <li>
+        <li v-if="authUser.username !== 'UNAUTHENTICATED'">
           <RouterLink to="/devices" custom v-slot="{ href, isActive, navigate }">
             <RailButton :href="href" :active="isActive" @click="navigate">
               <template v-slot:icon>
@@ -173,7 +173,7 @@
       </RouterLink>
 
       <!-- Settings -->
-      <RouterLink to="/settings" custom v-slot="{ href, isActive, navigate }">
+      <RouterLink v-if="authUser.username !== 'UNAUTHENTICATED' && authUser.username !== 'anonymous'" to="/settings" custom v-slot="{ href, isActive, navigate }">
         <RailButton :href="href" :active="isActive" @click="navigate">
           <template v-slot:icon>
             <!-- settings svg normal -->
@@ -198,7 +198,7 @@
       </RouterLink>
 
       <!-- Wiki (external link, not router) -->
-      <RailButton :href="docsUrl" target="_blank" @click.prevent="openHelpPopup(docsUrl)">
+      <RailButton v-if="authUser.username !== 'UNAUTHENTICATED' && authUser.username !== 'anonymous'" :href="docsUrl" target="_blank" @click.prevent="openHelpPopup(docsUrl)">
         <template v-slot:icon>
           <svg width="24" height="24" fill="none" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
             <path

--- a/frontend/lib/components/Titlebar/Titlebar.vue
+++ b/frontend/lib/components/Titlebar/Titlebar.vue
@@ -263,7 +263,10 @@
             !hideProfileMenu &&
             simpleModeEnabled &&
             route.path !== '/settings' &&
-            route.path !== '/policies'
+            route.path !== '/policies' &&
+            authUser &&
+            authUser.username !== 'anonymous' &&
+            authUser.username !== 'UNAUTHENTICATED'
           "
         >
           <svg width="24" height="24" fill="none" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
@@ -277,7 +280,7 @@
       <MenuFlyout
         placement="bottom"
         anchor="end"
-        v-if="!hideProfileMenu && authUser && policies.anonymousAuthentication !== 'always'"
+        v-if="!hideProfileMenu && authUser && authUser.username !== 'UNAUTHENTICATED' && authUser.username !== 'anonymous'"
       >
         <template v-slot="{ popoverId }">
           <Button

--- a/frontend/lib/dialogs/ManagedResourceListDialog.vue
+++ b/frontend/lib/dialogs/ManagedResourceListDialog.vue
@@ -19,7 +19,7 @@
   const { isPending, isFetching, isError, data, error, refetch, dataUpdatedAt } = useQuery({
     queryKey: ['remote-app-registry'],
     queryFn: async () => {
-      return fetch(`${iisBase}api/management/resources/registered`)
+      return fetch(`${iisBase}api/management/resources/registered?t=${Date.now()}`)
         .then(async (res) => {
           if (!res.ok) {
             await res.json().then((err) => {

--- a/frontend/lib/i18n.ts
+++ b/frontend/lib/i18n.ts
@@ -16,7 +16,12 @@ export const i18nextPromise = i18next
   .init({
     debug: false,
     lng: (() => {
-      if (typeof window === 'undefined' || !('language' in navigator)) {
+      if (typeof window === 'undefined') {
+        return undefined;
+      }
+      const stored = localStorage.getItem('raweb-language');
+      if (stored) return stored;
+      if (!('language' in navigator)) {
         return undefined;
       }
       return navigator.language;

--- a/frontend/lib/pages/Policies.vue
+++ b/frontend/lib/pages/Policies.vue
@@ -110,6 +110,22 @@
     transformVisibleState?: (state: 'enabled' | 'disabled' | 'unset') => 'enabled' | 'disabled' | 'unset';
   }[] = [
     {
+      key: 'App.Auth.Anonymous',
+      appliesTo: ['Web client'],
+      transformVisibleState: () => {
+        if (!data.value) return 'unset';
+        const state = data.value['App.Auth.Anonymous'];
+        if (state === 'always' || state === 'allow') return 'enabled';
+        if (state === 'never') return 'disabled';
+        return 'unset';
+      },
+      onApply: async (closeDialog, state: boolean | null) => {
+        const val = state === true ? 'always' : state === false ? 'never' : null;
+        await setPolicy('App.Auth.Anonymous', val);
+        closeDialog();
+      },
+    },
+    {
       key: 'App.FavoritesEnabled',
       appliesTo: ['Web client'],
       onApply: async (closeDialog, state: boolean | null) => {
@@ -165,6 +181,20 @@
 
         const aliasesString = extraFieldsState.aliases.map(([key, val]) => `${key}=${val}`).join(';');
         await setPolicy('TerminalServerAliases', aliasesString);
+        closeDialog();
+      },
+    },
+    {
+      key: 'App.RDP.StripSignatures',
+      appliesTo: ['Web client', 'Workspace'],
+      transformVisibleState() {
+        if (!data.value) return 'unset';
+        const value = data.value['App.RDP.StripSignatures'];
+        if (value === 'true') return 'enabled';
+        return 'unset';
+      },
+      onApply: async (closeDialog, state: boolean | null) => {
+        await setPolicy('App.RDP.StripSignatures', state ? 'true' : null);
         closeDialog();
       },
     },

--- a/frontend/lib/pages/Settings.vue
+++ b/frontend/lib/pages/Settings.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { Button, ContentDialog, InfoBar, TextBlock, ToggleSwitch } from '$components';
+  import { Button, ContentDialog, InfoBar, Select, TextBlock, ToggleSwitch } from '$components';
   import { useCoreDataStore } from '$stores';
   import {
     combineTerminalServersModeEnabled,
@@ -217,12 +217,40 @@
       loadingConnectionFile.value = false;
     }
   }
+
+  const currentLanguage = ref(localStorage.getItem('raweb-language') || navigator.language.split('-')[0]);
+  function changeLanguage() {
+    if (currentLanguage.value) {
+      localStorage.setItem('raweb-language', currentLanguage.value);
+    } else {
+      localStorage.removeItem('raweb-language');
+    }
+    window.location.reload();
+  }
 </script>
 
 <template>
   <div class="titlebar-row">
     <TextBlock variant="title">{{ t('settings.title') }}</TextBlock>
   </div>
+  <section>
+    <div class="section-title-row">
+      <TextBlock variant="subtitle">Language / Dil</TextBlock>
+    </div>
+    <div class="favorites">
+      <Select v-model="currentLanguage" @change="changeLanguage">
+        <option value="">Browser Default</option>
+        <option value="en">English</option>
+        <option value="tr">Türkçe</option>
+        <option value="zh">中文</option>
+        <option value="de">Deutsch</option>
+        <option value="fr">Français</option>
+        <option value="it">Italiano</option>
+        <option value="es">Español</option>
+        <option value="ru">Русский</option>
+      </Select>
+    </div>
+  </section>
   <section>
     <div class="section-title-row">
       <TextBlock variant="subtitle">{{ t('settings.favorites.title') }}</TextBlock>

--- a/frontend/lib/public/locales/en.json
+++ b/frontend/lib/public/locales/en.json
@@ -130,6 +130,10 @@
       "state": "State",
       "options": "Options"
     },
+    "App.Auth.Anonymous": {
+      "title": "Allow anonymous authentication",
+      "help": "When enabled, users automatically log in with an anonymous (guest) account without entering any password."
+    },
     "TerminalServerAliases": {
       "title": "Configure aliases for terminal servers",
       "help": "Customize the name of the hosting server that appears in RAWeb or any of the remote desktop clients, or customize the names of the terminal servers for your remote apps and desktops. \n\nWhen enabled, you can add aliases for terminal servers. The alias will be used in the RAWeb interface and all workspace clients. \n\nIf disabled or not configured, the terminal server names will be used as-is. \n\nExample: If you have a terminal server named 'TS1' and you want it to appear as 'Geospatial Analysis Server', you can add an alias with 'TS1' as the key and 'Geospatial Analysis Server' as the value. "
@@ -281,6 +285,10 @@
     "GuacdWebClient.Security.AllowIgnoreGatewayCertErrors": {
       "title": "Allow ignoring gateway certificate errors in the web client",
       "help": "Controls whether users can ignore gateway certificate errors when connecting via the web client. \n\nIf enabled, users will be able to ignore gateway certificate errors when connecting via the web client. \n\nIf disabled or not configured, users will not be able to ignore gateway certificate errors when connecting via the web client."
+    },
+    "App.RDP.StripSignatures": {
+      "title": "Strip RDP Signatures (Unlock Clipboard and Drives)",
+      "help": "When enabled, digital signatures from Centralized Publishing (RDS Broker) are stripped from the RDP connection. This allows users to freely check and uncheck options like Clipboard, Printers, and Local Drives before connecting."
     }
   },
   "wiki": {
@@ -1077,8 +1085,8 @@
         "refresh": "Refresh"
       },
       "create": {
-        "title": "Add new resource",
-        "409": "A resource with this unique identifier already exists. Please choose a different unique identifier."
+        "409": "A resource with this unique identifier already exists. Please choose a different unique identifier.",
+        "title": "Add new resource"
       },
       "remove": {
         "title": "Remove {{app_name}}?",

--- a/frontend/lib/public/locales/tr.json
+++ b/frontend/lib/public/locales/tr.json
@@ -1,0 +1,1247 @@
+{
+  "appName": "RemoteApp'ler",
+  "longAppName": "RemoteApp ve Masaüstü Bağlantıları",
+  "device": "cihaz",
+  "app": "uygulama",
+  "application": "başvuru",
+  "pleaseWait": "Lütfen bekleyin…",
+  "unknownError": "Beklenmeyen bir hata oluştu.",
+  "dialog": {
+    "help": "Yardım",
+    "close": "Kapalı",
+    "cancel": "İptal etmek",
+    "ok": "TAMAM",
+    "always": "Her zaman",
+    "once": "Sadece bir kez",
+    "yes": "Evet",
+    "no": "HAYIR"
+  },
+  "mgtOffline": {
+    "title": "RAWeb yönetim hizmeti çevrimdışı",
+    "message": "RAWeb sunucusunda yönetim hizmeti çalışmadığından RAWeb hiçbir kaynağa erişemiyor.\n\nBu sorunu çözmek için lütfen yöneticinizle iletişime geçin."
+  },
+  "profile": {
+    "changePassword": "Şifreyi değiştirme",
+    "signOut": "oturumu Kapat"
+  },
+  "titlebar": {
+    "updateAvailable": "Güncelleme mevcut"
+  },
+  "favorites": {
+    "title": "Favoriler",
+    "getStarted": "Favorileri kullanmaya başlayın",
+    "prose": {
+      "description": "Favorilere ekleme, en çok kullandığınız cihazlara ve uygulamalara ulaşmanızı kolaylaştırır.",
+      "howTo": "Cihaz veya uygulama adının yanındaki menü düğmesini kullanarak favorilere ekleyin."
+    },
+    "allDevices": "Tüm cihazlar",
+    "allApps": "Tüm uygulamalar",
+    "goToDevices": "Cihazlara git",
+    "goToApps": "Uygulamalara git",
+    "disable": "Favorileri devre dışı bırak"
+  },
+  "devices": {
+    "title": "Cihazlar",
+    "search": "Cihazları arayın"
+  },
+  "apps": {
+    "title": "Uygulamalar",
+    "search": "Uygulamaları arayın"
+  },
+  "simple": {
+    "title": "Uygulamalar ve masaüstü bilgisayarlar",
+    "search": "Uygulamaları ve masaüstü bilgisayarları arayın"
+  },
+  "settings": {
+    "title": "Ayarlar",
+    "favorites": {
+      "title": "Favoriler",
+      "disabledNoAnchorPos": "Tarayıcınız CSS Bağlantı Konumlandırmayı desteklemediğinden bu ayar devre dışı bırakıldı.",
+      "switch": "Favorileri etkinleştir",
+      "import": "İçe aktarmak",
+      "export": "İhracat"
+    },
+    "openConnectionsInNewWindow": {
+      "title": "Web istemcisi görüntüleme yöntemi",
+      "desc": "Web istemcisi aracılığıyla başlatılan bağlantıların yeni bir pencerede mi yoksa aynı pencerede mi açılacağını seçin. Bu ayar yalnızca web istemcisi aracılığıyla başlatılan bağlantılar için geçerlidir ve indirilen RDP dosyaları veya rdp:// protokol işleyicisi aracılığıyla başlatılan bağlantıları etkilemez.",
+      "switch": "Web istemcisi bağlantılarını yeni bir pencerede aç"
+    },
+    "flatMode": {
+      "title": "Klasörleri düzleştir",
+      "desc": "Klasörleri destekleyen görünümlerde, tüm uygulamaları ve masaüstlerini tek bir listede gösterecek şekilde klasörleri düzleştirin.",
+      "switch": "Düz modu etkinleştir"
+    },
+    "iconBackgrounds": {
+      "title": "Simge arka planları",
+      "desc": "Daha iyi görünürlük için uygulama ve masaüstü simgelerine dolgulu kare bir arka plan ekleyin.",
+      "switch": "Simge arka planlarını etkinleştir"
+    },
+    "combineTerminalServersMode": {
+      "title": "Uygulamaları sunucular arasında birleştirin",
+      "desc": "Barındırıldıkları terminal sunucularının sayısına bakılmaksızın her uygulama için yalnızca bir simge gösterin. Birden fazla terminal sunucusu mevcutsa, uygulama başlatılırken bir tanesinin seçilmesine yönelik bir istem gösterilecektir.",
+      "switch": "Birleştirilmiş uygulamaları etkinleştir",
+      "disabledNoDialogs": "Tarayıcınız <code> &lt; iletişim kutusu &#47; &gt; </code> öğelerinde <code> requestClose() </code> yöntemini desteklemediğinden bu ayar devre dışı bırakıldı"
+    },
+    "simpleMode": {
+      "title": "Basit mod",
+      "desc": "Uygulamaların ve masaüstü bilgisayarların kompakt, birleştirilmiş, tek sayfalı bir listesini kullanmak için basit modu etkinleştirin.",
+      "desc2": "Klasörleri düzleştirme seçeneği desteklenir. Diğer tüm sayfalar ve özellikler devre dışı bırakılacaktır.",
+      "switch": "Basit modu etkinleştir"
+    },
+    "hidePorts": {
+      "title": "Bağlantı noktalarını terminal sunucusu adlarından gizle",
+      "desc": "Ana bilgisayar adı için yalnızca bir bağlantı noktası kullanıldığında, terminal sunucusunun bağlantı noktasını uygulamalar ve masaüstü bilgisayarlar listesinden gizleyin",
+      "switch": "Mümkün olduğunda bağlantı noktalarını gizle"
+    },
+    "workspaceUrl": {
+      "title": "Çalışma alanı URL'si",
+      "copy": "Çalışma alanı URL'sini kopyala",
+      "copyEmail": "Çalışma alanı e-postasını kopyala",
+      "downloadConnectionFile": "Bağlantı dosyasını indir"
+    },
+    "about": {
+      "title": "Hakkında",
+      "appDesc": "Windows 10, 11 ve Server'da barındırılan RemoteApp'leriniz ve Masaüstleriniz için bir web arayüzü. RAWeb tarafından desteklenmektedir.",
+      "learnMore": "GitHub'da daha fazla bilgi edinin",
+      "coreVersion": "Sunucu sürümü",
+      "webVersion": "Uygulama sürümü",
+      "updates": {
+        "checking": "Güncellemeler kontrol ediliyor…",
+        "available": "Bir güncelleme mevcut",
+        "rateLimited": "Güncellemeler kontrol edilemedi (hız sınırlı). Lütfen daha sonra tekrar deneyin.",
+        "upToDate": "Güncel"
+      }
+    }
+  },
+  "policies": {
+    "title": "Politikalar",
+    "alertTitle": "Hata",
+    "table": {
+      "setting": "Ayar",
+      "state": "Durum"
+    },
+    "state": {
+      "enabled": "Etkinleştirilmiş",
+      "disabled": "Engelli",
+      "unset": "Yapılandırılmadı"
+    },
+    "dialog": {
+      "help": "Tanım",
+      "state": "Durum",
+      "options": "Seçenekler"
+    },
+    "App.Auth.Anonymous": {
+      "title": "Anonim kimlik doğrulamaya izin ver",
+      "help": "Etkinleştirildiğinde, kullanıcılar herhangi bir şifre girmeden otomatik olarak anonim (misafir) hesabıyla sisteme giriş yaparlar."
+    },
+    "TerminalServerAliases": {
+      "title": "Terminal sunucuları için takma adları yapılandırma",
+      "help": "RAWeb'de veya uzak masaüstü istemcilerinden herhangi birinde görünen barındırma sunucusunun adını özelleştirin veya uzak uygulamalarınız ve masaüstleriniz için terminal sunucularının adlarını özelleştirin. \n\nEtkinleştirildiğinde terminal sunucuları için takma adlar ekleyebilirsiniz. Takma ad, RAWeb arayüzünde ve tüm çalışma alanı istemcilerinde kullanılacaktır. \n\nDevre dışı bırakılırsa veya yapılandırılmazsa terminal sunucusu adları olduğu gibi kullanılacaktır. \n\nÖrnek: 'TS1' adında bir terminal sunucunuz varsa ve bunun 'Geospatial Analysis Server' olarak görünmesini istiyorsanız, anahtar olarak 'TS1' ve değer olarak 'Geospatial Analysis Server' olan bir takma ad ekleyebilirsiniz."
+    },
+    "App.CombineTerminalServersModeEnabled": {
+      "title": "Uygulamaları terminal sunucularında birleştirin",
+      "help": "RemoteApp'leri terminal sunucuları arasında birleştirme seçeneğinin kullanılabilirliğini kontrol eder. \n\nEtkinleştirilirse, barındırıldıkları terminal sunucularının sayısına bakılmaksızın her uygulama için yalnızca bir simge gösterilecektir. Birden fazla terminal sunucusu mevcutsa, uygulama başlatılırken bir tanesinin seçilmesine yönelik bir istem gösterilecektir. \n\nDevre dışı bırakılırsa her terminal sunucusu, her uygulama için kendi simgesini gösterecektir. \n\nYapılandırılmadığı takdirde her kullanıcı bu ayarı kontrol edebilecektir. Varsayılan olarak etkin olacaktır."
+    },
+    "App.FavoritesEnabled": {
+      "title": "Favorileri etkinleştir",
+      "help": "RAWeb'deki sık kullanılanlar özelliğinin kullanılabilirliğini kontrol eder. \n\nEtkinleştirilirse, kullanıcılar uygulamaları ve masaüstü bilgisayarları favorilerine ekleyebilecek ve bunlara favoriler sayfasından erişebilecek. \n\nDevre dışı bırakılırsa favoriler özelliği kullanılamayacaktır. \n\nYapılandırılmadığı takdirde her kullanıcı bu ayarı kontrol edebilecektir."
+    },
+    "App.OpenConnectionsInNewWindowEnabled": {
+      "title": "Web istemcisi bağlantılarını yeni bir pencerede aç",
+      "help": "RAWeb'de web istemcisi bağlantılarını yeni bir pencerede açma seçeneğinin kullanılabilirliğini kontrol eder. \n\nEtkinleştirilirse web istemcisi bağlantıları yeni bir pencerede açılacaktır. \n\nDevre dışı bırakılırsa web istemcisi bağlantıları geçerli pencereyi devralır. \n\nYapılandırılmadığı takdirde her kullanıcı bu ayarı kontrol edebilecektir."
+    },
+    "App.FlatModeEnabled": {
+      "title": "Klasörleri düzleştir",
+      "help": "RAWeb'deki düz mod özelliğinin kullanılabilirliğini kontrol eder. \n\nEtkinleştirilirse, klasörler tüm uygulamaları tek bir listede gösterecek şekilde düzleştirilir. \n\nDevre dışı bırakılırsa klasörler olduğu gibi gösterilir. \n\nYapılandırılmadığı takdirde her kullanıcı bu ayarı kontrol edebilecektir."
+    },
+    "App.IconBackgroundsEnabled": {
+      "title": "Kartlardaki simgeler için arka planları göster",
+      "help": "RAWeb'deki simge arka planları özelliğinin kullanılabilirliğini kontrol eder. \n\nEtkinleştirilirse, daha iyi görünürlük için uygulama ve masaüstü simgelerine dolgulu kare bir arka plan eklenecektir. Kare arka plan yalnızca görüntüleme modu 'kart' olduğunda eklenir. \n\nDevre dışı bırakılırsa simgelerin arka planı olmaz. \n\nYapılandırılmadığı takdirde her kullanıcı bu ayarı kontrol edebilecektir."
+    },
+    "App.SimpleModeEnabled": {
+      "title": "Yalnızca uygulamaların ve masaüstü bilgisayarların birleştirilmiş listesini göster",
+      "help": "RAWeb'deki basit mod özelliğinin kullanılabilirliğini kontrol eder. \n\nEtkinleştirilirse, masaüstü bilgisayarlar ve uygulamalar için ayrı sekmeler yerine uygulamaların ve masaüstü bilgisayarların kompakt, birleştirilmiş, tek sayfalık bir listesi gösterilecektir. \n\nDevre dışı bırakılırsa tam RAWeb arayüzü kullanılabilir olacaktır. \n\nYapılandırılmadığı takdirde her kullanıcı bu ayarı kontrol edebilecektir. \n\nBu ayarın yalnızca aşağıdaki durumlarda etkisi vardır:"
+    },
+    "App.HidePortsEnabled": {
+      "title": "Bağlantı noktalarını terminal sunucusu adlarından gizle",
+      "help": "Ana bilgisayar adı için yalnızca bir bağlantı noktası kullanıldığında, terminal sunucusunun bağlantı noktasının uygulamalar ve masaüstü bilgisayarlar listesinden gizlenip gizlenmeyeceğini kontrol eder. \n\nEtkinleştirilirse bağlantı noktası, uygulamalar ve masaüstü bilgisayarlar listesindeki terminal sunucusu adından gizlenecektir. \n\nDevre dışı bırakılırsa bağlantı noktası terminal sunucusu adında gösterilecektir. \n\nYapılandırılmadığı takdirde her kullanıcı bu ayarı kontrol edebilecektir."
+    },
+    "App.ConnectionMethod.RdpFileDownload.Enabled": {
+      "title": "RDP dosyası indirme bağlantı yöntemine izin ver",
+      "help": "Bağlantı yöntemi iletişim kutusunda RDP dosyası indirme seçeneğinin görünüp görünmeyeceğini kontrol eder. \n\nEtkinleştirilirse veya yapılandırılmazsa, bağlantı yöntemi iletişim kutusunda RDP dosyası indirme seçeneği görünecektir. \n\nDevre dışı bırakılırsa, RDP dosyası indirme seçeneği bağlantı yöntemi iletişim kutusunda gizlenecektir."
+    },
+    "App.ConnectionMethod.RdpProtocol.Enabled": {
+      "title": "RDP URL protokolüne (rdp://) bağlantı yöntemine izin ver",
+      "help": "Bağlantı yöntemi iletişim kutusunda rdp:// seçeneğinin görünüp görünmeyeceğini kontrol eder. \n\nEtkinleştirilmişse veya yapılandırılmamışsa, bağlantı yöntemi iletişim kutusunda rdp:// seçeneği görünecektir. \n\nDevre dışı bırakılırsa, rdp:// seçeneği bağlantı yöntemi iletişim kutusunda gizlenecektir."
+    },
+    "RegistryApps.Enabled": {
+      "title": "Genel liste yerine kayıt defterinde RemoteApps için özel bir koleksiyon kullanın",
+      "help": "RAWeb'in, geçerli RAWeb kurulumuna veya genel izin verilenler listesine ayrılmış bir koleksiyonda kayıt defterinde depolanan RemoteApp'leri oluşturup oluşturmadığını, değiştirip değiştirmediğini ve aradığını kontrol eder. \n\nEtkinleştirilirse veya yapılandırılmazsa RemoteApps, HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Terminal Server\\CentralPublishedResources\\PublishedFarms içindeki özel bir koleksiyondan algılanacaktır. RemoteApp'ler özel koleksiyonda ve genel izin verilenler listesinde saklanacaktır. \n\nDevre dışı bırakılırsa, RemoteApp'ler HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Terminal Server\\TSAppAllowList genel izin verilenler listesinden algılanacak ve bu listeye yazılacaktır. \n\nRemoteApp'ler, politikalar sayfasının üst kısmındaki 'Kayıt defteri RemoteApp'lerini yönet' düğmesi aracılığıyla kayıt defterine eklenebilir. RemoteApp'leri eklemek için önerilen yöntem budur. \n\nRemoteApp'ler, RemoteApp Aracı kullanılarak kayıt defterine de eklenebilir. RemoteApp'in RAWeb'e dahil edilebilmesi için 'TSWebAccess' seçeneği 'Evet' olarak ayarlanmalı ve bu ayar devre dışı bırakılmalıdır. RemoteApp Aracının yalnızca daha sınırlı sayıda özelliği desteklediğini unutmayın."
+    },
+    "RegistryApps.FullAddressOverride": {
+      "title": "Kayıt defterinde listelenen RemoteApps için oluşturulan RDP dosyalarının tam adresini geçersiz kılın",
+      "help": "Yönetilen RemoteApp'ler için oluşturulan RDP dosyalarındaki varsayılan 'tam adresi' değiştirin. Varsayılan olarak 'tam adres', terminal sunucusunun IPv4 adresi ve RDP bağlantı noktasından oluşur. \n\nEtkinleştirilirse 'tam adres', kaynak seçeneğinin değerine ayarlanacaktır. \n\nDevre dışı bırakılırsa veya yapılandırılmazsa, tam adres varsayılandan değiştirilmez.\n\nKaynak seçeneği, https://example.com:3389 gibi iyi biçimlendirilmiş bir kaynak olmalıdır. Bağlantı noktası isteğe bağlıdır ve belirtilmediği takdirde çoğu istemci tarafından varsayılan RDP bağlantı noktası (3389) kullanılacaktır. \n\nBu seçenek, terminal sunucusunun bir ters proxy arkasında olduğu veya belirli bir ana bilgisayar adı veya IP adresi aracılığıyla erişilmesi gerektiği durumlarda kullanışlıdır."
+    },
+    "RegistryApps.AdditionalProperties": {
+      "title": "Kayıt defterinde listelenen RemoteApps'e ek RDP dosya özellikleri ekleyin",
+      "help": "Kayıt defterinde listelenen RemoteApps için oluşturulan RDP dosyalarına eklenecek RDP dosya özelliklerini belirtin. \n\nEtkinleştirilirse belirtilen özellikler RDP dosyasına eklenecektir. \n\nDevre dışı bırakılırsa veya yapılandırılmazsa hiçbir ek özellik eklenmez. \n\nÖzellikler tam olarak RDP dosyasında görünecekleri şekilde belirtilmelidir. Her seferinde bir özellik belirtin. Özellikler RDP dosyasına olduğu gibi ekleneceğinden bunların geçerli RDP özellikleri olduğundan emin olun. \n\nÖzelliklerin açıklamalarını https://kimmknight.github.io/rdpfileeditor adresinde bulabilirsiniz."
+    },
+    "Workspace.ShowMultiuserResourcesUserAndGroupNames": {
+      "title": "Çok kullanıcılı kaynakları, ilişkili kullanıcı veya grup adıyla sanal klasörlere yerleştirin",
+      "help": "Kullanıcı ve grup kaynaklarının, çalışma alanı akışında ilişkili kullanıcı veya grup adıyla birlikte sanal klasörlere yerleştirilip yerleştirilmeyeceğini kontrol eder. \n\nEtkinleştirilirse veya yapılandırılmazsa, kullanıcı ve grup kaynakları, ilişkili kullanıcı veya grup adıyla eşleşen sanal bir klasöre yerleştirilecektir. \n\nDevre dışı bırakılırsa kaynaklar kök sanal klasöre yerleştirilecektir. \n\nÖrneğin, '/multiuser-resources/users/kimmknight/tools' klasöründeki bir kaynak, etkinleştirildiğinde veya yapılandırılmadığında '/kimmknight/tools' ve devre dışı bırakıldığında '/tools' adlı sanal bir klasöre yerleştirilecektir."
+    },
+    "UserCache.Enabled": {
+      "title": "Kullanıcı önbelleğini etkinleştir",
+      "help": "Kullanıcı önbelleğinin etkin olup olmadığını kontrol eder. Kullanıcı önbelleğinin etkinleştirilmesi, etki alanı denetleyicisine RAWeb tarafından erişilemediğinde bile oturum açma işlemlerinin gerçekleştirilmesine olanak tanır. \n\nÖnbellek etkinleştirildiğinde, oturum açma işlemleri yalnızca hesap daha önce etki alanı denetleyicisine ulaşılırken RAWeb'de oturum açmışsa veya hesap daha önce RAWeb'i barındıran cihazda oturum açmışsa gerçekleşebilir. \n\nÖnbellek, \"App_Data\\usercache.sqlite\" konumundaki bir SQLite veritabanında depolanır. Önbellek kullanıcı adını, etki alanını, kullanıcı SID'sini, tam adını ve grupları (SID'ler ve adlar) içerir. \n\nÖnbellek yalnızca bu politika etkinleştirildiğinde oluşturulur ve güncellenir. Bu politika daha önce etkinleştirildikten sonra devre dışı bırakılırsa önbellek silinmez. \n\nEtkinleştirilirse etki alanı denetleyicisine ulaşılamadığında kullanıcı önbelleği kullanılır. \n\nDevre dışı bırakılırsa veya yapılandırılmazsa kullanıcı önbelleği hiçbir zaman kullanılmaz."
+    },
+    "UserCache.StaleWhileRevalidate": {
+      "title": "Yeniden doğrulama gerekmeden önce, önbelleğe alınan kullanıcı kimlik bilgilerinin izin verilen maksimum yaşını yapılandırın",
+      "help": "RAWeb'in önbelleğe alınmış kimlik bilgileriyle ne zaman anında yanıt verebileceğini kontrol eder. Bu politikanın etkili olması için kullanıcı önbelleğinin etkinleştirilmesi gerekir. \n\nYanıt vermeden önce etki alanı denetleyicisinden kullanıcı bilgilerini almak yerine, daha hızlı yanıtlar için kullanıcı önbelleği kullanılabilir. Bu, etki alanı denetleyicisinin uzak bir sitede olması nedeniyle yavaş yanıt verdiği durumlarda önemlidir. \n\nBu seçenekle RAWeb, eski olmayan, önbelleğe alınmış kimlik bilgilerini hemen kullanır. Her istekten sonra kimlik bilgileri arka planda yeniden doğrulanır. Bu davranış, HTTP'nin eskimişken yeniden doğrulama davranışına benzer. Yeniden doğrulama 5 saniye süreyle iptal edilir. \n\nEtkinleştirilirse, RAWeb'in istemci isteklerine yanıt vermeden önce bunları yeniden doğrulamayı denemesinden önce, önbelleğe alınan kimlik bilgilerinin maksimum yaşını özelleştirebilirsiniz. \nZaten önbelleğe alınmış olan kimlik bilgilerini hiçbir zaman yeniden doğrulamaya çalışmamak için maksimum önbellek yaşını -1 veya 0 olarak ayarlayın. \nYeniden doğrulama girişimlerini en üst düzeye çıkarmak için maksimum önbellek yaşını 1 olarak ayarlayın. \n\nDevre dışı bırakılırsa veya yapılandırılmazsa RAWeb, istemci isteklerine yanıt vermeden önce 59 saniyeden eski kimlik bilgilerini yeniden doğrulamayı deneyecektir. \n\nHer durumda, etki alanı denetleyicisine ulaşılamıyorsa önbelleğe alınmış kimlik bilgileri kullanılacaktır."
+    },
+    "PasswordChange.Enabled": {
+      "title": "Kullanıcıların RAWeb aracılığıyla şifrelerini değiştirmelerine izin ver",
+      "help": "Kullanıcıların RAWeb aracılığıyla parolalarını değiştirip değiştiremeyeceklerini kontrol eder. \n\nKullanıcının Active Directory'de parolasını değiştirme olanağı yoksa bu özellik çalışmaz. Raweb uygulama havuzunun kullanıcı sorumlularına veya dizin girişlerine erişim izni yoksa da çalışmayacaktır. Bu özellik yalnızca yerel hesaplar ve RAWeb'in yüklü olduğu makineyle aynı etki alanındaki hesaplar için desteklenir. \n\nBu özellik, kullanıcının uzak bir oturuma bağlandıktan sonra Ctrl + Alt + End tuşlarına basarak şifresini değiştirme yeteneğini kontrol etmez. \n\nEtkinleştirilirse veya yapılandırılmazsa kullanıcılar, 'Şifreyi değiştir' sayfasından şifrelerini değiştirebilirler. \n\nDevre dışı bırakılırsa 'Şifreyi değiştir' sayfası kullanılamayacaktır."
+    },
+    "App.Alerts.SignedInUser": {
+      "title": "Oturum açmış kullanıcılar için her rotanın üst kısmında uyarıları veya duyuruları yapılandırın",
+      "help": "Web istemcisinin üst kısmında görüntülenecek özel uyarıları yapılandırın. \n\nEtkinleştirilirse, oturum açan kullanıcılara uyarılar gösterilir. \n\nDevre dışı bırakılırsa veya yapılandırılmazsa hiçbir uyarı gösterilmez. \n\nUyarılar bir başlık, mesaj ve köprü içerebilir. Birden fazla uyarı görüntülenebilir. Bağlantı, uyarı mesajının sonunda yeni bir satırda görünecek ve bir açılır pencerede veya yeni sekmede açılacaktır. Metin ve URL belirtilmedikçe bağlantı görünmeyecektir."
+    },
+    "GuacdWebClient.Address": {
+      "title": "Web istemcisi bağlantı yöntemine izin ver",
+      "help": "Masaüstü bilgisayarların web istemcisi aracılığıyla başlatılmasını sağlamak için Guacamole arka plan programı (guacd) proxy sunucusunu yapılandırın. \n\nEtkinleştirilirse veya yapılandırılmazsa kullanıcılar masaüstü bilgisayarları web istemcisi aracılığıyla başlatabilecektir. \n\nDevre dışı bırakılırsa web istemcisi aracılığıyla başlatma mümkün olmayacaktır. \n\nRAWeb tarafından yönetilen kapsayıcı konumu seçilirse, Linux için Windows Alt Sisteminin C:\\Program Files\\WSL konumuna yüklenmesi gerekir. Ana sunucu WSL2'yi desteklemiyorsa RAWeb tarafından yönetilen kapsayıcı seçeneği gizlenecektir. Ayrıntılar için wiki'ye bakın. \n\nHarici kapsayıcı konumu seçilirse, guacd çalıştıran bir sunucuya işaret eden geçerli bir ana bilgisayar adı veya IP adresi ve guacd'nin dinlediği bağlantı noktası numarasını belirtin.",
+      "fields": {
+        "externalAddress": "Harici adres",
+        "externalHostname": "Ana bilgisayar adı veya IP adresi",
+        "externalPort": "Liman",
+        "method": "Guacamole arka plan programı (guacd) konumu",
+        "useContainer": "Linux 2 için Windows Alt Sisteminde (WSL2) RAWeb tarafından yönetilen bir guacd kapsayıcısı kullanma",
+        "useExternal": "Harici olarak yönetilen bir guacd örneği kullanın"
+      },
+      "errors": {
+        "hostnameEmpty": "Ana bilgisayar adı veya IP adresi boş olmamalıdır.",
+        "portEmpty": "Bağlantı noktası boş olmamalıdır.",
+        "hostnameInvalid": "Ana bilgisayar adı, protokol veya yol içermeyen geçerli bir ana bilgisayar adı veya IP adresi olmalıdır.",
+        "methodInvalid": "Bir daemon konumu seçilmelidir."
+      }
+    },
+    "App.Auth.MFA.Duo": {
+      "title": "Duo Evrensel İstemi çok faktörlü kimlik doğrulamasını (MFA) yapılandırma",
+      "help": "Kullanıcı oturum açma işlemleri için Duo Security aracılığıyla çok faktörlü kimlik doğrulamayı (MFA) etkinleştirin. \n\nEtkinleştirilirse kullanıcılardan, kullanıcı adlarını ve şifrelerini girdikten sonra Duo aracılığıyla ikinci bir kimlik doğrulama faktörünü tamamlamaları istenecektir. \n\nDevre dışı bırakılırsa veya yapılandırılmazsa Duo MFA kullanılmayacaktır. \n\nDuo MFA'yı yapılandırmak için: Duo Yönetici panelinde bir Web SDK uygulaması oluşturun; basit kullanıcı adı normalleştirmesini etkinleştirin; ve ardından bu politikada uygulamadaki istemci kimliğini, istemci sırrını ve API ana bilgisayar adını belirtin. \n\nHer Duo uygulaması için virgülle ayrılmış bir alan adı listesi girin. Uygulamayı tüm etki alanlarına uygulamak için * kullanın. Kullanıcılara, kullanıcının etki alanını belirten ilk uygulamayla ilişkili Duo Evrensel İstemi gösterilecektir. \n\nHesapları Duo MFA'dan hariç tutmak için hesapları ALAN\\kullanıcı adı veya etki alanı.tld\\kullanıcı adı biçiminde belirtin. Yerel hesaplar için .\\kullanıcıadı kullanın. \n\nRAWeb sunucusunun Duo API ana bilgisayar adına internet üzerinden erişebildiğinden emin olun.",
+      "fields": {
+        "clientId": "Müşteri Kimliği",
+        "clientSecret": "İstemci sırrı",
+        "hostname": "API ana bilgisayar adı",
+        "domains": "Alanlar",
+        "connections": "Uygulamalar",
+        "excludedUsernames": "Hariç tutulan hesaplar"
+      },
+      "errors": {
+        "connectionsEmpty": "En az bir uygulama belirtilmelidir.",
+        "clientIdEmpty": "Müşteri Kimliği boş olmamalıdır.",
+        "clientSecretEmpty": "İstemci sırrı boş olmamalıdır.",
+        "hostnameEmpty": "API ana makine adı boş olmamalıdır.",
+        "hostnameInvalid": "API ana bilgisayar adı, protokolü olmayan geçerli bir URL olmalıdır.",
+        "domainsEmpty": "Alan adları boş olmamalıdır. Tüm alanlar için virgülle ayrılmış bir alan adı listesi veya * belirtin.",
+        "usernameEmpty": "Hariç tutulan hesap kullanıcı adı boş olmamalıdır.",
+        "usernameMissingDomain": "Hariç tutulan hesap kullanıcı adları, ETKİ ALANI\\kullanıcı adı veya etki alanı.tld\\kullanıcı adı biçiminde bir etki alanı içermelidir. Yerel hesaplar için \".\" kullanın. veya alan adı olarak makine adı."
+      }
+    },
+    "App.Auth.MFA.LoginTC": {
+      "title": "LoginTC çok faktörlü kimlik doğrulamayı (MFA) yapılandırma",
+      "help": "Kullanıcı oturum açma işlemleri için LoginTC aracılığıyla çok faktörlü kimlik doğrulamayı (MFA) etkinleştirin. \n\nEtkinleştirilirse, kullanıcılardan kullanıcı adlarını ve şifrelerini girdikten sonra LoginTC aracılığıyla ikinci bir kimlik doğrulama faktörünü tamamlamaları istenecektir. \n\nDevre dışı bırakılırsa veya yapılandırılmazsa LoginTC MFA kullanılmayacaktır. \n\nLoginTC MFA'yı yapılandırmak için: LoginTC Yönetici Panelinde bir uygulama oluşturun; ve ardından bu politikada uygulama kimliğini, uygulama API anahtarını ve LoginTC örneği ana bilgisayar adını (ör. cloud.logintc.com) belirtin. \n\nHer LoginTC uygulaması için virgülle ayrılmış bir alan adı listesi girin. Uygulamayı tüm etki alanlarına uygulamak için * kullanın. Kullanıcılara, kullanıcının etki alanını belirten ilk uygulamayla ilişkili LoginTC sorgulaması gösterilecektir. \n\nHesapları LoginTC MFA'dan hariç tutmak için, hesapları ALAN\\kullanıcı adı veya etki alanı.tld\\kullanıcı adı biçiminde belirtin. Yerel hesaplar için .\\kullanıcıadı kullanın. \n\nRAWeb sunucusunun LoginTC API ana bilgisayarına erişebildiğinden emin olun.",
+      "fields": {
+        "applicationId": "Uygulama Kimliği",
+        "applicationApiKey": "Uygulama API anahtarı",
+        "host": "LoginTC örneği ana bilgisayar adı",
+        "domains": "Alanlar",
+        "connections": "Uygulamalar",
+        "excludedUsernames": "Hariç tutulan hesaplar"
+      },
+      "errors": {
+        "connectionsEmpty": "En az bir uygulama belirtilmelidir.",
+        "applicationIdEmpty": "Uygulama kimliği boş olmamalıdır.",
+        "applicationApiKeyEmpty": "Uygulama API anahtarı boş olmamalıdır.",
+        "hostEmpty": "API ana bilgisayarı boş olmamalıdır.",
+        "hostInvalid": "API ana bilgisayarı, protokolü olmayan geçerli bir URL olmalıdır.",
+        "domainsEmpty": "Alan adları boş olmamalıdır. Tüm alanlar için virgülle ayrılmış bir alan adı listesi veya * belirtin.",
+        "usernameEmpty": "Hariç tutulan hesap kullanıcı adı boş olmamalıdır.",
+        "usernameMissingDomain": "Hariç tutulan hesap kullanıcı adları, ETKİ ALANI\\kullanıcı adı veya etki alanı.tld\\kullanıcı adı biçiminde bir etki alanı içermelidir. Yerel hesaplar için \".\" kullanın. veya alan adı olarak makine adı."
+      }
+    },
+    "WorkspaceAuth.Block": {
+      "title": "Çalışma alanı istemcisi kimlik doğrulamasını engelle",
+      "help": "Kullanıcıların Windows RemoteApp ve Masaüstü Bağlantıları ve Windows Uygulaması gibi çalışma alanı istemcilerinde oturum açmasını engelleyin. \n\nEtkinleştirilirse kullanıcılar, çalışma alanı istemcileri aracılığıyla kimlik doğrulaması yapamaz. \n\nDevre dışı bırakılırsa veya yapılandırılmazsa kullanıcılar, çalışma alanı istemcileri aracılığıyla kimlik doğrulaması yapabilecektir. \n\nTüm kullanıcılar için çok faktörlü kimlik doğrulamayı (MFA) zorunlu kılmak istediğinizde bu politikayı kullanın. Workspace istemcileri MFA'yı desteklemediğinden kimlik doğrulamalarının engellenmesi, tüm kullanıcıların MFA'yı destekleyen web uygulamasını kullanması gerektiğini garanti eder."
+    },
+    "LogFiles.DiscardAgeDays": {
+      "title": "Sunucu günlük dosyası saklamayı yapılandırma",
+      "help": "RAWeb sunucusunun bazı bölümleri, sorun giderme sorunlarına yardımcı olmak için günlük dosyaları oluşturacaktır. \n\nEtkinleştirilirse, belirtilen gün sayısından daha eski olan günlük dosyaları otomatik olarak silinir. \n\nDevre dışı bırakılırsa günlük dosyaları oluşturulmaz. \n\nYapılandırılmadığı takdirde günlük dosyaları varsayılan 3 günlük süre boyunca saklanacaktır. \n\nBu politika, Internet Information Services (IIS) tarafından oluşturulan ek günlükleri denetlemez.",
+      "fields": {
+        "days": "Günler"
+      },
+      "errors": {
+        "daysInvalid": "Günler pozitif bir tam sayı olmalıdır (0'dan büyük)."
+      }
+    },
+    "GuacdWebClient.Security.AllowIgnoreGatewayCertErrors": {
+      "title": "Web istemcisindeki ağ geçidi sertifikası hatalarının yoksayılmasına izin ver",
+      "help": "Kullanıcıların web istemcisi aracılığıyla bağlanırken ağ geçidi sertifikası hatalarını göz ardı edip edemeyeceğini kontrol eder. \n\nEtkinleştirilirse kullanıcılar, web istemcisi aracılığıyla bağlanırken ağ geçidi sertifikası hatalarını göz ardı edebilecektir. \n\nDevre dışı bırakılırsa veya yapılandırılmazsa kullanıcılar, web istemcisi aracılığıyla bağlanırken ağ geçidi sertifikası hatalarını göz ardı edemeyeceklerdir."
+    },
+    "App.RDP.StripSignatures": {
+      "title": "RDP İmzalarını Temizle (Pano ve Sürücüleri Serbest Bırak)",
+      "help": "Etkinleştirildiğinde, merkezi yayımlama sunucusundan (RDS Broker) gelen RDP bağlantılarındaki dijital imzalar silinir. Bu sayede kullanıcılar bağlantı öncesinde Pano (Kopyala/Yapıştır), Yazıcılar ve Yerel Sürücüler gibi seçenekleri özgürce seçip değiştirebilirler."
+    }
+  },
+  "wiki": {
+    "title": "Viki"
+  },
+  "actions": {
+    "sort": {
+      "label": "Düzenlemek",
+      "name": "İsim",
+      "ts": "Terminal sunucusu",
+      "date": "Değiştirilme tarihi",
+      "asc": "Artan",
+      "desc": "Azalan"
+    },
+    "view": {
+      "label": "Görüş",
+      "card": "Kart",
+      "grid": "Izgara",
+      "tile": "Fayans",
+      "list": "Liste"
+    },
+    "ts": {
+      "label": "Terminal sunucuları",
+      "all": "Tüm terminal sunucuları"
+    }
+  },
+  "resource": {
+    "menu": {
+      "connect": "Bağlamak",
+      "connectWith": "Şununla bağlantı kur:",
+      "favAdd": "Favorilere ekle",
+      "favRemove": "Favorilerden kaldır",
+      "props": "Özellikler"
+    },
+    "props": {
+      "title": "{{name}} {{section}} özellikleri",
+      "ts": "Terminal sunucusu",
+      "empty": "boş",
+      "type": "Kaynak türü",
+      "location": "Konum",
+      "unknownType": "Bilinmeyen tür",
+      "id": "Benzersiz tanımlayıcı",
+      "sections": {
+        "connection": "bağlantı",
+        "display": "görüntülemek",
+        "gateway": "geçit",
+        "hardware": "donanım",
+        "remoteapp": "RemoteApp",
+        "session": "oturum",
+        "signature": "imza",
+        "raweb": "RAWeb"
+      },
+      "defaultPropertyValue": "Ayarlanmadı",
+      "properties": {
+        "administrative session__i": {
+          "label": "Bir yönetim oturumu kullanın",
+          "description": "Uzak bilgisayarın yönetim oturumuna bağlanın.",
+          "options": {
+            "0": "Yönetim oturumunu kullanmayın.",
+            "1": "Yönetim oturumuna bağlanın."
+          }
+        },
+        "allow desktop composition__i": {
+          "label": "Masaüstü kompozisyonuna izin ver",
+          "description": "Uzak bilgisayarda oturum açtığınızda masaüstü kompozisyonuna (Aero için gerekli) izin verilip verilmeyeceğini belirler.",
+          "options": {
+            "0": "Uzak oturumda masaüstü kompozisyonunu devre dışı bırakın.",
+            "1": "Masaüstü kompozisyonuna izin verilir."
+          }
+        },
+        "allow font smoothing__i": {
+          "label": "Yazı tipi yumuşatmaya izin ver",
+          "description": "Uzak oturumda yazı tipi yumuşatmanın kullanılıp kullanılamayacağını belirler.",
+          "options": {
+            "0": "Uzak oturumda yazı tipi yumuşatmayı devre dışı bırakın.",
+            "1": "Yazı tipi yumuşatmaya izin verilir."
+          }
+        },
+        "alternate full address__s": {
+          "label": "Terminal sunucusu adresi (alternatif)",
+          "description": "Bağlanmak istediğiniz uzak bilgisayarın alternatif adını veya IP adresini belirtir."
+        },
+        "alternate shell__s": {
+          "label": "Kabuk yolunu değiştir",
+          "description": "Uzak bir bilgisayara bağlandığınızda otomatik olarak başlatılacak programı belirtir. Değer, yürütülebilir bir dosyaya giden geçerli bir yol olmalıdır.\nBu ayar yalnızca sunuculara bağlanırken çalışır."
+        },
+        "audiocapturemode__i": {
+          "label": "Yakalanan sesi uzak bilgisayara gönderin",
+          "description": "Uzak bilgisayara bağlandığınızda yerel bilgisayarda yakalanan (kaydedilen) seslerin nasıl işleneceğini belirler.",
+          "options": {
+            "0": "Yerel bilgisayardan ses yakalamayın.",
+            "1": "Yerel bilgisayardan ses yakalayın ve uzaktaki bilgisayara gönderin."
+          }
+        },
+        "audiomode__i": {
+          "label": "Ses çalma modu",
+          "description": "Uzak bilgisayara bağlandığınızda uzak bilgisayardaki seslerin nasıl işleneceğini belirler.",
+          "options": {
+            "0": "Yerel bilgisayarda sesleri çalın.",
+            "1": "Uzak bilgisayardaki sesleri çalın.",
+            "2": "Sesleri çalmayın."
+          }
+        },
+        "audioqualitymode__i": {
+          "label": "Ses kalitesi modu",
+          "description": "Uzak oturumda çalınan sesin kalitesini belirler.",
+          "options": {
+            "0": "Mevcut bant genişliğine göre ses kalitesini dinamik olarak ayarlayın.",
+            "1": "Her zaman orta ses kalitesini kullanın.",
+            "2": "Her zaman sıkıştırılmamış ses kalitesini kullanın."
+          }
+        },
+        "authentication level__i": {
+          "label": "Kimlik doğrulama hatası davranışını yapılandırma",
+          "description": "Sunucu kimlik doğrulaması başarısız olduğunda ne olması gerektiğini belirler.",
+          "options": {
+            "0": "Sunucu kimlik doğrulaması başarısız olursa uyarı vermeden bağlanın.",
+            "1": "Sunucu kimlik doğrulaması başarısız olursa bağlanmayın.",
+            "2": "Sunucu kimlik doğrulaması başarısız olursa bir uyarı gösterin ve kullanıcının bağlanıp bağlanmayacağını seçmesine izin verin.",
+            "3": "Sunucu kimlik doğrulaması gerekli değildir."
+          }
+        },
+        "autoreconnect max retries__i": {
+          "label": "Maksimum yeniden bağlanma denemesi",
+          "description": "Bağlantı kesilirse istemci bilgisayarın uzak bilgisayara maksimum kaç kez yeniden bağlanmayı deneyeceğini belirler.\nNot: Uzak Masaüstü'nün işleyebileceği maksimum değer 200'dür."
+        },
+        "autoreconnection enabled__i": {
+          "label": "Bağlantı kesildiğinde otomatik olarak yeniden bağlanın",
+          "description": "Bağlantı kesilirse istemci bilgisayarın uzak bilgisayara otomatik olarak yeniden bağlanmayı deneyip denemeyeceğini belirler.",
+          "options": {
+            "0": "Yeniden bağlanmaya çalışmayın.",
+            "1": "Yeniden bağlanmayı deneyin."
+          }
+        },
+        "bandwidthautodetect__i": {
+          "label": "Ağ türünü otomatik olarak algıla",
+          "description": "Ağ türünün otomatik algılanması seçeneğini etkinleştirir. Networkautodetect ile birlikte kullanılır. Ayrıca bağlantı türüne bakın.",
+          "options": {
+            "0": "Otomatik ağ algılama seçeneğini etkinleştirmeyin.",
+            "1": "Otomatik ağ algılama seçeneğini etkinleştirin."
+          }
+        },
+        "bitmapcachepersistenable__i": {
+          "label": "Bitmap önbelleğini etkinleştir",
+          "description": "Bit eşlemlerin yerel bilgisayarda (disk tabanlı önbellek) önbelleğe alınıp alınmayacağını belirler. Bitmap önbelleğe alma, uzak oturumunuzun performansını artırabilir.",
+          "options": {
+            "0": "Bitmap'leri önbelleğe almayın.",
+            "1": "Bitmap'leri önbelleğe alın."
+          }
+        },
+        "bitmapcachesize__i": {
+          "label": "Bitmap önbellek boyutu",
+          "description": "Bellek tabanlı bitmap önbelleğinin kilobayt cinsinden boyutunu belirtir. Maksimum değer 32000'dir."
+        },
+        "camerastoredirect__s": {
+          "label": "Kameraları istemciden yönlendirme yapacak şekilde yapılandırma",
+          "description": "Hangi kameraların yönlendirileceğini yapılandırır. Bu ayar, yeniden yönlendirme için etkinleştirilen kameraların KSCATEGORY_VIDEO_CAMERA arayüzlerinin noktalı virgülle ayrılmış bir listesini kullanır."
+        },
+        "compression__i": {
+          "label": "Toplu sıkıştırma kullan",
+          "description": "Bağlantının toplu sıkıştırma kullanması gerekip gerekmediğini belirler.",
+          "options": {
+            "0": "Toplu sıkıştırma kullanmayın.",
+            "1": "Toplu sıkıştırmayı kullanın."
+          }
+        },
+        "connection type__i": {
+          "label": "Bağlantı türü",
+          "description": "Uzak Masaüstü oturumu için önceden tanımlanmış performans ayarlarını belirtir.\n\nBu ayar tek başına hiçbir şey yapmaz. RDC GUI'de seçildiğinde, bu seçenek performansla ilgili çeşitli ayarları (temalar, animasyon, yazı tipi yumuşatma vb.) değiştirir. Bu ayrı ayarlar her zaman bağlantı türü ayarını geçersiz kılar.",
+          "options": {
+            "1": "Modem (56 Kbps).",
+            "2": "Düşük hızlı geniş bant (256 Kbps - 2 Mbps).",
+            "3": "Uydu (2 Mbps - 16 Mbps, yüksek gecikme süresiyle).",
+            "4": "Yüksek hızlı geniş bant (2 Mbps - 10 Mbps).",
+            "5": "WAN (yüksek gecikmeyle 10 Mbps veya daha yüksek).",
+            "6": "LAN (10 Mbps veya daha yüksek).",
+            "7": "Otomatik bant genişliği tespiti. Bant genişliğinin otomatik olarak algılanması gerekir."
+          }
+        },
+        "desktop size id__i": {
+          "label": "Masaüstü boyutu ön ayarı",
+          "description": "Uzak oturum masaüstünün önceden tanımlanmış boyutlarını belirtir.\n\n/w ve /h ya da masaüstü genişliği ve masaüstü yüksekliği zaten belirtildiğinde bu ayar yoksayılır.",
+          "options": {
+            "0": "640x480.",
+            "1": "800x600.",
+            "2": "1024x768.",
+            "3": "1280x1024.",
+            "4": "1600x1200."
+          }
+        },
+        "desktopheight__i": {
+          "label": "Ekran yüksekliği",
+          "description": "Uzak oturum masaüstünün yüksekliği (piksel cinsinden)."
+        },
+        "desktopscalefactor__i": {
+          "label": "Ölçek faktörünü görüntüle",
+          "description": "İçeriğin daha büyük görünmesini sağlamak için uzak oturumun ölçek faktörünü belirtir.\n\nDesteklenen değerler:\nAşağıdaki listeden sayısal değer: 100, 125, 150, 175, 200, 250, 300, 400, 500\n\nNot: Desktopscalefactor özelliği kullanımdan kaldırılıyor ve yakında kullanılamayacak."
+        },
+        "desktopwidth__i": {
+          "label": "Ekran genişliği",
+          "description": "Uzak oturum masaüstünün genişliği (piksel cinsinden)."
+        },
+        "devicestoredirect__s": {
+          "label": "Tak ve Kullan aygıt yeniden yönlendirme davranışını yapılandırma",
+          "description": "İstemci bilgisayardaki desteklenen hangi Tak ve Kullan aygıtlarının yeniden yönlendirileceğini ve uzak oturumda kullanılabilir olacağını belirler.\n\nDeğer belirtilmedi - Desteklenen Tak ve Kullan aygıtlarının hiçbirini yeniden yönlendirmeyin.\n* - Daha sonra bağlananlar da dahil olmak üzere, desteklenen tüm Tak ve Çalıştır aygıtlarını yeniden yönlendirin.\nDynamicDevices - Daha sonra bağlanan, desteklenen Tak ve Kullan aygıtlarını yeniden yönlendirin.\nBir veya daha fazla Tak ve Kullan aygıtının donanım kimliği - Belirtilen desteklenen Tak ve Kullan aygıtını/aygıtlarını yönlendirin."
+        },
+        "disable ctrl+alt+del__i": {
+          "label": "Ctrl+Alt+Delete gereksinimini devre dışı bırakın",
+          "description": "Uzak bilgisayara bağlandıktan sonra kimlik bilgilerini girmeden önce CTRL+ALT+DELETE tuşlarına basmanız gerekip gerekmediğini belirler.\n\nNot: Devre dışı bırakıldığında bu ayar, kullanıcı CTRL+ALT+DELETE tuşlarına basana kadar otomatik oturum açmayı da geciktirir.",
+          "options": {
+            "0": "Giriş yapmadan önce CTRL+ALT+DELETE gereklidir.",
+            "1": "CTRL+ALT+DELETE gerekli değildir. Hemen oturum açabilirsiniz."
+          }
+        },
+        "disable full window drag__i": {
+          "label": "Tam pencere sürüklemeyi devre dışı bırak",
+          "description": "Pencereyi yeni bir konuma sürüklediğinizde pencere içeriğinin görüntülenip görüntülenmeyeceğini belirler.",
+          "options": {
+            "0": "Sürüklerken pencerenin içeriğini gösterin.",
+            "1": "Sürüklerken pencerenin ana hatlarını gösterin."
+          }
+        },
+        "disable menu anims__i": {
+          "label": "Menü animasyonlarını devre dışı bırak",
+          "description": "Uzak oturumda menü ve pencerelerin animasyon efektleriyle görüntülenip görüntülenemeyeceğini belirler.",
+          "options": {
+            "0": "Menü ve pencere animasyonuna izin verilir.",
+            "1": "Menü ve pencere animasyonu yok."
+          }
+        },
+        "disable themes__i": {
+          "label": "Temaları devre dışı bırak",
+          "description": "Uzak bilgisayarda oturum açtığınızda temalara izin verilip verilmeyeceğini belirler.",
+          "options": {
+            "0": "Temalara izin verilir.",
+            "1": "Uzak oturumda temayı devre dışı bırakın."
+          }
+        },
+        "disable wallpaper__i": {
+          "label": "Duvar kağıdını devre dışı bırak",
+          "description": "Uzak oturumda masaüstü arka planının görüntülenip görüntülenmeyeceğini belirler.",
+          "options": {
+            "0": "Duvar kağıdını görüntüleyin.",
+            "1": "Herhangi bir duvar kağıdı gösterme."
+          }
+        },
+        "disableconnectionsharing__i": {
+          "label": "RemoteApps için oturum paylaşımını devre dışı bırakın",
+          "description": "RemoteApp'in aynı bilgisayara ve aynı kimlik bilgileriyle her başlatılmasında yeni bir Terminal Sunucusu oturumunun başlatılıp başlatılmayacağını belirler.",
+          "options": {
+            "0": "Yeni oturum başlatılmadı. Kullanıcının o anda aktif olan oturumu paylaşılır.",
+            "1": "RemoteApp için yeni bir oturum açma oturumu başlatıldı."
+          }
+        },
+        "disableremoteappcapscheck__i": {
+          "label": "RemoteApp yetenekleri kontrolünü devre dışı bırak",
+          "description": "Uzak Masaüstü istemcisinin uzak bilgisayarı RemoteApp yetenekleri açısından denetlemesi gerekip gerekmediğini belirtir.\n\nNot: Üzerinde RemoteApps yapılandırılmış olan Windows XP SP3, Vista veya 7 bilgisayarlara bağlanırken bu ayarın 1 olarak ayarlanması gerekir.",
+          "options": {
+            "0": "Oturum açmadan önce uzak bilgisayardaki RemoteApp özelliklerini kontrol edin.",
+            "1": "RemoteApp yetenekleri için uzaktaki bilgisayarı kontrol etmeyin."
+          }
+        },
+        "displayconnectionbar__i": {
+          "label": "Bağlantı çubuğunu tam ekran modunda göster",
+          "description": "Tam ekran modundayken bağlantı çubuğunun görünüp görünmeyeceğini belirler.",
+          "options": {
+            "0": "Bağlantı çubuğunu göstermeyin.",
+            "1": "Bağlantı çubuğunu göster."
+          }
+        },
+        "domain__s": {
+          "label": "Kimlik doğrulama alanı",
+          "description": "Kullanıcının etki alanının adını belirtir."
+        },
+        "drivestoredirect__s": {
+          "label": "Uzak oturuma yönlendirmek için yerel sürücüler",
+          "description": "İstemci bilgisayardaki hangi yerel disk sürücülerinin yeniden yönlendirileceğini ve uzak oturumda kullanılabilir olacağını belirler.\n\nDeğer belirtilmedi - Hiçbir sürücüyü yeniden yönlendirmeyin.\n* - Daha sonra bağlanan sürücüler de dahil olmak üzere tüm disk sürücülerini yeniden yönlendirin.\nDynamicDrives - Daha sonra bağlanan tüm sürücüleri yeniden yönlendirin.\nBir veya daha fazla sürücünün sürücüsü ve etiketleri - Belirtilen sürücüyü/sürücüleri yeniden yönlendirin."
+        },
+        "dynamic resolution__i": {
+          "label": "Yeniden boyutlandırmada oturum çözünürlüğünü güncelleyin",
+          "description": "Yerel pencere yeniden boyutlandırıldığında uzak oturumun çözünürlüğünün otomatik olarak güncelleştirilip güncelleştirilmeyeceğini belirler.",
+          "options": {
+            "0": "Oturum çözünürlüğü oturum sırasında statik kalır.",
+            "1": "Yerel pencere yeniden boyutlandırıldıkça oturum çözünürlüğü güncellenir."
+          }
+        },
+        "enablecredsspsupport__i": {
+          "label": "Mümkün olduğunda kimlik doğrulama için CredSSP'yi kullanın",
+          "description": "Uzak Masaüstü'nün, varsa kimlik doğrulama için CredSSP'yi kullanıp kullanmayacağını belirler.",
+          "options": {
+            "0": "İşletim sisteminiz desteklese bile CredSSP'yi kullanmayın.",
+            "1": "İşletim sistemi destekliyorsa CredSSP'yi kullanın."
+          }
+        },
+        "enablerdsaadauth__i": {
+          "label": "Microsoft Entra ID kimlik doğrulamasını kullanın",
+          "description": "İstemcinin uzak bilgisayarda kimlik doğrulaması yapmak için Microsoft Entra ID'yi kullanıp kullanmayacağını belirler. Azure Sanal Masaüstü ile birlikte kullanıldığında bu, tek oturum açma deneyimi sağlar. Bu özellik targetisaadjoined özelliğinin yerine geçer.",
+          "options": {
+            "0": "Uzak bilgisayar desteklese bile bağlantılarda Microsoft Entra kimlik doğrulaması kullanılmaz.",
+            "1": "Uzak bilgisayar destekliyorsa, bağlantılarda Microsoft Entra kimlik doğrulaması kullanılacaktır."
+          }
+        },
+        "enablesuperpan__i": {
+          "label": "SuperPan'i etkinleştir",
+          "description": "SuperPan'in etkin mi yoksa devre dışı mı olduğunu belirler. SuperPan, uzak masaüstünün boyutları geçerli istemci penceresinin boyutlarından daha büyük olduğunda, kullanıcının uzak masaüstünde kaydırma çubukları olmadan tam ekran modunda gezinmesine olanak tanır. Kullanıcı pencere kenarlığını işaret edebilir ve masaüstü görünümü otomatik olarak o yönde kaydırılır.",
+          "options": {
+            "0": "SuperPan'i kullanmayın. Uzak oturum penceresi istemci penceresinin boyutuna göre boyutlandırılır.",
+            "1": "SuperPan'i etkinleştirin. Uzak oturum penceresi, /w ve /h veya masaüstü genişliği ve masaüstü yüksekliği aracılığıyla belirtilen boyutlara göre boyutlandırılır."
+          }
+        },
+        "encode redirected video capture__i": {
+          "label": "Yeniden yönlendirilen videoyu kodlayın",
+          "description": "Yeniden yönlendirilen videonun kodlanmasını etkinleştirir veya devre dışı bırakır.",
+          "options": {
+            "0": "Yeniden yönlendirilen videonun kodlamasını devre dışı bırakın.",
+            "1": "Yeniden yönlendirilen videonun kodlamasını etkinleştirin."
+          }
+        },
+        "full address__s": {
+          "label": "Terminal sunucusu adresi",
+          "description": "Bağlanmak istediğiniz uzak bilgisayarın adını veya IP adresini (ve isteğe bağlı bağlantı noktasını) belirtir."
+        },
+        "gatewaycredentialssource__i": {
+          "label": "Ağ geçidi kimlik bilgileri kaynağı",
+          "description": "RD Ağ Geçidi ile bağlantıyı doğrulamak için kullanılması gereken kimlik bilgilerini belirtir.",
+          "options": {
+            "0": "Şifre isteyin (NTLM).",
+            "1": "Akıllı kart kullanın.",
+            "4": "Kullanıcının daha sonra seçim yapmasına izin ver."
+          }
+        },
+        "gatewayhostname__s": {
+          "label": "Ağ geçidi ana bilgisayar adı",
+          "description": "RD Ağ Geçidinin ana bilgisayar adını belirtir."
+        },
+        "gatewayprofileusagemethod__i": {
+          "label": "Açık ağ geçidi ayarlarını kullan",
+          "description": "Kullanılacak RD Ağ Geçidi kimlik doğrulama yöntemini belirler.",
+          "options": {
+            "0": "Yönetici tarafından belirtildiği şekilde varsayılan profil modunu kullanın.",
+            "1": "Açık ayarları kullanın."
+          }
+        },
+        "gatewayusagemethod__i": {
+          "label": "Ağ geçidi kullanım yöntemi",
+          "description": "Uzak Masaüstü Ağ Geçidi (RD Ağ Geçidi) sunucusunun kullanılıp kullanılmayacağını ve nasıl kullanılacağını belirtir.\n\n0 ve 4 aynı etkiye sahiptir ancak yöntemi 4'e ayarlamak aynı zamanda Uzak Masaüstü kullanıcı arayüzünde yerel adresleri atlama seçeneğini de ayarlar.",
+          "options": {
+            "0": "RD Ağ Geçidi sunucusu kullanmayın.",
+            "1": "Yerel bağlantılar için bile her zaman bir RD Ağ Geçidi kullanın.",
+            "2": "Uzak bilgisayara doğrudan bağlantı kurulamıyorsa (yani yerel adresleri atlamak) RD Ağ Geçidini kullanın.",
+            "3": "Varsayılan RD Ağ Geçidi ayarlarını kullanın.",
+            "4": "RD Ağ Geçidi sunucusu kullanmayın."
+          }
+        },
+        "kdcproxyname__s": {
+          "label": "Kerberos Anahtar Dağıtım Merkezi proxy'si tam nitelikli alan adı",
+          "description": "KDC proxy'sinin tam etki alanı adını belirtir."
+        },
+        "keyboardhook__i": {
+          "label": "Windows tuş birleşimleri davranışı",
+          "description": "Uzak bir bilgisayara bağlandığınızda Windows tuş birleşimlerinin nasıl uygulanacağını belirler.",
+          "options": {
+            "0": "Windows tuş birleşimleri yerel bilgisayara uygulanır.",
+            "1": "Windows tuş birleşimleri uzak bilgisayara uygulanır.",
+            "2": "Windows tuş birleşimleri yalnızca tam ekran modunda uygulanır."
+          }
+        },
+        "maximizetocurrentdisplays__i": {
+          "label": "Büyütme sırasında tam ekran için ekranı dinamik olarak seçin",
+          "description": "Büyütme sırasında uzak oturumun tam ekran için hangi ekranı kullanacağını belirler. Requires use multimon set to 1. Only available on Windows App for Windows and the Remote Desktop app for Windows.",
+          "options": {
+            "0": "Ekranı kaplarken başlangıçta seçilen ekranlarda oturum tam ekrandır.",
+            "1": "Oturum dinamik olarak tam ekran olup, ekranı kaplarken oturum penceresinin kapsadığı alanları görüntüler."
+          }
+        },
+        "negotiate security layer__i": {
+          "label": "Güvenlik katmanı anlaşmasını kullan",
+          "description": "Güvenlik düzeyinin müzakere edilip edilmediğini belirler.",
+          "options": {
+            "0": "Güvenlik katmanı anlaşması etkin değil ve oturum Güvenli Yuva Katmanı (SSL) kullanılarak başlatılıyor.",
+            "1": "Güvenlik katmanı anlaşması etkinleştirilir ve oturum x.224 şifrelemesi kullanılarak başlatılır."
+          }
+        },
+        "networkautodetect__i": {
+          "label": "Use automatic network bandwidth detection",
+          "description": "Otomatik ağ bant genişliği algılamanın kullanılıp kullanılmayacağını belirler. Bant genişliği otomatik algılama seçeneğinin ayarlanmasını gerektirir ve bağlantı türü 7 ile ilişkilendirilir.",
+          "options": {
+            "0": "Otomatik ağ bant genişliği algılamayı kullanın.",
+            "1": "Otomatik ağ bant genişliği algılamayı kullanmayın."
+          }
+        },
+        "password 51__b": {
+          "label": "Yerel şifreli şifre karması",
+          "description": "İkili karma değerindeki kullanıcı parolası. Parola istemci bilgisayarda saklanmalı ve şifrelenmelidir. Mevcut bir şifre karma değeriyle eşleşiyorsa, kullanıcının kimliğini doğrulamak için kullanılacaktır."
+        },
+        "pinconnectionbar__i": {
+          "label": "Bağlantı çubuğunu tam ekran modunda sabitleyin",
+          "description": "Determines whether or not the connection bar should be pinned to the top of the remote session upon connection when in full screen mode.",
+          "options": {
+            "0": "Bağlantı çubuğu uzak oturumun üst kısmına sabitlenmemelidir.",
+            "1": "Bağlantı çubuğu uzak oturumun üst kısmına sabitlenmelidir."
+          }
+        },
+        "prompt for credentials on client__i": {
+          "label": "Sunucu, sunucu kimlik doğrulamasını desteklemediğinde istemcide kimlik bilgilerini sor",
+          "description": "Sunucu kimlik doğrulamasını desteklemeyen bir sunucuya bağlanırken Uzak Masaüstü Bağlantısı'nın kimlik bilgileri isteyip istemediğini belirler.",
+          "options": {
+            "0": "Uzak Masaüstü kimlik bilgilerini sormayacaktır.",
+            "1": "Uzak Masaüstü kimlik bilgilerini isteyecektir."
+          }
+        },
+        "prompt for credentials__i": {
+          "label": "Sunucudaki kimlik bilgilerini her zaman sor",
+          "description": "Kimlik bilgilerinin daha önce kaydedildiği uzak bir bilgisayara bağlanırken Uzak Masaüstü Bağlantısı'nın kimlik bilgileri isteyip istemediğini belirler.",
+          "options": {
+            "0": "Uzak Masaüstü kayıtlı kimlik bilgilerini kullanacak ve kimlik bilgileri istemeyecektir.",
+            "1": "Uzak Masaüstü kimlik bilgilerini isteyecektir."
+          }
+        },
+        "promptcredentialonce__i": {
+          "label": "Oturumun tamamı için aynı kimlik bilgilerini kullanın",
+          "description": "RD Ağ Geçidi üzerinden bağlanırken, RDC'nin hem RD Ağ Geçidi hem de uzak bilgisayar için aynı kimlik bilgilerini kullanması gerekip gerekmediğini belirler.",
+          "options": {
+            "0": "Uzak Masaüstü aynı kimlik bilgilerini kullanmayacaktır.",
+            "1": "Uzak Masaüstü, hem RD ağ geçidi hem de uzak bilgisayar için aynı kimlik bilgilerini kullanacaktır."
+          }
+        },
+        "public mode__i": {
+          "label": "Herkese açık modda başlat",
+          "description": "Uzak Masaüstü Bağlantısının genel modda başlatılıp başlatılmayacağını belirler.",
+          "options": {
+            "0": "Uzak Masaüstü genel modda başlamayacak.",
+            "1": "Uzak Masaüstü genel modda başlayacak ve yerel makineye herhangi bir kullanıcı verisi (kimlik bilgileri, bitmap önbelleği, MRU) kaydedilmeyecektir."
+          }
+        },
+        "redirectclipboard__i": {
+          "label": "Panoyu yönlendir",
+          "description": "İstemci bilgisayardaki panonun yeniden yönlendirilip yönlendirilmeyeceğini ve uzak oturumda kullanılabilir olup olmayacağını (veya tam tersi) belirler.",
+          "options": {
+            "0": "Panoyu yeniden yönlendirmeyin.",
+            "1": "Panoyu yeniden yönlendirin."
+          }
+        },
+        "redirectcomports__i": {
+          "label": "COM bağlantı noktalarını istemci bilgisayardan yeniden yönlendir",
+          "description": "İstemci bilgisayardaki COM (seri) bağlantı noktalarının yeniden yönlendirilip yönlendirilmeyeceğini ve uzak oturumda kullanılabilir olup olmayacağını belirler.",
+          "options": {
+            "0": "Yerel bilgisayardaki COM bağlantı noktaları uzak oturumda kullanılamıyor.",
+            "1": "Yerel bilgisayardaki COM bağlantı noktaları uzak oturumda kullanılabilir."
+          }
+        },
+        "redirectdirectx__i": {
+          "label": "DirectX oluşturmayı etkinleştir",
+          "description": "Uzak oturum için DirectX'in etkinleştirilip etkinleştirilmeyeceğini belirler.",
+          "options": {
+            "0": "DirectX oluşturmayı etkinleştirmeyin.",
+            "1": "Uzak oturumda DirectX oluşturmayı etkinleştirin."
+          }
+        },
+        "redirected video capture encoding quality__i": {
+          "label": "Video yakalama kodlama kalitesi",
+          "description": "Kodlanmış videonun kalitesini kontrol eder.",
+          "options": {
+            "0": "Yüksek sıkıştırmalı video. Çok fazla hareket olduğunda kalite düşebilir.",
+            "1": "Orta sıkıştırma.",
+            "2": "Yüksek resim kalitesine sahip düşük sıkıştırmalı video."
+          }
+        },
+        "redirectlocation__i": {
+          "label": "İstemci bilgisayardan konumu (adres/koordinatlar) yeniden yönlendir",
+          "description": "Yerel cihazın konumunun yeniden yönlendirilip yönlendirilmeyeceğini ve uzak oturumda kullanılabilir olup olmayacağını belirler.",
+          "options": {
+            "0": "Uzak oturum uzak bilgisayarın konumunu kullanır.",
+            "1": "Uzak oturum yerel cihazın konumunu kullanır."
+          }
+        },
+        "redirectposdevices__i": {
+          "label": "Microsoft Hizmet Noktası aygıtlarını istemci bilgisayardan yeniden yönlendirme",
+          "description": "İstemci bilgisayara bağlı .NET cihazları için Microsoft Hizmet Noktası'nın (POS) yeniden yönlendirilip yönlendirilmeyeceğini ve uzak oturumda kullanılabilir olup olmayacağını belirler.",
+          "options": {
+            "0": "Yerel bilgisayardaki POS cihazları uzak oturumda kullanılamıyor.",
+            "1": "Yerel bilgisayardaki POS cihazları uzak oturumda kullanılabilir."
+          }
+        },
+        "redirectprinters__i": {
+          "label": "Yazıcıları istemci bilgisayardan yeniden yönlendirme",
+          "description": "İstemci bilgisayarda yapılandırılan yazıcıların yeniden yönlendirilip yönlendirilmeyeceğini ve uzak oturumda kullanılabilir olup olmayacağını belirler.",
+          "options": {
+            "0": "Yerel bilgisayardaki yazıcılar uzak oturumda kullanılamıyor.",
+            "1": "Yerel bilgisayardaki yazıcılar uzak oturumda kullanılabilir."
+          }
+        },
+        "redirectsmartcards__i": {
+          "label": "Akıllı kartları istemci bilgisayardan yönlendirme",
+          "description": "İstemci bilgisayardaki akıllı kart cihazlarının yeniden yönlendirilip yönlendirilmeyeceğini ve uzak oturumda kullanılabilir olup olmayacağını belirler.",
+          "options": {
+            "0": "Yerel bilgisayardaki akıllı kart cihazı uzak oturumda kullanılamıyor.",
+            "1": "Yerel bilgisayardaki akıllı kart cihazı uzak oturumda kullanılabilir."
+          }
+        },
+        "redirectwebauthn__i": {
+          "label": "WebAuthn isteklerini yerel bilgisayara yönlendirin",
+          "description": "Uzak bilgisayardaki WebAuthn isteklerinin, yerel kimlik doğrulayıcıların (İş için Windows Merhaba ve güvenlik anahtarı gibi) kullanılmasına izin vererek yerel bilgisayara yönlendirilip yönlendirilmeyeceğini belirler.",
+          "options": {
+            "0": "Uzak oturumdan gelen WebAuthn istekleri, kimlik doğrulama için yerel bilgisayara gönderilmez ve uzak oturumda tamamlanması gerekir.",
+            "1": "Uzak oturumdan gelen WebAuthn istekleri, kimlik doğrulama için yerel bilgisayara gönderilir."
+          }
+        },
+        "remoteapplicationcmdline__s": {
+          "label": "Komut satırı parametreleri",
+          "description": "RemoteApp için isteğe bağlı komut satırı parametreleri."
+        },
+        "remoteapplicationexpandcmdline__i": {
+          "label": "Komut satırı parametreleri ortam değişkeni genişletme modu",
+          "description": "RemoteApp komut satırı parametresinde bulunan ortam değişkenlerinin yerel olarak mı yoksa uzaktan mı genişletilmesi gerektiğini belirler.",
+          "options": {
+            "0": "Ortam değişkenleri yerel bilgisayarın değerlerine genişletilmelidir.",
+            "1": "Uzak bilgisayardaki ortam değişkenleri uzak bilgisayarın değerlerine genişletilmelidir."
+          }
+        },
+        "remoteapplicationexpandworkingdir__i": {
+          "label": "Çalışma dizini ortamı değişken genişletme modu",
+          "description": "RemoteApp çalışma dizini parametresinde bulunan ortam değişkenlerinin yerel olarak mı yoksa uzaktan mı genişletilmesi gerektiğini belirler.\n\nNot: RemoteApp çalışma dizini, kabuk çalışma dizini parametresi aracılığıyla belirtilir.",
+          "options": {
+            "0": "Ortam değişkenleri yerel bilgisayarın değerlerine genişletilmelidir.",
+            "1": "Uzak bilgisayardaki ortam değişkenleri uzak bilgisayarın değerlerine genişletilmelidir."
+          }
+        },
+        "remoteapplicationfile__s": {
+          "label": "Dosyayı başlat",
+          "description": "Uzak bilgisayarda RemoteApp tarafından açılacak dosyayı belirtir.\n\nNot: Yerel dosyaların açılması için, (en azından) kaynak sürücü için sürücü yeniden yönlendirmeyi de etkinleştirmeniz gerekir."
+        },
+        "remoteapplicationfileextensions__s": {
+          "label": "RemoteApp ile ilişkili dosya uzantıları",
+          "description": "RemoteApp ile ilişkili bir veya daha fazla dosya uzantısını belirtir. Bazı çalışma alanı istemcileri bu dosya türleri için destek kaydeder.\n\nBirden fazla dosya uzantısı virgülle (,) ayrılmalıdır. Her dosya uzantısı bir nokta (.) ile başlamalıdır."
+        },
+        "remoteapplicationicon__s": {
+          "label": "Başlangıç ​​simgesi yolu",
+          "description": "RemoteApp başlatılırken Uzak Masaüstü arayüzünde görüntülenecek bir simge dosyasının dosya adını belirtir. Varsayılan olarak RDC standart Uzak Masaüstü simgesini gösterecektir.\n\nNot: Yalnızca .ico dosyaları desteklenir. Yol, istemci bilgisayardaki yerel bir yol olmalıdır."
+        },
+        "remoteapplicationmode__i": {
+          "label": "RemoteApp'ı kullanın",
+          "description": "Uzak bilgisayara bağlanırken RemoteApp'in başlatılıp başlatılmayacağını belirler.",
+          "options": {
+            "0": "Normal bir oturum kullanın ve RemoteApp başlatmayın.",
+            "1": "Bir RemoteApp'e bağlanın ve başlatın."
+          }
+        },
+        "remoteapplicationname__s": {
+          "label": "Ekran adı",
+          "description": "RemoteApp başlatılırken Uzak Masaüstü arayüzündeki RemoteApp'in adını belirtir."
+        },
+        "remoteapplicationprogram__s": {
+          "label": "Uygulama veya uygulama yolu",
+          "description": "RemoteApp'in takma adını veya yürütülebilir adını belirtir."
+        },
+        "screen mode id__i": {
+          "label": "Ekran modu",
+          "description": "Uzak bilgisayara bağlandığınızda uzak oturum penceresinin tam ekran görünüp görünmeyeceğini belirler.",
+          "options": {
+            "1": "Uzak oturum bir pencerede görünecektir.",
+            "2": "Uzak oturum tam ekran görünecektir."
+          }
+        },
+        "selectedmonitors__s": {
+          "label": "Çoklu monitör desteği için seçilen monitör",
+          "description": "Uzak oturum için hangi yerel ekranların kullanılacağını belirtir. Seçilen ekranlar bitişik olmalıdır. Multimon kullanımının 1'e ayarlanmasını gerektirir.\n\nMakineye özel ekran kimliklerinin virgülle ayrılmış listesi. Mstsc.exe /l'yi çağırarak kimlikleri alabilirsiniz. Listelenen ilk kimlik, oturumdaki birincil ekran olarak ayarlanacaktır. Tüm ekranlar için varsayılandır."
+        },
+        "server port__i": {
+          "label": "Sunucu bağlantı noktası",
+          "description": "Uzak Masaüstü bağlantısı için alternatif bir varsayılan bağlantı noktası tanımlar.\n\nSunucu adına eklenen herhangi bir bağlantı noktası numarası tarafından geçersiz kılınacaktır."
+        },
+        "session bpp__i": {
+          "label": "Renk derinliği (piksel başına bit sayısı)",
+          "description": "Bağlandığınızda uzak bilgisayardaki renk derinliğini (bit cinsinden) belirler.",
+          "options": {
+            "8": "256 renk (8 bit).",
+            "15": "Yüksek renk (15 bit).",
+            "16": "Yüksek renk (16 bit).",
+            "24": "Gerçek renk (24 bit).",
+            "32": "En yüksek kalite (32 bit)."
+          }
+        },
+        "shell working directory__s": {
+          "label": "Alternatif kabuk çalışma dizini",
+          "description": "Alternatif bir kabuk belirtilirse kullanılacak uzak bilgisayardaki çalışma dizini."
+        },
+        "signature__s": {
+          "label": "İmza",
+          "description": "Bu .rdp dosyasının imzası."
+        },
+        "signscope__s": {
+          "label": "İmza oluşturma kapsamı",
+          "description": ".rdp dosya imzalama kullanılırken imzanın oluşturulduğu .rdp dosya ayarlarının virgülle ayrılmış listesi."
+        },
+        "singlemoninwindowedmode__i": {
+          "label": "Tam ekrandan çıkarken tek monitör moduna geçin",
+          "description": "Çoklu ekran uzak oturumunun, tam ekrandan çıkarken otomatik olarak tek ekrana geçip geçmeyeceğini belirler. Multimon'un 1 olarak ayarlanmasını gerektirir. Yalnızca Windows için Windows Uygulamasında ve Windows için Uzak Masaüstü uygulamasında kullanılabilir.",
+          "options": {
+            "0": "Uzak oturum, tam ekrandan çıkıldığında tüm görüntüleri korur.",
+            "1": "Uzak oturum, tam ekrandan çıkıldığında tek bir ekrana geçer."
+          }
+        },
+        "smart sizing__i": {
+          "label": "Akıllı boyutlandırmayı etkinleştir",
+          "description": "Pencere yeniden boyutlandırıldığında istemci bilgisayarın, uzak bilgisayardaki içeriği istemci bilgisayarın pencere boyutuna sığacak şekilde ölçeklendirmesi gerekip gerekmediğini belirler.",
+          "options": {
+            "0": "İstemci penceresi görüntüsü yeniden boyutlandırıldığında ölçeklenmeyecektir.",
+            "1": "İstemci penceresi görüntüsü yeniden boyutlandırıldığında ölçeklenecektir."
+          }
+        },
+        "span monitors__i": {
+          "label": "Birden fazla monitörün yayılmasına izin ver",
+          "description": "Uzak bilgisayara bağlandığınızda uzak oturum penceresinin birden fazla monitöre yayılıp yayılmayacağını belirler.\n\nNot: Uzak Masaüstü Bağlantısı 7 (Windows 7/2008) kullanılırken multimon ayarının kullanılması önerilir.",
+          "options": {
+            "0": "Monitör yayma etkin değil.",
+            "1": "Monitör yayma etkinleştirildi."
+          }
+        },
+        "superpanaccelerationfactor__i": {
+          "label": "SuperPan modu hızlanma faktörü",
+          "description": "SuperPan modundayken istemcinin fare hareketinin her pikseli için ekran görünümünün belirli bir yönde kaydırılacağı piksel sayısını belirtir"
+        },
+        "targetisaadjoined__i": {
+          "label": "Microsoft Entra'ya katılan oturum ana bilgisayarlarına bağlantılara izin ver (eski)",
+          "description": "Kullanıcı adı ve parola kullanılarak Microsoft Entra'nın katıldığı oturum ana bilgisayarlarına bağlantı yapılmasına izin verir. Bu özellik yalnızca Windows olmayan istemciler ve Microsoft Entra'ya katılmamış yerel Windows aygıtları için geçerlidir.\n\nNot: Bu özelliğin yerini activerdsaadauth alıyor.",
+          "options": {
+            "0": "Microsoft Entra'ya katılmış oturum ana bilgisayarlarına yapılan bağlantılar, gereksinimleri karşılayan Windows cihazları için başarılı olur, ancak diğer bağlantılar başarısız olur.",
+            "1": "Microsoft Entra'ya katılan ana bilgisayarlara bağlantılar başarılı olur ancak oturum ana bilgisayarlarına bağlanırken kullanıcı adı ve parola kimlik bilgilerinin girilmesiyle sınırlıdır."
+          }
+        },
+        "usbdevicestoredirect__s": {
+          "label": "RemoteFX USB cihazı destek modu",
+          "description": "RemoteFX USB yeniden yönlendirmeyi destekleyen bir uzak oturuma bağlandığınızda, istemci bilgisayardaki hangi desteklenen RemoteFX USB aygıtlarının yeniden yönlendirileceğini ve uzak oturumda kullanılabilir olacağını belirler.\n\nDeğer belirtilmedi - Desteklenen RemoteFX USB aygıtlarının hiçbirini yeniden yönlendirmeyin.\n* - Üst düzey yeniden yönlendirme mekanizmaları tarafından yönlendirilmeyen, desteklenen tüm RemoteFX USB aygıtlarını yeniden yönlendirme için yönlendirin.\n{Device Kurulum Sınıfı GUID'i} - Belirtilen cihaz kurulum sınıfının üyesi olan tüm desteklenen RemoteFX USB cihazlarını yönlendirin.\nUSB\\InstanceID - Verilen örnek kimliğiyle belirtilen desteklenen RemoteFX USB cihazını yönlendirin.\n-USB\\InstanceID - Cihaz yeniden yönlendirilen bir cihaz kurulum sınıfında olsa bile, verilen örnek kimliği tarafından belirtilen desteklenen RemoteFX USB cihazını yeniden yönlendirmeyin."
+        },
+        "use multimon__i": {
+          "label": "Birden fazla monitörü destekleyin",
+          "description": "Uzak bilgisayara bağlanırken oturumun gerçek çoklu monitör desteğini kullanıp kullanmayacağını belirler.",
+          "options": {
+            "0": "Çoklu monitör desteğini etkinleştirmeyin.",
+            "1": "Çoklu monitör desteğini etkinleştirin."
+          }
+        },
+        "username__s": {
+          "label": "Kullanıcı adı",
+          "description": "Uzak bilgisayarda oturum açmak için kullanılacak kullanıcı hesabının adını belirtir."
+        },
+        "videoplaybackmode__i": {
+          "label": "Video oynatma modu",
+          "description": "RDC'nin video oynatma için RDP verimli multimedya akışını kullanıp kullanmayacağını belirler.",
+          "options": {
+            "0": "Video oynatma için RDP verimli multimedya akışını kullanmayın.",
+            "1": "Mümkün olduğunda video oynatmak için RDP verimli multimedya akışını kullanın."
+          }
+        },
+        "winposstr__s": {
+          "label": "Oturum penceresi konum dizesi",
+          "description": "İstemci bilgisayardaki oturum penceresinin konumunu ve boyutlarını belirtir."
+        },
+        "workspace id__s": {
+          "label": "Çalışma Alanı Kimliği",
+          "description": "Bu ayar, bu ayarı içeren RDP dosyasıyla ilişkili RemoteApp ve Masaüstü Kimliğini tanımlar.\n\nHAYIR"
+        }
+      }
+    },
+    "tsPicker": {
+      "title": "için bir terminal sunucusu seçin"
+    },
+    "methodPicker": {
+      "title": "{{resourceTitle}} için bir bağlantı yöntemi seçin",
+      "rdpFile": "Bir RDP dosyası indirin",
+      "rdpProtocolUri": "Rdp:// aracılığıyla başlat",
+      "webGuacd": "Tarayıcıya bağlanın"
+    },
+    "getProtocolApp": {
+      "title": "Uzak Masaüstü Protokol İşleyicisi uygulamasını edinin",
+      "message": "Bu kaynağa rdp:// aracılığıyla bağlanmak için cihazınızda Uzak Masaüstü Protokol İşleyicisi uygulamasının yüklü olması gerekir. Microsoft Store'dan alabilirsiniz.",
+      "message2": "Uygulamayı yükledikten sonra devam et seçeneğine tıklayın.",
+      "action": "Devam etmek"
+    },
+    "getWindowsApp": {
+      "title": "Windows Uygulamasını edinin",
+      "message": "Bu kaynağa rdp:// aracılığıyla bağlanmak için cihazınızda Windows Uygulamasının yüklü olması gerekir. {{store}}'ten alabilirsiniz.",
+      "message2": "Uygulamayı yükledikten sonra devam et seçeneğine tıklayın.",
+      "action": "Devam etmek"
+    },
+    "noMethodsAvailable": {
+      "title": "Bağlantı yöntemi mevcut değil",
+      "message": "{{resourceTitle}} için kullanılabilir bağlantı yöntemi yoktur. Lütfen yöneticinizle iletişime geçin."
+    }
+  },
+  "securityError503": {
+    "title": "Güvenlik Hatası 5003",
+    "message": "Cihazınız SSL sertifikasına güvenmediği için servis çalışanı yüklenemedi. Sertifikayı bu bilgisayardaki güvenilen kök sertifika yetkilileri deposuna ekleyin veya RAWeb'i güvenilen bir sertifika kullanacak şekilde yapılandırın. Performans ve işlevsellik sınırlı olabilir. Çevrimdışı özellikler kullanılamıyor.",
+    "action": "Daha fazla bilgi edin"
+  },
+  "tsError517": {
+    "title": "Bu terminal sunucusu bağlantıları kabul etmiyor.",
+    "message": "Bu kaynak web arayüzünden ve diğer çalışma alanı istemcilerinden gizlenecektir.",
+    "action": "Bu terminal sunucusuna bağlantıları nasıl etkinleştireceğinizi öğrenin"
+  },
+  "login": {
+    "title": "Oturum aç",
+    "captionContinue": "Devam etmek için",
+    "captionOn": "Açık",
+    "incorrectUsernameOrPassword": "Yanlış kullanıcı adı veya şifre.",
+    "continue": "Devam etmek",
+    "continueAnonymous": "Atlamak",
+    "changePasswordButton": "Şifrenizi değiştirin",
+    "securityError503": {
+      "title": "Kimlik bilgileriniz risk altında",
+      "message": "Bu sayfa güvenli değil. Kötü niyetli bir aktör şifrenizi çalabilir.",
+      "action": "Çözümü görüntüle",
+      "code": "Güvenlik Hatası 5003"
+    },
+    "server": {
+      "unfoundDomain": "Belirtilen etki alanı mevcut olmadığından oturum açılamadı. Lütfen RAWeb sunucusunun alan adınızın ağına bağlı olduğundan emin olun ve tekrar deneyin.",
+      "localMachineError": "Kimlik bilgileri yerel makinede doğrulanırken bir şeyler ters gitti. Lütfen daha sonra tekrar deneyin.",
+      "accountRestrictionError": "Hesabınızda oturum açmanızı engelleyen kısıtlamalar var.",
+      "invalidLogonHoursError": "Hesabınızda şu anda oturum açmanızı engelleyen zaman kısıtlamaları var.",
+      "invalidWorkstationError": "Bu sunucuya giriş yapmanıza izin verilmiyor.",
+      "passwordExpiredError": "Bu hesabın şifresinin süresi doldu. {password_change_button}",
+      "accountDisabledError": "Hesabınız şu anda devre dışı.",
+      "passwordMustChange": "Oturum açabilmeniz için önce şifrenizi değiştirmeniz gerekir. {password_change_button}"
+    }
+  },
+  "domain": "İhtisas",
+  "username": "Kullanıcı adı",
+  "password": "Şifre",
+  "usernameRequired": "Bir kullanıcı adı belirtmelisiniz",
+  "passwordRequired": "Bir şifre belirtmelisiniz",
+  "poweredBy": "RAWeb tarafından desteklenmektedir",
+  "poweredByLearnMore": "Daha fazla bilgi edin",
+  "signOut": {
+    "title": "Oturum kapatılıyor"
+  },
+  "changePassword": {
+    "title": "Şifreyi değiştirme",
+    "genericFailureMessage": "Geçersiz kullanıcı adı veya şifre.",
+    "oldPassword": "Eski Şifre",
+    "newPassword": "Yeni Şifre",
+    "confirmPassword": "Şifreyi onayla",
+    "passwordsDoNotMatch": "Şifreler eşleşmiyor.",
+    "submit": "Göndermek",
+    "cancel": "İptal etmek"
+  },
+  "copyToClipboard": "Panoya kopyala",
+  "copiedToClipboard": "Panoya kopyalandı",
+  "closeDialogWithUnsavedChangesGuard": {
+    "title": "Değişiklikler silinsin mi?",
+    "message": "Kaydedilmemiş değişiklikleriniz var. Bu iletişim kutusunu kaydetmeden kapatmak istediğinizden emin misiniz?"
+  },
+  "registryApps": {
+    "manager": {
+      "open": "Kaynakları yönet",
+      "title": "RemoteApps ve masaüstü yöneticisi",
+      "add": "Yeni RemoteApp ekle",
+      "addFromSystem": "Ana sistemden ekle",
+      "fromRdpFile": "RDP dosyasından ekle",
+      "rdpUploadFail": {
+        "title": "Kaynak oluşturulamıyor",
+        "missingAppPath": "RDP dosyasında bir uygulama yolu (uzak uygulama programı) eksik.",
+        "missingConnectionAddress": "RDP dosyasında bir terminal sunucusu adresi (tam adres) eksik.",
+        "invalidFileType": "Yüklenen dosya geçerli bir RDP dosyası değil."
+      },
+      "refresh": "Listeyi yenile",
+      "appProperties": {
+        "sections": {
+          "application": "Başvuru",
+          "desktop": "Masaüstü",
+          "icon": "Simge",
+          "wallpaper": "Duvar kağıdı",
+          "advanced": "Gelişmiş",
+          "dangerZone": "Tehlike bölgesi"
+        },
+        "title": "Özellikler",
+        "selectIcon": "Simge seç",
+        "selectWallpaper": "Duvar kağıdını seçin",
+        "configureFileTypeAssociations": "Dosya türü ilişkilerini yapılandırma",
+        "manageUserAssignment": "Kullanıcı atamasını yönet",
+        "saveError": "Kaynak kaydedilirken hata oluştu",
+        "removeApp": "RemoteApp'ı kaldır",
+        "removeDesktop": "Masaüstünü kaldır",
+        "customizeRdpFile": "RDP dosyasını düzenle",
+        "manageVirtualFolders": "Sanal klasörleri yönet"
+      },
+      "iconPicker": {
+        "title": "Simge Seç"
+      },
+      "discover": {
+        "title": "Eklenecek uygulamaları keşfedin",
+        "manualAdd": "Manuel olarak oluştur",
+        "upload": "RDP dosyasını yükle",
+        "refresh": "Yenile"
+      },
+      "create": {
+        "409": "Bu benzersiz tanımlayıcıya sahip bir kaynak zaten mevcut. Lütfen farklı bir benzersiz tanımlayıcı seçin.",
+        "title": "Yeni kaynak ekle"
+      },
+      "remove": {
+        "title": "{{app_name}} kaldırılsın mı?",
+        "message": "Bu eylem geri alınamaz."
+      },
+      "fileTypeAssociationsEditor": {
+        "title": "{{app_name}} Dosya Türü İlişkileri",
+        "add": "İlişkilendirme ekle",
+        "remove": "Kaldırmak",
+        "removeAll": "Tümünü kaldır",
+        "selectIcon": "Simge seç"
+      },
+      "securityEditor": {
+        "title": "{{app_name}} Güvenliği",
+        "add": "Kullanıcı veya grup ekle",
+        "removeAll": "Tümünü kaldır",
+        "description": "Bu ayarlar kaynağın kendisine erişimi etkilemez, yalnızca RAWeb web uygulaması ve diğer çalışma alanı istemcilerindeki görünürlüğünü etkiler.",
+        "allowedUsersGroupsLabel": "İzin verilen kullanıcılar ve gruplar",
+        "deniedUsersGroupsLabel": "Reddedilen kullanıcılar ve gruplar",
+        "undefined": "Bu kaynağa erişim, Uzak Masaüstü Kullanıcıları veya Yöneticileri üyesi olan tüm kullanıcılara veya gruplara verilecektir.",
+        "undefinedAllowed": "Hiçbir kullanıcıya veya gruba erişim/görünürlük izni verilmedi.",
+        "undefinedDenied": "Hiçbir kullanıcının veya grubun erişimi/görünürlüğü reddedilmedi.",
+        "denyReadAccess": "Okuma erişimini reddet",
+        "allowReadAccess": "Okuma erişimine izin ver",
+        "remove": "Kaldırmak"
+      },
+      "selectUsersOrGroups": {
+        "title": "Kullanıcıları veya grupları seçin",
+        "locationsField": "Bu konumdan",
+        "objectNamesField": "Seçilecek nesne adlarını girin",
+        "checkNames": "Adları kontrol edin",
+        "pickLocations": "Konumlar",
+        "notFoundTitle": "İsim bulunamadı",
+        "notFoundMessage": "'{{name}}' adı bulunamadı. Ne yapmak istersin?",
+        "discardNotFoundObject": "Seçimden çıkar",
+        "keepNotFoundObject": "Görmezden gelmek"
+      },
+      "selectLocation": {
+        "title": "Konum seçin"
+      },
+      "virtualFoldersEditor": {
+        "title": "{{app_name}} için sanal klasörleri yönetin",
+        "add": "Sanal klasör ekle",
+        "remove": "Kaldırmak",
+        "removeAll": "Tümünü kaldır"
+      }
+    },
+    "properties": {
+      "key": "Benzersiz tanımlayıcı",
+      "displayName": "Ekran adı",
+      "appPath": "Uygulama yolu",
+      "cmdLineArgs": "Komut satırı argümanları",
+      "iconPath": "Simge yolu",
+      "iconIndex": "Simge dizini",
+      "managedIcon": {
+        "light": "Işık modu",
+        "dark": "Karanlık mod"
+      },
+      "includeInWorkspace": "Web arayüzünde ve çalışma alanı akışlarında göster",
+      "virtualFolders": "Sanal klasörler",
+      "fileTypeAssociations": "Dosya türü ilişkileri",
+      "userAssignment": "Kullanıcı ataması",
+      "customizeRdpFile": "RDP dosya özellikleri",
+      "externalAddress": "Harici terminal sunucusu adresi"
+    }
+  },
+  "client": {
+    "resourceNotFound": "Kaynak bulunamadı",
+    "resourceNotFoundMessage": "\" {{hostId}} \" ana bilgisayarı için \" {{resourceId}} \" tanımlayıcısına sahip geçerli bir kaynak bulamadık.",
+    "creds": {
+      "title": "Kimlik bilgilerinizi girin",
+      "gatewayTitle": "Ağ geçidi kimlik bilgilerinizi girin",
+      "message": "Bu kimlik bilgileri {{hostId}}'e bağlanmak için kullanılacaktır.",
+      "gatewayMessage": "Bu kimlik bilgileri {{hostId}} konumunda bulunan ağ geçidi için kullanılacaktır.",
+      "failtitle": "Kimlik bilgileriniz işe yaramadı",
+      "gatewayfailtitle": "Ağ geçidi kimlik bilgileriniz işe yaramadı",
+      "failmessage": "{{hostId}}'e bağlanmak için kullandığınız kimlik bilgileri işe yaramadı. Lütfen yeni kimlik bilgilerini girin.",
+      "gatewayfailmessage": "{{hostId}}'te bulunan ağ geçidine bağlanmak için kullandığınız kimlik bilgileri işe yaramadı. Lütfen yeni kimlik bilgilerini girin.",
+      "failerror": "Oturum açma denemesi başarısız oldu",
+      "allFail": {
+        "title": "Cihazınız veya ağ geçidi kimlik bilgileriniz çalışmadı",
+        "message": "{{gatewayHostId}}'te bulunan ağ geçidi aracılığıyla {{hostId}}'e bağlanmak için kullandığınız kimlik bilgileri çalışmadı. Lütfen yeni kimlik bilgileriyle tekrar deneyin.",
+        "retry": "Yeniden dene",
+        "cancel": "İptal etmek"
+      }
+    },
+    "certError": {
+      "tsTitle": "Uzak bilgisayarın kimliği doğrulanamadı. Yine de bağlanmak istiyor musunuz?",
+      "gatewayTitle": "Ağ geçidi sunucusunun kimliği doğrulanamadı. Yine de bağlanmak istiyor musunuz?",
+      "strictErrorTitle": "Güvenlik ayarlarınız bu bağlantıyı engelledi.",
+      "tsStrictErrorMessage": "Uzak bilgisayarlara güvenli olmayan bağlantılar engellenir. Daha fazla bilgi için yöneticinizle iletişime geçin.",
+      "gatewayStrictErrorMessage": "Güvenli olmayan ağ geçidi sunucusu bağlantıları engellendi. Daha fazla bilgi için yöneticinizle iletişime geçin.",
+      "yes": "Evet",
+      "no": "HAYIR",
+      "cancel": "İptal etmek"
+    },
+    "disconnected": {
+      "title": "Bağlantı kesildi",
+      "message": "Uzak cihazla bağlantı kapatıldı.",
+      "reconnect": "Yeniden bağlan",
+      "leave": "Ayrılmak"
+    },
+    "connectionError": {
+      "title": "Bağlantı hatası",
+      "retry": "Yeniden dene",
+      "cancel": "İptal etmek"
+    },
+    "unreachable": {
+      "title": "Terminal sunucusuna ulaşılamıyor",
+      "message": "Uzak masaüstü proxy hizmeti aşağıdaki nedenlerden biri nedeniyle {{hostId}}'e ulaşamadı:\n\n1) Terminal sunucusuna uzaktan erişim etkin değil.\n2) Terminal sunucusu kapalı.\n3) Terminal sunucusu, uzak masaüstü proxy hizmetiyle aynı ağda mevcut değil.\n4) Güvenlik duvarı terminal sunucusuna erişimi engelliyor.\n\nTerminal sunucusunun açık olduğundan ve uzak masaüstü proxy hizmetiyle aynı ağa bağlı olduğundan ve terminal sunucusunda uzaktan erişimin etkinleştirildiğinden emin olun.",
+      "retry": "Yeniden dene",
+      "cancel": "İptal etmek"
+    },
+    "alreadyConnected": {
+      "title": "Bir şeyler ters gitti",
+      "message": "Tarayıcınız, bağlantı zaten etkinken {{hostId}} ile bağlantı başlatmayı denedi. Lütfen tekrar deneyin.",
+      "retry": "Yeniden dene",
+      "cancel": "İptal etmek"
+    },
+    "clipboardError": {
+      "NO_CLIPBOARD_API": {
+        "title": "Tarayıcınız Clipboard API'sini desteklemiyor",
+        "message": "Bu uzak oturum sırasında pano işlevi kullanılamayacak."
+      },
+      "NO_PERMISSIONS_API": {
+        "title": "Tarayıcınız RAWeb'in pano izinlerini kontrol etmesini engelliyor",
+        "message": "Bu uzak oturum sırasında pano işlevi kullanılamayacak."
+      },
+      "NO_PERMISSION_TO_READ": {
+        "title": "Tarayıcınız panodan okuma iznini reddetti",
+        "message": "Bu uzak oturum sırasında pano işlevi kullanılamayacak."
+      },
+      "NO_PERMISSION_TO_WRITE": {
+        "title": "Tarayıcınız panoya yazma iznini reddetti",
+        "message": "Bu uzak oturum sırasında pano işlevi kullanılamayacak."
+      }
+    },
+    "reconnectingErrorMessage": "Bağlantı kesildi. Yeniden bağlanılıyor...",
+    "connecting": "{{hostId}}'e bağlanma",
+    "reconnecting": "{{hostId}}'e yeniden bağlanma",
+    "serviceOffline": "Uzak masaüstü proxy hizmeti çevrimdışı.",
+    "startingService": "Uzak masaüstü proxy hizmetini başlatma",
+    "installingService": "Uzak masaüstü proxy hizmetini yükleme",
+    "hostNotFoundError": "Belirtilen uzak ana bilgisayara ( {{hostId}} ) ulaşılamadı."
+  },
+  "docs": {
+    "search": {
+      "title": "\"{{query}}\" için arama sonuçları",
+      "placeholder": "Belgeleri arayın",
+      "typeToSearch": "Aramak için yazın",
+      "noResults": "Sonuç bulunamadı",
+      "searching": "Arama..."
+    }
+  },
+  "security": {
+    "dialogTitle": "RAWeb Güvenliği"
+  }
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,0 +1,2620 @@
+{
+  "name": "frontend",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "@tanstack/vue-query": "^5.100.10",
+        "devalue": "^5.8.1",
+        "dompurify": "^3.4.3",
+        "front-matter": "^4.0.2",
+        "guacamole-common-js": "1.5.0",
+        "i18next": "^25.10.10",
+        "i18next-http-backend": "^3.0.6",
+        "i18next-vue": "^5.4.0",
+        "markdown-it-attrs": "^4.3.1",
+        "markdown-it-footnote": "^4.0.0",
+        "pinia": "^3.0.4",
+        "unplugin-vue-markdown": "^29.2.0",
+        "vue": "^3.5.34",
+        "vue-router": "^4.6.4",
+        "zod": "^4.4.3"
+      },
+      "devDependencies": {
+        "@types/guacamole-common-js": "~1.5.5",
+        "@types/markdown-it-attrs": "^4.1.3",
+        "@types/markdown-it-footnote": "^3.0.4",
+        "@types/node": "^22.19.19",
+        "@vitejs/plugin-vue": "^5.2.4",
+        "@xmldom/xmldom": "^0.8.13",
+        "i18next-fs-backend": "^2.6.5",
+        "image-size": "^2.0.2",
+        "pagefind": "^1.5.2",
+        "selfsigned": "^5.5.0",
+        "typescript": "^5.9.3",
+        "vite": "^6.4.2"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@mdit-vue/plugin-component": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@mdit-vue/plugin-component/-/plugin-component-3.0.2.tgz",
+      "integrity": "sha512-Fu53MajrZMOAjOIPGMTdTXgHLgGU9KwTqKtYc6WNYtFZNKw04euSfJ/zFg8eBY/2MlciVngkF7Gyc2IL7e8Bsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/markdown-it": "^14.1.2",
+        "markdown-it": "^14.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@mdit-vue/plugin-frontmatter": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@mdit-vue/plugin-frontmatter/-/plugin-frontmatter-3.0.2.tgz",
+      "integrity": "sha512-QKKgIva31YtqHgSAz7S7hRcL7cHXiqdog4wxTfxeQCHo+9IP4Oi5/r1Y5E93nTPccpadDWzAwr3A0F+kAEnsVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@mdit-vue/types": "3.0.2",
+        "@types/markdown-it": "^14.1.2",
+        "gray-matter": "^4.0.3",
+        "markdown-it": "^14.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@mdit-vue/types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@mdit-vue/types/-/types-3.0.2.tgz",
+      "integrity": "sha512-00aAZ0F0NLik6I6Yba2emGbHLxv+QYrPH00qQ5dFKXlAo1Ll2RHDXwY7nN2WAfrx2pP+WrvSRFTGFCNGdzBDHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@pagefind/darwin-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-arm64/-/darwin-arm64-1.5.2.tgz",
+      "integrity": "sha512-MXpI+7HsAdPkvJ0gk9xj9g541BCqBZOBbdwj9g6lB5LCj6kSV6nqDSjzcAJwvOsfu0fjwvC8hQU+ecfhp+MpiQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/darwin-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-x64/-/darwin-x64-1.5.2.tgz",
+      "integrity": "sha512-IojxFWMEJe0RQ7PQ3KXQsPIImNsbpPYpoZ+QUDrL8fAl/O27IX+LVLs74/UzEZy5uA2LD8Nz1AiwKr72vrkZQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/freebsd-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/freebsd-x64/-/freebsd-x64-1.5.2.tgz",
+      "integrity": "sha512-7EVzo9+0w+2cbe671BtMj10UlNo83I+HrLVLfRxO731svHRJKUfJ/mo05gU14pe9PCfpKNQT8FS3Xc/oDN6pOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@pagefind/linux-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-arm64/-/linux-arm64-1.5.2.tgz",
+      "integrity": "sha512-Ovt9+K35sqzn8H3ZMXGwls4TD/wMJuvRtShHIsmUQREmaxjrDEX7gHckRCrwYJ4XE1H1p6HkLz3wukrAnsfXQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/linux-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-x64/-/linux-x64-1.5.2.tgz",
+      "integrity": "sha512-V+tFqHKXhQKq/WqPBD67AFy7scn1/aZID00ws4fSDd+1daSi5UHR9VVlRrOUYKxn3VuFQYRD7lYXdZK1WED1YA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/windows-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-arm64/-/windows-arm64-1.5.2.tgz",
+      "integrity": "sha512-hN9Nh90fNW61nNRCW9ZyQrAj/mD0eRvmJ8NlTUzkbuW8kIzGJUi3cxjFkEcMZ5h/8FsKWD/VcouZl4yo1F7B6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@pagefind/windows-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-x64/-/windows-x64-1.5.2.tgz",
+      "integrity": "sha512-Fa2Iyw7kaDRzGMfNYNUXNW2zbL5FQVDgSOcbDHdzBrDEdpqOqg8TcZ68F22ol6NJ9IGzvUdmeyZypLW5dyhqsg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@peculiar/asn1-cms": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.8.0.tgz",
+      "integrity": "sha512-NgekZOrSJFSBFLFoLfwePguAWAx7z1+f2TEsWFUMyiqqfntZ4+S/S5hzqME3q4pCA0iOsFKdwiQ35dwY24eVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "@peculiar/asn1-x509-attr": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-csr": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.8.0.tgz",
+      "integrity": "sha512-akbF8+uvleHs8sejNPQxwmVFuInAg6FMNHOwMILXfP518YfFJwdR3jr6oNUPOaEJfuEhn/vkNOCIT6ASUd4mbg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-ecc": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.8.0.tgz",
+      "integrity": "sha512-ohwlk+u9Rv2NOAY1c6MfHj45ATVF8R1DUN/WCgABiRtLi2ZftlZWZX7KvpAbU8v9xPcmoILfELeEABj/rn18AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pfx": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.8.0.tgz",
+      "integrity": "sha512-5yof1ytoB++RQtaFbqSUJ8pxDJtZT6vbVqZ8XoJ61ph7UjNVvfFwAilnCodqkNsAodpy13gDhoxZXw00pghnyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.8.0",
+        "@peculiar/asn1-pkcs8": "^2.8.0",
+        "@peculiar/asn1-rsa": "^2.8.0",
+        "@peculiar/asn1-schema": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs8": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.8.0.tgz",
+      "integrity": "sha512-qAKXtLpBEw9LqhKpjw3ajZSXlBur+ipW+y2ivVBQAG6F6qRx94yO+1ZR4mvw+YaCfKSaOzLeYEzsPaBp4SJELA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs9": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.8.0.tgz",
+      "integrity": "sha512-b5nDWCnkV60+cQ141D6sVVwK9nz64R5n3zSVnklGd+ECdkW2Ol3U1a6yYFlalpSOaD557yuJB64A+q42jG7lUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.8.0",
+        "@peculiar/asn1-pfx": "^2.8.0",
+        "@peculiar/asn1-pkcs8": "^2.8.0",
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "@peculiar/asn1-x509-attr": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-rsa": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.8.0.tgz",
+      "integrity": "sha512-zHEUlCqB2mk7x2lxDwHHJy7hWZOPdGHVlsmITWKB5/PbQo61atbu9PJ/0r9dQNMwFzbKPXZ8uK8/91eUhRznSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-schema": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.8.0.tgz",
+      "integrity": "sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.8.0.tgz",
+      "integrity": "sha512-N0CMuhWUzsWEVq6F1q9X6+VKUnWzSW+cSVg+aPaGGwDdbFoFWTYgin5MHwXgpWd6y9COMBxnfy/Qc+Xc7F0Zwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509-attr": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.8.0.tgz",
+      "integrity": "sha512-tHjkfS/qhMnmrlB2J9NhflQlQ7In3khO3CfmVrriOlpTeErY9ZIKOso1hQ5JQiyrJ7ShvqVPk7E5fQmbclkSKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.8.0",
+        "@peculiar/asn1-x509": "^2.8.0",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/utils/-/utils-2.0.3.tgz",
+      "integrity": "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/x509": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-1.14.3.tgz",
+      "integrity": "sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.6.0",
+        "@peculiar/asn1-csr": "^2.6.0",
+        "@peculiar/asn1-ecc": "^2.6.0",
+        "@peculiar/asn1-pkcs9": "^2.6.0",
+        "@peculiar/asn1-rsa": "^2.6.0",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.0",
+        "pvtsutils": "^1.3.6",
+        "reflect-metadata": "^0.2.2",
+        "tslib": "^2.8.1",
+        "tsyringe": "^4.10.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@tanstack/match-sorter-utils": {
+      "version": "8.19.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/match-sorter-utils/-/match-sorter-utils-8.19.4.tgz",
+      "integrity": "sha512-Wo1iKt2b9OT7d+YGhvEPD3DXvPv2etTusIMhMUoG7fbhmxcXCtIjJDEygy91Y2JFlwGyjqiBPRozme7UD8hoqg==",
+      "license": "MIT",
+      "dependencies": {
+        "remove-accents": "0.5.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.101.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.2.tgz",
+      "integrity": "sha512-hH5MLoJhF7KaIGd7q3xTXGXvslI+GYlM1Z/35aSHHWaCJWB7XvTSHYuV3eM7tw+aE0mT/xMro4M4Q9rCGHT0lw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/vue-query": {
+      "version": "5.101.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/vue-query/-/vue-query-5.101.2.tgz",
+      "integrity": "sha512-nFXKNK4dI/PnKNejyIkQmmobBsJWWXTPcpjPvkgFLkpFPz9DcmqIiKIAF2Pa7MZCipH62/+bt2sxEIA0wNEeOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/match-sorter-utils": "^8.19.4",
+        "@tanstack/query-core": "5.101.2",
+        "@vue/devtools-api": "^6.6.3",
+        "vue-demi": "^0.14.10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.1.2",
+        "vue": "^2.6.0 || ^3.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@tanstack/vue-query/node_modules/vue-demi": {
+      "version": "0.14.10",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/guacamole-common-js": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@types/guacamole-common-js/-/guacamole-common-js-1.5.5.tgz",
+      "integrity": "sha512-dqDYo/PhbOXFGSph23rFDRZRzXdKPXy/nsTkovFMb6P3iGrd0qGB5r5BXHmX5Cr/LK7L1TK9nYrTMbtPkhdXyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/markdown-it-attrs": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it-attrs/-/markdown-it-attrs-4.1.3.tgz",
+      "integrity": "sha512-1JsseFdHD6rQHsPcy4W3xx/whxvZ09Z+CqPpnOtrGtpmkFW07N11q7oM383//LtoKv54yn+HGnk6r4ZHUTHJVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/markdown-it": "*"
+      }
+    },
+    "node_modules/@types/markdown-it-footnote": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it-footnote/-/markdown-it-footnote-3.0.4.tgz",
+      "integrity": "sha512-XJ6n+v+2u+2gmYLSHcxyoNT/YrgrKvHuDJQlykFjuxCQCr86P2/fx1V6/0lcKxv5cSIlCaJ6sUcNS3zDI7I+LA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/markdown-it": "*"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
+      "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@vitejs/plugin-vue": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz",
+      "integrity": "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0 || ^6.0.0",
+        "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.39.tgz",
+      "integrity": "sha512-16KBTEXAJCpDr0mwlw+AZyhu8iyC7R3S2vBwsI7QnWJU6X3WKc9VKeNEZpiMdZ569qWhz9574L3vV55qRL0Vtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@vue/shared": "3.5.39",
+        "entities": "^7.0.1",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-core/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.39.tgz",
+      "integrity": "sha512-oQPigALqYbNxTNPvNgSOe+czwVExfbVF02lz8jP0S3AXJiu3jxYDygNUiqSep4ezzW8XgnubqH63My2A7JR/vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.39",
+        "@vue/shared": "3.5.39"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.39.tgz",
+      "integrity": "sha512-d0ki86iOyN8LoZPBmk5SJWNwHP19CnDDCfuo//+2WJa2g5Ke0Jay983PIBIcSSzldC68I8DrD5GrHV3OSDfodg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@vue/compiler-core": "3.5.39",
+        "@vue/compiler-dom": "3.5.39",
+        "@vue/compiler-ssr": "3.5.39",
+        "@vue/shared": "3.5.39",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.15",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.39.tgz",
+      "integrity": "sha512-Ce7/wvwMHai74bdszfXExdazFigYnlF9zgCmEQUcM1j0fOymlouZ7XilTYNo8oUjhlnjYOZbGrcYKuqjz89Ucw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.39",
+        "@vue/shared": "3.5.39"
+      }
+    },
+    "node_modules/@vue/devtools-api": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
+      "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
+      "license": "MIT"
+    },
+    "node_modules/@vue/devtools-kit": {
+      "version": "7.7.10",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.10.tgz",
+      "integrity": "sha512-3WNi2Kq4tbpVbmhml7RiphmAt0279oh3fKNeWMQIrltfX8Q91b4i5PL8DtyNKdwmcsGrV4fg+erwWOmD05CLIw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-shared": "^7.7.10",
+        "birpc": "^2.3.0",
+        "hookable": "^5.5.3",
+        "mitt": "^3.0.1",
+        "perfect-debounce": "^1.0.0",
+        "speakingurl": "^14.0.1",
+        "superjson": "^2.2.2"
+      }
+    },
+    "node_modules/@vue/devtools-shared": {
+      "version": "7.7.10",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.10.tgz",
+      "integrity": "sha512-wOPslzB8vTvpxwdaOcR2qAbwmuSP0L+rhpoC6Cf56V3Jip+HWb7PQQXOUPgBNQARpXsbQX/+mvi8kKucmBGRwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "rfdc": "^1.4.1"
+      }
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.39.tgz",
+      "integrity": "sha512-TpsuBJ9gGlZa5d23XcM2y8EXanz9dZeVDQBXRwzy46ItgvM+rWpzs+UVM0wcRLxGvcav0HE5jz2gNL53xlRAog==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.5.39"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.39.tgz",
+      "integrity": "sha512-9GLtNyRvPAUMbX+7ono0RC2j0guo2LXVi8LvcmAooImACUKm0oFf0jjwbX8/H0AE/t1nxhAkn8RSl9PMCzzxZw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.39",
+        "@vue/shared": "3.5.39"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.39.tgz",
+      "integrity": "sha512-7Y6aAGboKcXAZ3ECuUy7RrS5yy2r47dhTp2SKaJmYxjopImaVFaNa5Ne66NwGovsrxVAl5S5rwc7m22UG7Lmww==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.39",
+        "@vue/runtime-core": "3.5.39",
+        "@vue/shared": "3.5.39",
+        "csstype": "^3.2.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.39.tgz",
+      "integrity": "sha512-yZSakiAGw85rZfG7UM8akMnIF+FmeiNk47uvHf2nVBBSe+dIKUhZuZq9+XgJhbV3nS5Z4ALH23/MpXofW+mbcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.39",
+        "@vue/shared": "3.5.39"
+      },
+      "peerDependencies": {
+        "vue": "3.5.39"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.39.tgz",
+      "integrity": "sha512-l1rrBtBfTnmxvtsvdQDXltUUy8S1Y+ZaqdfUzmAnJkTd8Z8rv5v/ytW+TKiqEOWyHPoqtPlNFSs0lhRmYVSHVA==",
+      "license": "MIT"
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/asn1js": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
+      "integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "pvtsutils": "^1.3.6",
+        "pvutils": "^1.1.5",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/birpc": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
+      "integrity": "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/bytestreamjs": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/bytestreamjs/-/bytestreamjs-2.0.1.tgz",
+      "integrity": "sha512-U1Z/ob71V/bXfVABvNr/Kumf5VyeQRBEm6Txb0PQ6S7V5GpBM3w4Cbqz/xPDicR5tN0uvDifng8C+5qECeGwyQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/copy-anything": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-4.0.5.tgz",
+      "integrity": "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-what": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/cross-fetch": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
+      "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.7.0"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/devalue": {
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
+      "integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
+      "license": "MIT"
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
+    },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/front-matter": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/front-matter/-/front-matter-4.0.2.tgz",
+      "integrity": "sha512-I8ZuJ/qG92NWX8i5x1Y8qyj3vizhXS31OxjKDu3LKP+7/qBgfIKValiZIEwoVoJKUHlhWtYrktkxV1XsX+pPlg==",
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^3.13.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/guacamole-common-js": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/guacamole-common-js/-/guacamole-common-js-1.5.0.tgz",
+      "integrity": "sha512-zxztif3GGhKbg1RgOqwmqot8kXgv2HmHFg1EvWwd4q7UfEKvBcYZ0f+7G8HzvU+FUxF0Psqm9Kl5vCbgfrRgJg==",
+      "license": "Apache 2.0"
+    },
+    "node_modules/hookable": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
+      "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
+      "license": "MIT"
+    },
+    "node_modules/i18next": {
+      "version": "25.10.10",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.10.10.tgz",
+      "integrity": "sha512-cqUW2Z3EkRx7NqSyywjkgCLK7KLCL6IFVFcONG7nVYIJ3ekZ1/N5jUsihHV6Bq37NfhgtczxJcxduELtjTwkuQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://www.locize.com/i18next"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.locize.com"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2"
+      },
+      "peerDependencies": {
+        "typescript": "^5 || ^6"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/i18next-fs-backend": {
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/i18next-fs-backend/-/i18next-fs-backend-2.6.6.tgz",
+      "integrity": "sha512-mYGu6Nt8RIp3X/U8Y+Gej1wo5xmYWmGKLqBGMCC2OCAou5rW5epeHgHmVcw20mJs9Z9+DAPHIxQPNCgFyPRMeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/i18next-http-backend": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/i18next-http-backend/-/i18next-http-backend-3.0.6.tgz",
+      "integrity": "sha512-mBOqy8993jtqAoj6XaI1XeC/8/9v6EPS+681ziegrPvTB0DoaCY7PpTS0SpY56qLMoS4OI1TZEM2Zf59zNh05w==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-fetch": "4.1.0"
+      }
+    },
+    "node_modules/i18next-vue": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/i18next-vue/-/i18next-vue-5.4.0.tgz",
+      "integrity": "sha512-GDj0Xvmis5Xgcvo9gMBJMgJCtewYMLZP6gAEPDDGCMjA+QeB4uS4qUf1MK79mkz/FukhaJdC+nlj0y1qk6NO2Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "i18next": ">=23",
+        "vue": "^3.4.38"
+      }
+    },
+    "node_modules/image-size": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-2.0.2.tgz",
+      "integrity": "sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "image-size": "bin/image-size.js"
+      },
+      "engines": {
+        "node": ">=16.x"
+      }
+    },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-what": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-5.5.0.tgz",
+      "integrity": "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/linkify-it": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/markdown-it": {
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.0.tgz",
+      "integrity": "sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.5.0",
+        "linkify-it": "^5.0.2",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-it-async": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-async/-/markdown-it-async-2.2.0.tgz",
+      "integrity": "sha512-sITME+kf799vMeO/ww/CjH6q+c05f6TLpn6VOmmWCGNqPJzSh+uFgZoMB9s0plNtW6afy63qglNAC3MhrhP/gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/markdown-it": "^14.1.2",
+        "markdown-it": "^14.1.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/markdown-it-attrs": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-attrs/-/markdown-it-attrs-4.5.0.tgz",
+      "integrity": "sha512-dsuEyK/MDAYsdZLDIaDAQXz5+gP0AAbJ4ZjOSB0w+ZGe4lLbzyCgGg0LApC6j9zUK2F+2SA9VkzXfyNG9hL/8g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependencies": {
+        "markdown-it": ">= 9.0.0"
+      }
+    },
+    "node_modules/markdown-it-footnote": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-footnote/-/markdown-it-footnote-4.0.0.tgz",
+      "integrity": "sha512-WYJ7urf+khJYl3DqofQpYfEYkZKbmXmwxQV8c8mO/hGIhgZ1wOe7R4HLFNwqx7TjILbnC98fuyeSsin19JdFcQ==",
+      "license": "MIT"
+    },
+    "node_modules/markdown-it/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "license": "MIT"
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pagefind": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/pagefind/-/pagefind-1.5.2.tgz",
+      "integrity": "sha512-XTUaK0hXMCu2jszWE584JGQT7y284TmMV9l/HX3rnG5uo3rHI/uHU56XTyyyPFjeWEBxECbAi0CaFDJOONtG0Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "pagefind": "lib/runner/bin.cjs"
+      },
+      "optionalDependencies": {
+        "@pagefind/darwin-arm64": "1.5.2",
+        "@pagefind/darwin-x64": "1.5.2",
+        "@pagefind/freebsd-x64": "1.5.2",
+        "@pagefind/linux-arm64": "1.5.2",
+        "@pagefind/linux-x64": "1.5.2",
+        "@pagefind/windows-arm64": "1.5.2",
+        "@pagefind/windows-x64": "1.5.2"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "license": "MIT"
+    },
+    "node_modules/perfect-debounce": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
+      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pinia": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pinia/-/pinia-3.0.4.tgz",
+      "integrity": "sha512-l7pqLUFTI/+ESXn6k3nu30ZIzW5E2WZF/LaHJEpoq6ElcLD+wduZoB2kBN19du6K/4FDpPMazY2wJr+IndBtQw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-api": "^7.7.7"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.5.0",
+        "vue": "^3.5.11"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pinia/node_modules/@vue/devtools-api": {
+      "version": "7.7.10",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.10.tgz",
+      "integrity": "sha512-KxtEpUOOpFz/qOGRrAwA36QF7DqIA+FXgCYit9mk9wjbaZt0sXOFz81ElOZtKA4HbWHUdwNjZHBFsFFyp5BZiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-kit": "^7.7.10"
+      }
+    },
+    "node_modules/pkijs": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/pkijs/-/pkijs-3.4.0.tgz",
+      "integrity": "sha512-emEcLuomt2j03vxD54giVB4SxTjnsqkU692xZOZXHDVoYyypEm+b3jpiTcc+Cf+myooc+/Ly0z01jqeNHVgJGw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@noble/hashes": "1.4.0",
+        "asn1js": "^3.0.6",
+        "bytestreamjs": "^2.0.1",
+        "pvtsutils": "^1.3.6",
+        "pvutils": "^1.1.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pvtsutils": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+      "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/pvutils": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
+      "integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/remove-accents": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.5.0.tgz",
+      "integrity": "sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==",
+      "license": "MIT"
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "license": "MIT"
+    },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/selfsigned": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-5.5.0.tgz",
+      "integrity": "sha512-ftnu3TW4+3eBfLRFnDEkzGxSF/10BJBkaLJuBHZX0kiPS7bRdlpZGu6YGt4KngMkdTwJE6MbjavFpqHvqVt+Ew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/x509": "^1.14.2",
+        "pkijs": "^3.3.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/speakingurl": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz",
+      "integrity": "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/superjson": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.6.tgz",
+      "integrity": "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==",
+      "license": "MIT",
+      "dependencies": {
+        "copy-anything": "^4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/tsyringe": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.10.0.tgz",
+      "integrity": "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/tsyringe/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/unplugin": {
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-2.3.11.tgz",
+      "integrity": "sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "acorn": "^8.15.0",
+        "picomatch": "^4.0.3",
+        "webpack-virtual-modules": "^0.6.2"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      }
+    },
+    "node_modules/unplugin-utils": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/unplugin-utils/-/unplugin-utils-0.3.2.tgz",
+      "integrity": "sha512-xVToRh2CTmLk2HnEG7ac4rl1MJTT3RFkpS8B++/SnB0kXvuaavD+n3m/vrzyWQOdJNSZQACnbz01pnppbwV5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sxzz"
+      }
+    },
+    "node_modules/unplugin-vue-markdown": {
+      "version": "29.2.0",
+      "resolved": "https://registry.npmjs.org/unplugin-vue-markdown/-/unplugin-vue-markdown-29.2.0.tgz",
+      "integrity": "sha512-/x2hFgQ6cWN1Kls+yK5mAI9YDmeTofftynVGgOy1llBlDX1ifaXsQBls/bpORaiwn7cxA7HkOo0wn/xKcrXBHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@mdit-vue/plugin-component": "^3.0.2",
+        "@mdit-vue/plugin-frontmatter": "^3.0.2",
+        "@mdit-vue/types": "^3.0.2",
+        "@types/markdown-it": "^14.1.2",
+        "markdown-it": "^14.1.0",
+        "markdown-it-async": "^2.2.0",
+        "unplugin": "^2.3.10",
+        "unplugin-utils": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "vite": "^2.0.0 || ^3.0.0-0 || ^4.0.0-0 || ^5.0.0-0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.39.tgz",
+      "integrity": "sha512-xmZCYabFGcirU8r0fTuvl/LICc1OU620rnqepaJDL/a141ZigkG7AyaxQLdqJ02ZRYzWe6YPaDHeQx7MfknQfA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.39",
+        "@vue/compiler-sfc": "3.5.39",
+        "@vue/runtime-dom": "3.5.39",
+        "@vue/server-renderer": "3.5.39",
+        "@vue/shared": "3.5.39"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue-router": {
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.6.4.tgz",
+      "integrity": "sha512-Hz9q5sa33Yhduglwz6g9skT8OBPii+4bFn88w6J+J4MfEo4KRRpmiNG/hHHkdbRFlLBOqxN8y8gf2Fb0MTUgVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-api": "^6.6.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/webpack-virtual-modules": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
+      "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
+      "license": "MIT"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}


### PR DESCRIPTION
> **Summary of Changes:**
> 1. **Added RDP Signature Stripping Policy**: Introduced `App.RDP.StripSignatures` policy. When enabled, it dynamically strips the `signscope:s:` and `signature:s:` properties from the RDP contents generated via RDS Broker (in `RegistryUtilities.cs`). This unlocks the local resources checkboxes (Clipboard, Drives, etc.) in the RDP client, allowing users to toggle them freely. Added a UI toggle in `Policies.vue` with EN/TR locales.
> 2. **UI Language Selection**: Added a new setting to the Settings page that allows users to dynamically change the Web UI language.
> 3. **Anonymous Auth UI/UX Fixes**: Hidden the `Settings` and `Docs` links in `NavigationRail.vue` and `Titlebar.vue` for unauthenticated/anonymous users, introduced the `/admin` URL endpoint for administrators to access the management panel, and added route guards in `appRouter.ts` to prevent direct URL access to restricted pages for anonymous sessions.
>
> **⚠️ Note on Language Files (`en.json` & `tr.json`):**
> I currently have another open Pull Request specifically for adding Turkish language support (`tr.json`). The locale files in *this* PR contain both my previous Turkish translations and the new strings required for the `App.RDP.StripSignatures` feature. 
> * If you choose to accept this PR, it will bring the full Turkish translation along with the new feature strings.
> * If you prefer not to merge the new features (RDP signature & Auth UI), you can just merge my previous Language PR, as the locale files there are based on the clean main branch without these new feature strings.
