### PR TITLE
Add animated navigation selection indicator component

### DIFF
--- a/frontend/docs/(development)/custom-content/index.md
+++ b/frontend/docs/(development)/custom-content/index.md
@@ -31,7 +31,7 @@ For example, you could use `index.css` to change the color scheme of the RAWeb i
 To hide the "Docs" button from the navigation bar, you can create an `index.css` file in the `App_Data/inject` folder with the following content:
 
 ```css
-.nav-rail a[href='/docs'] {
+.nav-rail a[data-id='wiki'] {
   display: none;
 }
 ```
@@ -152,14 +152,14 @@ window.addEventListener('RAWebReady', async ({ detail: raweb }) => {
 
 window.addEventListener('RAWebAppMounted', async ({ detail: raweb }) => {
   // Inject a link in the navigation rail
-  const navRailElement = document.querySelector('.nav-rail > nav > ul');
-  if (navRailElement) {
+  const navRailAppsElement = document.querySelector(".nav-rail > nav > ul > li[data-id='apps']");
+  if (navRailAppsElement) {
     const container = document.createElement('li');
     const Component = createFilesAndShortcutsNavRailLinkComponent(raweb);
     const subApp = raweb.vue.createApp(Component);
     subApp.use(raweb.router);
     subApp.mount(container);
-    navRailElement.appendChild(container);
+    navRailAppsElement.after(container);
   }
 });
 
@@ -302,8 +302,9 @@ function createFilesAndShortcutsPageComponent(raweb) {
 }
 
 function createFilesAndShortcutsNavRailLinkComponent(raweb) {
-  const { RailButton, RouterLink } = raweb.components;
+  const { RailButton, RouterLink, AnimatedNavigationItemIndicator } = raweb.components;
   const { h } = raweb.vue;
+  const { useNavigationRailStore } = raweb.stores;
 
   return {
     render() {
@@ -316,53 +317,61 @@ function createFilesAndShortcutsNavRailLinkComponent(raweb) {
 
         ({ href, isActive, navigate }) =>
           h(
-            RailButton,
+            AnimatedNavigationItemIndicator.Selectable,
             {
-              href,
-              active: isActive,
-              onClick: navigate,
+              selected: isActive,
+              indicatorSize: 24,
+              trackHandle: useNavigationRailStore().trackHandle,
             },
-            {
-              icon: () =>
-                h(
-                  'svg',
-                  {
-                    width: '24',
-                    height: '24',
-                    fill: 'none',
-                    viewBox: '0 0 24 24',
-                    xmlns: 'http://www.w3.org/2000/svg',
-                  },
-                  h('path', {
-                    d: 'M12.04 6.017a4.75 4.75 0 1 0 .335-.012h-.01a1.35 1.35 0 0 0-.326.012Zm-1.622 1.835c-.226.677-.368 1.506-.407 2.398h-1.1a3.5 3.5 0 0 1 1.507-2.398Zm-.374 3.898a8.43 8.43 0 0 0 .379 1.91 3.507 3.507 0 0 1-1.405-1.91h1.026Zm3.966 2.1.003-.008c.22-.587.373-1.306.443-2.092h1.276a3.51 3.51 0 0 1-1.722 2.1Zm-1.061-2.1c-.065.618-.187 1.154-.34 1.565-.118.313-.24.514-.336.623a.914.914 0 0 1-.023.025.914.914 0 0 1-.023-.025c-.097-.11-.218-.31-.335-.623-.154-.41-.276-.947-.341-1.565h1.398Zm.039-1.5h-1.476c.042-.828.185-1.547.38-2.065.117-.313.238-.514.335-.623a.79.79 0 0 1 .023-.025.79.79 0 0 1 .023.025c.097.11.218.31.335.623.195.518.338 1.237.38 2.065Zm1.501 0c-.043-.978-.21-1.88-.475-2.588a3.503 3.503 0 0 1 1.825 2.588h-1.35Zm-2.182-2.76-.004.002.004-.003Zm-.113 0 .003.002a.014.014 0 0 0-.004-.003l.001.001Z',
-                    fill: 'currentColor',
-                  }),
-                  h('path', {
-                    d: 'M6.5 2A2.5 2.5 0 0 0 4 4.5v15A2.5 2.5 0 0 0 6.5 22h13.25a.75.75 0 0 0 0-1.5H6.5a1 1 0 0 1-1-1h14.25a.75.75 0 0 0 .75-.75V4.5A2.5 2.5 0 0 0 18 2H6.5ZM19 4.5V18H5.5V4.5a1 1 0 0 1 1-1H18a1 1 0 0 1 1 1Z',
-                    fill: 'currentColor',
-                  })
-                ),
-              'icon-active': () =>
-                h(
-                  'svg',
-                  {
-                    width: '24',
-                    height: '24',
-                    fill: 'none',
-                    viewBox: '0 0 24 24',
-                    xmlns: 'http://www.w3.org/2000/svg',
-                  },
-                  h('path', {
-                    d: 'M12.04 6.017a4.75 4.75 0 1 0 .335-.012h-.01a1.35 1.35 0 0 0-.326.012Zm-1.622 1.835c-.226.677-.368 1.506-.407 2.398h-1.1a3.5 3.5 0 0 1 1.507-2.398Zm-.374 3.898a8.43 8.43 0 0 0 .379 1.91 3.507 3.507 0 0 1-1.405-1.91h1.026Zm3.966 2.1.003-.008c.22-.587.373-1.306.443-2.092h1.276a3.51 3.51 0 0 1-1.722 2.1Zm-1.061-2.1c-.065.618-.187 1.154-.34 1.565-.118.313-.24.514-.336.623a.914.914 0 0 1-.023.025.914.914 0 0 1-.023-.025c-.097-.11-.218-.31-.335-.623-.154-.41-.276-.947-.341-1.565h1.398Zm.039-1.5h-1.476c.042-.828.185-1.547.38-2.065.117-.313.238-.514.335-.623a.79.79 0 0 1 .023-.025.79.79 0 0 1 .023.025c.097.11.218.31.335.623.195.518.338 1.237.38 2.065Zm1.501 0c-.043-.978-.21-1.88-.475-2.588a3.503 3.503 0 0 1 1.825 2.588h-1.35Zm-2.182-2.76-.004.002.004-.003Zm-.113 0 .003.002a.014.014 0 0 0-.004-.003l.001.001Z',
-                    fill: 'currentColor',
-                  }),
-                  h('path', {
-                    d: 'M6.5 2A2.5 2.5 0 0 0 4 4.5v15A2.5 2.5 0 0 0 6.5 22h13.25a.75.75 0 0 0 0-1.5H6.5a1 1 0 0 1-1-1h14.25a.75.75 0 0 0 .75-.75V4.5A2.5 2.5 0 0 0 18 2H6.5ZM19 4.5V18H5.5V4.5a1 1 0 0 1 1-1H18a1 1 0 0 1 1 1Z',
-                    fill: 'currentColor',
-                  })
-                ),
-              default: () => 'Files & shortcuts',
-            }
+            h(
+              RailButton,
+              {
+                href,
+                active: isActive,
+                onClick: navigate,
+              },
+              {
+                icon: () =>
+                  h(
+                    'svg',
+                    {
+                      width: '24',
+                      height: '24',
+                      fill: 'none',
+                      viewBox: '0 0 24 24',
+                      xmlns: 'http://www.w3.org/2000/svg',
+                    },
+                    h('path', {
+                      d: 'M12.04 6.017a4.75 4.75 0 1 0 .335-.012h-.01a1.35 1.35 0 0 0-.326.012Zm-1.622 1.835c-.226.677-.368 1.506-.407 2.398h-1.1a3.5 3.5 0 0 1 1.507-2.398Zm-.374 3.898a8.43 8.43 0 0 0 .379 1.91 3.507 3.507 0 0 1-1.405-1.91h1.026Zm3.966 2.1.003-.008c.22-.587.373-1.306.443-2.092h1.276a3.51 3.51 0 0 1-1.722 2.1Zm-1.061-2.1c-.065.618-.187 1.154-.34 1.565-.118.313-.24.514-.336.623a.914.914 0 0 1-.023.025.914.914 0 0 1-.023-.025c-.097-.11-.218-.31-.335-.623-.154-.41-.276-.947-.341-1.565h1.398Zm.039-1.5h-1.476c.042-.828.185-1.547.38-2.065.117-.313.238-.514.335-.623a.79.79 0 0 1 .023-.025.79.79 0 0 1 .023.025c.097.11.218.31.335.623.195.518.338 1.237.38 2.065Zm1.501 0c-.043-.978-.21-1.88-.475-2.588a3.503 3.503 0 0 1 1.825 2.588h-1.35Zm-2.182-2.76-.004.002.004-.003Zm-.113 0 .003.002a.014.014 0 0 0-.004-.003l.001.001Z',
+                      fill: 'currentColor',
+                    }),
+                    h('path', {
+                      d: 'M6.5 2A2.5 2.5 0 0 0 4 4.5v15A2.5 2.5 0 0 0 6.5 22h13.25a.75.75 0 0 0 0-1.5H6.5a1 1 0 0 1-1-1h14.25a.75.75 0 0 0 .75-.75V4.5A2.5 2.5 0 0 0 18 2H6.5ZM19 4.5V18H5.5V4.5a1 1 0 0 1 1-1H18a1 1 0 0 1 1 1Z',
+                      fill: 'currentColor',
+                    })
+                  ),
+                'icon-active': () =>
+                  h(
+                    'svg',
+                    {
+                      width: '24',
+                      height: '24',
+                      fill: 'none',
+                      viewBox: '0 0 24 24',
+                      xmlns: 'http://www.w3.org/2000/svg',
+                    },
+                    h('path', {
+                      d: 'M12.04 6.017a4.75 4.75 0 1 0 .335-.012h-.01a1.35 1.35 0 0 0-.326.012Zm-1.622 1.835c-.226.677-.368 1.506-.407 2.398h-1.1a3.5 3.5 0 0 1 1.507-2.398Zm-.374 3.898a8.43 8.43 0 0 0 .379 1.91 3.507 3.507 0 0 1-1.405-1.91h1.026Zm3.966 2.1.003-.008c.22-.587.373-1.306.443-2.092h1.276a3.51 3.51 0 0 1-1.722 2.1Zm-1.061-2.1c-.065.618-.187 1.154-.34 1.565-.118.313-.24.514-.336.623a.914.914 0 0 1-.023.025.914.914 0 0 1-.023-.025c-.097-.11-.218-.31-.335-.623-.154-.41-.276-.947-.341-1.565h1.398Zm.039-1.5h-1.476c.042-.828.185-1.547.38-2.065.117-.313.238-.514.335-.623a.79.79 0 0 1 .023-.025.79.79 0 0 1 .023.025c.097.11.218.31.335.623.195.518.338 1.237.38 2.065Zm1.501 0c-.043-.978-.21-1.88-.475-2.588a3.503 3.503 0 0 1 1.825 2.588h-1.35Zm-2.182-2.76-.004.002.004-.003Zm-.113 0 .003.002a.014.014 0 0 0-.004-.003l.001.001Z',
+                      fill: 'currentColor',
+                    }),
+                    h('path', {
+                      d: 'M6.5 2A2.5 2.5 0 0 0 4 4.5v15A2.5 2.5 0 0 0 6.5 22h13.25a.75.75 0 0 0 0-1.5H6.5a1 1 0 0 1-1-1h14.25a.75.75 0 0 0 .75-.75V4.5A2.5 2.5 0 0 0 18 2H6.5ZM19 4.5V18H5.5V4.5a1 1 0 0 1 1-1H18a1 1 0 0 1 1 1Z',
+                      fill: 'currentColor',
+                    })
+                  ),
+                default: () => 'Files & shortcuts',
+              }
+            )
           )
       );
     },

--- a/frontend/lib/components/ListItem/ListItem.vue
+++ b/frontend/lib/components/ListItem/ListItem.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
   import { IconAnimationHandle, registerIconAnimationKey } from '$components/AnimatedIcon/iconAnimation';
+  import { IN_SELECTION_TRACK_KEY } from '$components/Navigation/AnimatedNavigationItemIndicator/keys';
   import TextBlock from '$components/TextBlock/TextBlock.vue';
-  import { computed, provide, useAttrs } from 'vue';
+  import { computed, inject, provide, useAttrs } from 'vue';
 
   const {
     selected = false,
@@ -21,6 +22,10 @@
     popovertarget?: string;
   }>();
   const restProps = useAttrs();
+
+  // when inside an AnimatedNavigationItemIndicator track, the track draws the
+  // selection accent bar, so we suppress this item's own static one
+  const inSelectionTrack = inject(IN_SELECTION_TRACK_KEY, false);
 
   const tagName = computed(() => (popovertarget ? 'button' : href ? 'a' : 'li'));
 
@@ -62,6 +67,7 @@
       selected ? 'selected' : '',
       disabled ? 'disabled' : '',
       compact ? 'compact' : '',
+      inSelectionTrack ? 'in-track' : '',
     ]"
     :href
     :role
@@ -133,6 +139,11 @@
   .list-item.selected::before {
     transform: scaleY(1);
     opacity: 1;
+  }
+
+  /* the surrounding selection track renders the accent bar instead */
+  .list-item.in-track::before {
+    display: none;
   }
 
   .list-item:hover,

--- a/frontend/lib/components/Navigation/AnimatedNavigationItemIndicator/Selectable.vue
+++ b/frontend/lib/components/Navigation/AnimatedNavigationItemIndicator/Selectable.vue
@@ -1,8 +1,12 @@
 <script setup lang="ts">
   import { inject, nextTick, onMounted, onUnmounted, provide, useTemplateRef, watch } from 'vue';
-  import { IN_SELECTION_TRACK_KEY, SELECTION_TRACK_KEY } from './keys';
+  import { IN_SELECTION_TRACK_KEY, SELECTION_TRACK_KEY, type TrackHandle } from './keys';
 
-  const { selected = false, indicatorSize } = defineProps<{
+  const {
+    selected = false,
+    indicatorSize,
+    trackHandle: trackHandleProp,
+  } = defineProps<{
     /** Whether this item is currently the active selection. */
     selected?: boolean;
     /**
@@ -10,9 +14,18 @@
      * main axis.
      */
     indicatorSize?: number;
+    /**
+     * Explicit track handle to use instead of the one obtained via `inject`.
+     *
+     * This is needed when this component is mounted in a separate Vue app instance
+     * (e.g. `App_Data/inject/index.js`), since provide + inject only resolves
+     * within a single app's component tree.
+     */
+    trackHandle?: TrackHandle;
   }>();
 
-  const trackHandle = inject(SELECTION_TRACK_KEY, null);
+  const injectedTrackHandle = inject(SELECTION_TRACK_KEY, null);
+  const trackHandle = trackHandleProp ?? injectedTrackHandle;
   const selectableElementWrapper = useTemplateRef<HTMLElement>('selectableElementWrapper');
 
   function getSelectableElement(): HTMLElement | null {

--- a/frontend/lib/components/Navigation/AnimatedNavigationItemIndicator/Selectable.vue
+++ b/frontend/lib/components/Navigation/AnimatedNavigationItemIndicator/Selectable.vue
@@ -2,11 +2,14 @@
   import { inject, onMounted, onUnmounted, provide, useTemplateRef, watch } from 'vue';
   import { IN_SELECTION_TRACK_KEY, SELECTION_TRACK_KEY } from './keys';
 
-  const { selected = false, indicatorHeight } = defineProps<{
+  const { selected = false, indicatorSize } = defineProps<{
     /** Whether this item is currently the active selection. */
     selected?: boolean;
-    /** Height of the accent line indicator in pixels. */
-    indicatorHeight?: number;
+    /**
+     * Length of the accent line indicator in pixels, measured along the track's
+     * main axis.
+     */
+    indicatorSize?: number;
   }>();
 
   const trackHandle = inject(SELECTION_TRACK_KEY, null);
@@ -22,7 +25,7 @@
     if (element) {
       trackHandle?.register(element);
       if (selected) {
-        trackHandle?.select(element, indicatorHeight);
+        trackHandle?.select(element, indicatorSize);
       }
     }
   });
@@ -43,7 +46,7 @@
       }
 
       if (isSelected) {
-        trackHandle?.select(element, indicatorHeight);
+        trackHandle?.select(element, indicatorSize);
       }
     }
   );

--- a/frontend/lib/components/Navigation/AnimatedNavigationItemIndicator/Selectable.vue
+++ b/frontend/lib/components/Navigation/AnimatedNavigationItemIndicator/Selectable.vue
@@ -1,0 +1,59 @@
+<script setup lang="ts">
+  import { inject, onMounted, onUnmounted, provide, useTemplateRef, watch } from 'vue';
+  import { IN_SELECTION_TRACK_KEY, SELECTION_TRACK_KEY } from './keys';
+
+  const { selected = false, indicatorHeight } = defineProps<{
+    /** Whether this item is currently the active selection. */
+    selected?: boolean;
+    /** Height of the accent line indicator in pixels. */
+    indicatorHeight?: number;
+  }>();
+
+  const trackHandle = inject(SELECTION_TRACK_KEY, null);
+  const selectableElementWrapper = useTemplateRef<HTMLElement>('selectableElementWrapper');
+
+  function getSelectableElement(): HTMLElement | null {
+    // the wrapper is display:contents, so we measure its first real child instead
+    return (selectableElementWrapper.value?.firstElementChild as HTMLElement) ?? null;
+  }
+
+  onMounted(() => {
+    const element = getSelectableElement();
+    if (element) {
+      trackHandle?.register(element);
+      if (selected) {
+        trackHandle?.select(element, indicatorHeight);
+      }
+    }
+  });
+
+  onUnmounted(() => {
+    const element = getSelectableElement();
+    if (element) {
+      trackHandle?.unregister(element);
+    }
+  });
+
+  watch(
+    () => selected,
+    (isSelected) => {
+      const element = getSelectableElement();
+      if (!element) {
+        return;
+      }
+
+      if (isSelected) {
+        trackHandle?.select(element, indicatorHeight);
+      }
+    }
+  );
+
+  // tell descendants (e.g. RailButton) that a track is managing the visual indicator
+  provide(IN_SELECTION_TRACK_KEY, true);
+</script>
+
+<template>
+  <div ref="selectableElementWrapper" style="display: contents">
+    <slot></slot>
+  </div>
+</template>

--- a/frontend/lib/components/Navigation/AnimatedNavigationItemIndicator/Selectable.vue
+++ b/frontend/lib/components/Navigation/AnimatedNavigationItemIndicator/Selectable.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { inject, onMounted, onUnmounted, provide, useTemplateRef, watch } from 'vue';
+  import { inject, nextTick, onMounted, onUnmounted, provide, useTemplateRef, watch } from 'vue';
   import { IN_SELECTION_TRACK_KEY, SELECTION_TRACK_KEY } from './keys';
 
   const { selected = false, indicatorSize } = defineProps<{
@@ -47,6 +47,17 @@
 
       if (isSelected) {
         trackHandle?.select(element, indicatorSize);
+      } else {
+        // Defer the deselect so that any sibling becoming selected in the same
+        // tick calls select() first. If a sibling in this track superseded us,
+        // deselect() is then a no-op; if selection left this track entirely, the
+        // indicator fades out. (See TrackHandle.deselect.)
+        nextTick(() => {
+          const currentElement = getSelectableElement();
+          if (currentElement) {
+            trackHandle?.deselect(currentElement);
+          }
+        });
       }
     }
   );

--- a/frontend/lib/components/Navigation/AnimatedNavigationItemIndicator/SelectionTrack.vue
+++ b/frontend/lib/components/Navigation/AnimatedNavigationItemIndicator/SelectionTrack.vue
@@ -22,7 +22,8 @@
   // catches up slightly later.
   // TODO: Determine the actual easings and durations. These are approximations.
   const fastDuration =
-    window.getComputedStyle(document.documentElement).getPropertyValue('--wui-control-fast-duration') ||
+    ('window' in globalThis &&
+      window.getComputedStyle(document.documentElement).getPropertyValue('--wui-control-fast-duration')) ||
     '167ms';
   const LEAD_DURATION = fastDuration;
   const LEAD_EASING = 'cubic-bezier(0.85, 0, 0.15, 1)';
@@ -424,30 +425,32 @@
     }, TRAIL_DELAY_MS);
   }
 
-  // update the fragment positions whenever the track container resizes
-  // so that the selection indicator is always positioned correctly relative
-  // to the selectable elements
-  const resizeObserver = new ResizeObserver(() => {
-    refreshFragmentPositions();
-    if (selectedElement) {
-      const fragmentDetail = getIndicatorFragmentDetail(selectedElement);
-      if (fragmentDetail) {
-        currentIndicatorMainStart =
-          getStartPos(fragmentDetail) + (getFragmentSize(fragmentDetail) - currentIndicatorMainSize) / 2;
-        forEachIndicatorFragment(selectedElement, (indicatorElement, frag) => {
-          place(indicatorElement, frag, currentIndicatorMainStart, currentIndicatorMainSize);
-        });
+  if ('window' in globalThis) {
+    // update the fragment positions whenever the track container resizes
+    // so that the selection indicator is always positioned correctly relative
+    // to the selectable elements
+    const resizeObserver = new ResizeObserver(() => {
+      refreshFragmentPositions();
+      if (selectedElement) {
+        const fragmentDetail = getIndicatorFragmentDetail(selectedElement);
+        if (fragmentDetail) {
+          currentIndicatorMainStart =
+            getStartPos(fragmentDetail) + (getFragmentSize(fragmentDetail) - currentIndicatorMainSize) / 2;
+          forEachIndicatorFragment(selectedElement, (indicatorElement, frag) => {
+            place(indicatorElement, frag, currentIndicatorMainStart, currentIndicatorMainSize);
+          });
+        }
       }
-    }
-  });
-  onMounted(() => {
-    if (trackEl.value) {
-      resizeObserver.observe(trackEl.value);
-    }
-  });
-  onUnmounted(() => {
-    resizeObserver.disconnect();
-  });
+    });
+    onMounted(() => {
+      if (trackEl.value) {
+        resizeObserver.observe(trackEl.value);
+      }
+    });
+    onUnmounted(() => {
+      resizeObserver.disconnect();
+    });
+  }
 
   /**
    * Clears the selection, but only if the given element is still the selected
@@ -461,7 +464,10 @@
     }
   }
 
-  const getComputedStyle = window.getComputedStyle.bind(window);
+  const getComputedStyle =
+    'window' in globalThis
+      ? window.getComputedStyle.bind(window)
+      : () => ({ borderRadius: '0px' }) as CSSStyleDeclaration;
 
   provide(SELECTION_TRACK_KEY, { register, unregister, select, deselect });
 

--- a/frontend/lib/components/Navigation/AnimatedNavigationItemIndicator/SelectionTrack.vue
+++ b/frontend/lib/components/Navigation/AnimatedNavigationItemIndicator/SelectionTrack.vue
@@ -6,7 +6,7 @@
 
 <script setup lang="ts">
   import { type ComponentPublicInstance, onMounted, onUnmounted, provide, ref, useTemplateRef } from 'vue';
-  import { SELECTION_TRACK_KEY } from './keys';
+  import { SELECTION_TRACK_KEY, TrackHandle } from './keys';
 
   const { orientation = 'vertical' } = defineProps<{
     /**
@@ -464,6 +464,11 @@
   const getComputedStyle = window.getComputedStyle.bind(window);
 
   provide(SELECTION_TRACK_KEY, { register, unregister, select, deselect });
+
+  // exposed so that ancestors can obtain this track's handle via a template ref
+  // (e.g. to hand it to Selectable instances mounted in a separate Vue app, which
+  // can't reach it through provide+inject since that only works within one app tree)
+  defineExpose({ register, unregister, select, deselect } satisfies TrackHandle);
 </script>
 
 <template>

--- a/frontend/lib/components/Navigation/AnimatedNavigationItemIndicator/SelectionTrack.vue
+++ b/frontend/lib/components/Navigation/AnimatedNavigationItemIndicator/SelectionTrack.vue
@@ -452,6 +452,8 @@
     }
   }
 
+  const getComputedStyle = window.getComputedStyle.bind(window);
+
   provide(SELECTION_TRACK_KEY, { register, unregister, select, deselect });
 </script>
 
@@ -467,6 +469,7 @@
         left: `${frag.left}px`,
         width: `${frag.width}px`,
         height: `${frag.height}px`,
+        'border-radius': getComputedStyle(frag.referenceElement).borderRadius || '4px',
       }"
       aria-hidden="true"
     >

--- a/frontend/lib/components/Navigation/AnimatedNavigationItemIndicator/SelectionTrack.vue
+++ b/frontend/lib/components/Navigation/AnimatedNavigationItemIndicator/SelectionTrack.vue
@@ -21,11 +21,14 @@
   // destination. The leading edge jumps ahead quickly, and then the trailing edge
   // catches up slightly later.
   // TODO: Determine the actual easings and durations. These are approximations.
-  const LEAD_MS = 200;
+  const fastDuration =
+    window.getComputedStyle(document.documentElement).getPropertyValue('--wui-control-fast-duration') ||
+    '167ms';
+  const LEAD_DURATION = fastDuration;
   const LEAD_EASING = 'cubic-bezier(0.85, 0, 0.15, 1)';
-  const TRAIL_MS = 200;
+  const TRAIL_DURATION = fastDuration;
   const TRAIL_EASING = 'cubic-bezier(0.24, 1, 0.45, 1)';
-  const TRAIL_DELAY_MS = 200;
+  const TRAIL_DELAY_MS = parseInt(fastDuration.replace('ms', ''), 10);
 
   // for when the indicator is hidden from the track because there is no selected element
   const FADE_TRANSITION = 'opacity var(--wui-control-fast-duration) ease';
@@ -35,7 +38,7 @@
   const mainSizeProperty = isHorizontal ? 'width' : 'height';
 
   interface IndicatorFragmentDetail {
-    el: HTMLElement;
+    referenceElement: HTMLElement;
     id: number;
     top: number;
     left: number;
@@ -111,7 +114,7 @@
     const track = trackEl.value;
     if (!track) return;
     for (const frag of indicatorFragments.value) {
-      Object.assign(frag, measure(frag.el, track));
+      Object.assign(frag, measure(frag.referenceElement, track));
     }
   }
 
@@ -123,7 +126,7 @@
       return undefined;
     }
 
-    return indicatorFragments.value.find(({ el }) => el === element);
+    return indicatorFragments.value.find(({ referenceElement: el }) => el === element);
   }
 
   /**
@@ -145,7 +148,7 @@
    **/
   function whitelistIndicatorFragmentsForSelectableElements(...keep: HTMLElement[]) {
     for (const fragmentDetail of indicatorFragments.value) {
-      if (keep.includes(fragmentDetail.el)) continue;
+      if (keep.includes(fragmentDetail.referenceElement)) continue;
       const indicatorElement = selectableElements.get(fragmentDetail.id);
       if (indicatorElement) {
         indicatorElement.style.transition = FADE_TRANSITION;
@@ -166,7 +169,7 @@
     }
 
     const frag: IndicatorFragmentDetail = {
-      el: element,
+      referenceElement: element,
       id: nextIndicatorFragmentId++, // incrementing id is used to key the fragment in the v-for
       ...measure(element, track),
     };
@@ -178,7 +181,7 @@
    * clearing any selection state.
    */
   function unregister(element: HTMLElement) {
-    const registeredIndex = indicatorFragments.value.findIndex(({ el }) => el === element);
+    const registeredIndex = indicatorFragments.value.findIndex(({ referenceElement: el }) => el === element);
     if (registeredIndex !== -1) {
       const [removed] = indicatorFragments.value.splice(registeredIndex, 1);
       selectableElements.delete(removed.id);
@@ -245,7 +248,7 @@
     place(indicatorElement, fragmentDetail, currentIndicatorMainStart, currentIndicatorMainSize);
     indicatorElement.getBoundingClientRect(); // force reflow
     indicatorElement.style.transition = '';
-    indicatorElement.style.opacity = selectedElement === fragmentDetail.el ? '1' : '0';
+    indicatorElement.style.opacity = selectedElement === fragmentDetail.referenceElement ? '1' : '0';
   }
 
   /**
@@ -263,9 +266,12 @@
     if (trailTimer !== null) {
       clearTimeout(trailTimer);
       trailTimer = null;
-      setTimeout(() => {
-        isAnimating = false;
-      }, TRAIL_MS);
+      setTimeout(
+        () => {
+          isAnimating = false;
+        },
+        parseInt(fastDuration.replace('ms', ''), 10)
+      );
     }
 
     // if the element is null, clear selection and hide all indicator fragments
@@ -383,8 +389,8 @@
     const leadStart = movingForward ? fromStart : toStart;
     const leadSize = movingForward ? toEnd - fromStart : fromEnd - toStart;
     const leadTransition = movingForward
-      ? `${mainSizeProperty} ${LEAD_MS}ms ${LEAD_EASING}`
-      : `${mainPositionProperty} ${LEAD_MS}ms ${LEAD_EASING}, ${mainSizeProperty} ${LEAD_MS}ms ${LEAD_EASING}`;
+      ? `${mainSizeProperty} ${LEAD_DURATION} ${LEAD_EASING}`
+      : `${mainPositionProperty} ${LEAD_DURATION} ${LEAD_EASING}, ${mainSizeProperty} ${LEAD_DURATION} ${LEAD_EASING}`;
 
     for (const element of [fromElement, toElement]) {
       forEachIndicatorFragment(element, (indicatorElement, fragmentDetail) => {
@@ -397,8 +403,8 @@
     // the indicator in its final position on the newly-selected element.
 
     const trailTransition = movingForward
-      ? `${mainPositionProperty} ${TRAIL_MS}ms ${TRAIL_EASING}, ${mainSizeProperty} ${TRAIL_MS}ms ${TRAIL_EASING}`
-      : `${mainSizeProperty} ${TRAIL_MS}ms ${TRAIL_EASING}`;
+      ? `${mainPositionProperty} ${TRAIL_DURATION} ${TRAIL_EASING}, ${mainSizeProperty} ${TRAIL_DURATION} ${TRAIL_EASING}`
+      : `${mainSizeProperty} ${TRAIL_DURATION} ${TRAIL_EASING}`;
 
     trailTimer = setTimeout(() => {
       trailTimer = null;
@@ -409,9 +415,12 @@
         });
       }
 
-      setTimeout(() => {
-        isAnimating = false;
-      }, TRAIL_MS);
+      setTimeout(
+        () => {
+          isAnimating = false;
+        },
+        parseInt(fastDuration.replace('ms', ''), 10)
+      );
     }, TRAIL_DELAY_MS);
   }
 

--- a/frontend/lib/components/Navigation/AnimatedNavigationItemIndicator/SelectionTrack.vue
+++ b/frontend/lib/components/Navigation/AnimatedNavigationItemIndicator/SelectionTrack.vue
@@ -1,0 +1,452 @@
+<script lang="ts">
+  import { defineComponent } from 'vue';
+
+  export default defineComponent({ inheritAttrs: false });
+</script>
+
+<script setup lang="ts">
+  import { type ComponentPublicInstance, onMounted, onUnmounted, provide, ref, useTemplateRef } from 'vue';
+  import { SELECTION_TRACK_KEY } from './keys';
+
+  // The indicator moves in two phases so it appears to visually stretch toward its
+  // destination. The leading edge jumps ahead quickly, and then the trailing edge
+  // catches up slightly later.
+  // TODO: Determine the actual easings and durations. These are approximations.
+  const LEAD_MS = 200;
+  const LEAD_EASING = 'cubic-bezier(0.85, 0, 0.15, 1)';
+  const TRAIL_MS = 200;
+  const TRAIL_EASING = 'cubic-bezier(0.24, 1, 0.45, 1)';
+  const TRAIL_DELAY_MS = 200;
+
+  interface IndicatorFragmentDetail {
+    el: HTMLElement;
+    id: number;
+    top: number;
+    left: number;
+    width: number;
+    height: number;
+  }
+
+  const trackEl = useTemplateRef<HTMLElement>('trackEl');
+
+  /**
+   * The part of the indicator that is loaded into each selectable element.
+   * The indicator is fragmented so that it only renders within the bounds
+   * of the start and end items, never in the gaps or over any items in between.
+   */
+  const indicatorFragments = ref<IndicatorFragmentDetail[]>([]);
+  let nextIndicatorFragmentId = 0;
+
+  /** map of fragment ids and their inner indicator element */
+  const selectableElements = new Map<number, HTMLElement>();
+  /** map of fragment ids and their stable ref callback (see getInnerElRef) */
+  const refCallbacks = new Map<number, (el: Element | ComponentPublicInstance | null) => void>();
+
+  /** The currently-selected selectable element */
+  let selectedElement: HTMLElement | null = null;
+
+  // current logical indicator geometry using coordinates relative to the track
+  // container, used for rendering the indicator fragment for each selectable element.
+  let currentIndicatorPositionTop = 0;
+  let currentIndicatorHeight = 0;
+  let trailTimer: ReturnType<typeof setTimeout> | null = null;
+  let isAnimating = false;
+
+  /**
+   * Measure an element's box relative to the track container.
+   **/
+  function measure(el: HTMLElement, track: HTMLElement) {
+    const trackRect = track.getBoundingClientRect();
+    const elRect = el.getBoundingClientRect();
+    return {
+      top: elRect.top - trackRect.top,
+      left: elRect.left - trackRect.left,
+      width: elRect.width,
+      height: elRect.height,
+    };
+  }
+
+  /**
+   * Position an indicator fragment, converting track coords to fragment-local.
+   **/
+  function place(
+    indicatorElement: HTMLElement,
+    fragmentDetail: IndicatorFragmentDetail,
+    top: number,
+    height: number
+  ) {
+    indicatorElement.style.top = `${top - fragmentDetail.top}px`;
+    indicatorElement.style.height = `${height}px`;
+  }
+
+  function refreshFragmentPositions() {
+    const track = trackEl.value;
+    if (!track) return;
+    for (const frag of indicatorFragments.value) {
+      Object.assign(frag, measure(frag.el, track));
+    }
+  }
+
+  /**
+   * Gets the fragment detail for a given selectable element, if it exists.
+   */
+  function getIndicatorFragmentDetail(element: HTMLElement | null): IndicatorFragmentDetail | undefined {
+    if (!element) {
+      return undefined;
+    }
+
+    return indicatorFragments.value.find(({ el }) => el === element);
+  }
+
+  /**
+   * Run a callback against a specific item's indicator fragment, if it exists.
+   **/
+  function forEachIndicatorFragment(
+    element: HTMLElement | null,
+    fn: (indicatorElement: HTMLElement, frag: IndicatorFragmentDetail) => void
+  ) {
+    const detail = getIndicatorFragmentDetail(element);
+    const indicatorElement = detail && selectableElements.get(detail.id);
+    if (detail && indicatorElement) {
+      fn(indicatorElement, detail);
+    }
+  }
+
+  /**
+   * Hide every indicator fragment except those belonging to the given items.
+   **/
+  function whitelistIndicatorFragmentsForSelectableElements(...keep: HTMLElement[]) {
+    for (const fragmentDetail of indicatorFragments.value) {
+      if (keep.includes(fragmentDetail.el)) continue;
+      const indicatorElement = selectableElements.get(fragmentDetail.id);
+      if (indicatorElement) {
+        indicatorElement.style.opacity = '0';
+      }
+    }
+  }
+
+  /**
+   * Registers an element as a selectable element that can receive an indicator fragment
+   * to indicate active selection. The element must be a child of the track container.
+   */
+  function register(element: HTMLElement) {
+    const track = trackEl.value;
+    if (!track) {
+      console.warn('Cannot register selectable element: track container not found.');
+      return;
+    }
+
+    const frag: IndicatorFragmentDetail = {
+      el: element,
+      id: nextIndicatorFragmentId++, // incrementing id is used to key the fragment in the v-for
+      ...measure(element, track),
+    };
+    indicatorFragments.value.push(frag);
+  }
+
+  /**
+   * Unregisters a selectable element, removing its indicator fragment and
+   * clearing any selection state.
+   */
+  function unregister(element: HTMLElement) {
+    const registeredIndex = indicatorFragments.value.findIndex(({ el }) => el === element);
+    if (registeredIndex !== -1) {
+      const [removed] = indicatorFragments.value.splice(registeredIndex, 1);
+      selectableElements.delete(removed.id);
+      refCallbacks.delete(removed.id);
+    }
+
+    // clear selection if the unregistered element was selected
+    if (selectedElement === element) {
+      select(null);
+    }
+  }
+
+  /**
+   * Returns a cached ref callback for a fragment, keyed by its id.
+   *
+   * The reasoning behind this is a bit complicated:
+   *
+   * Vue calls a ref callback with the element when it mounts and with null when
+   * it unmounts. But if the callback is a different function on each render (e.g.
+   * an inline arrow), Vue also calls the old one with null every render, even
+   * though the element never left the DOM. That false "unmount" would drop the
+   * tracked element and break an in-progress animation.
+   * Reusing one callback per fragment keeps its identity stable, ensuring that the null
+   * call only happens on a real unmount.
+   */
+  function getStableIndicatorFragmentRef(id: number) {
+    let callback = refCallbacks.get(id);
+
+    // if the callback does not already exist, create it and save it to the map
+    if (!callback) {
+      callback = (indicatorElement) => {
+        if (indicatorElement instanceof HTMLElement) {
+          // Vue runs this callback every time it re-renders and updates this
+          // element, not only on mount/unmount. Only sync when we're handed a
+          // different node than before; otherwise, a re-render mid-animation (e.g.
+          // a route navigation) would clobber the in-progress transition by
+          // snapping to the final position.
+          const isNewElement = selectableElements.get(id) !== indicatorElement;
+          selectableElements.set(id, indicatorElement);
+          if (isNewElement) {
+            syncIndicatorFragmentElement(id);
+          }
+        } else {
+          selectableElements.delete(id);
+        }
+      };
+      refCallbacks.set(id, callback);
+    }
+
+    return callback;
+  }
+
+  /**
+   * Syncs a freshly-mounted indicator fragment to the current selection state.
+   **/
+  function syncIndicatorFragmentElement(id: number) {
+    const fragmentDetail = indicatorFragments.value.find((f) => f.id === id);
+    const indicatorElement = selectableElements.get(id);
+    if (!fragmentDetail || !indicatorElement) {
+      return;
+    }
+
+    indicatorElement.style.transition = 'none';
+    place(indicatorElement, fragmentDetail, currentIndicatorPositionTop, currentIndicatorHeight);
+    indicatorElement.getBoundingClientRect(); // force reflow
+    indicatorElement.style.transition = '';
+    indicatorElement.style.opacity = selectedElement === fragmentDetail.el ? '1' : '0';
+  }
+
+  /**
+   * Triggers the selection indicator to move to the given element.
+   *
+   * The element must be a registered selectable element that is a child
+   * of the track container.
+   */
+  function select(el: HTMLElement | null, indicatorHeight?: number) {
+    // cancel any in-progress trailing edge animation so we can start a new one
+    if (trailTimer !== null) {
+      clearTimeout(trailTimer);
+      trailTimer = null;
+      setTimeout(() => {
+        isAnimating = false;
+      }, TRAIL_MS);
+    }
+
+    // if the element is null, clear selection and hide all indicator fragments
+    if (el === null) {
+      whitelistIndicatorFragmentsForSelectableElements();
+      selectedElement = null;
+      return;
+    }
+
+    // require the element to be a registered selectable element
+    const fragmentDetail = getIndicatorFragmentDetail(el);
+    if (!fragmentDetail) {
+      console.warn('Cannot select element: not a registered selectable element.', el);
+      return;
+    }
+
+    refreshFragmentPositions();
+
+    const track = trackEl.value;
+    if (!track) {
+      return;
+    }
+
+    const lineHeight = indicatorHeight ?? fragmentDetail.height;
+    const nextTop = fragmentDetail.top + (fragmentDetail.height - lineHeight) / 2;
+
+    const fromElement = selectedElement;
+    const fromTop = currentIndicatorPositionTop;
+    const fromHeight = currentIndicatorHeight;
+
+    selectedElement = el;
+    currentIndicatorPositionTop = nextTop;
+    currentIndicatorHeight = lineHeight;
+
+    // if there is an animation already in progress, cancel that animation
+    // and snap to the current position instead of changing the animation
+    // (matches WinUI 3 behavior)
+    if (isAnimating) {
+      snapTo(el, nextTop, lineHeight);
+    }
+
+    // if there is no previous selection, snap to the new position with no animation
+    else if (!fromElement) {
+      snapTo(el, nextTop, lineHeight);
+    }
+
+    // if there is a previous selection, animate the indicator
+    // from the previous position to the new position
+    else {
+      stretchBetween(fromElement, el, fromTop, fromHeight, nextTop, lineHeight);
+    }
+  }
+
+  /**
+   * Place the indicator on a single item with no animation (first selection).
+   **/
+  function snapTo(el: HTMLElement, top: number, height: number) {
+    whitelistIndicatorFragmentsForSelectableElements(el);
+    forEachIndicatorFragment(el, (indicatorElement, fragmentDetail) => {
+      indicatorElement.style.transition = 'none';
+      place(indicatorElement, fragmentDetail, top, height);
+      indicatorElement.getBoundingClientRect(); // force reflow
+      indicatorElement.style.transition = '';
+      indicatorElement.style.opacity = '1';
+    });
+  }
+
+  /**
+   * Animate the indicator from one item to another. The indicator only ever
+   * renders within the start and end elements.
+   *
+   * A tall bar is drawn spanning this distance between both elements, but
+   * each element's indicator fragment reveals only its own portion, causing the middle
+   * (gaps and any items in between) to stay empty.
+   */
+  function stretchBetween(
+    fromElement: HTMLElement,
+    toElement: HTMLElement,
+    fromTop: number,
+    fromHeight: number,
+    toTop: number,
+    toHeight: number
+  ) {
+    const movingDown = toTop > fromTop;
+    const fromBottom = fromTop + fromHeight;
+    const toBottom = toTop + toHeight;
+
+    if (!trackEl.value) {
+      return;
+    }
+
+    whitelistIndicatorFragmentsForSelectableElements(fromElement, toElement);
+
+    // Phase 0. Snap both indicator fragments to their current positions
+    // before starting the animation. This ensures that the animation starts from
+    // the correct position even if the previous animation was interrupted.
+    for (const element of [fromElement, toElement]) {
+      forEachIndicatorFragment(element, (indicatorElement, fragmentDetail) => {
+        indicatorElement.style.transition = 'none';
+        indicatorElement.style.opacity = '1';
+        place(indicatorElement, fragmentDetail, fromTop, fromHeight);
+        indicatorElement.getBoundingClientRect(); // force reflow so the reset tak1es effect
+      });
+    }
+
+    // Phase 1. The leading edge of the selection indicator expands toward
+    // the destination, drawing a bar that spans from the trailing edge all
+    // the way to the new leading edge.
+
+    isAnimating = true;
+
+    const leadTop = movingDown ? fromTop : toTop;
+    const leadHeight = movingDown ? toBottom - fromTop : fromBottom - toTop;
+    const leadTransition = movingDown
+      ? `height ${LEAD_MS}ms ${LEAD_EASING}`
+      : `top ${LEAD_MS}ms ${LEAD_EASING}, height ${LEAD_MS}ms ${LEAD_EASING}`;
+
+    for (const element of [fromElement, toElement]) {
+      forEachIndicatorFragment(element, (indicatorElement, fragmentDetail) => {
+        indicatorElement.style.transition = leadTransition;
+        place(indicatorElement, fragmentDetail, leadTop, leadHeight);
+      });
+    }
+
+    // Phase 2. The trailing edge catches up after a short delay, leaving
+    // the indicator in its final position on the newly-selected element.
+
+    const trailTransition = movingDown
+      ? `top ${TRAIL_MS}ms ${TRAIL_EASING}, height ${TRAIL_MS}ms ${TRAIL_EASING}`
+      : `height ${TRAIL_MS}ms ${TRAIL_EASING}`;
+
+    trailTimer = setTimeout(() => {
+      trailTimer = null;
+      for (const element of [fromElement, toElement]) {
+        forEachIndicatorFragment(element, (indicatorElement, fragmentDetail) => {
+          indicatorElement.style.transition = trailTransition;
+          place(indicatorElement, fragmentDetail, toTop, toHeight);
+        });
+      }
+
+      setTimeout(() => {
+        isAnimating = false;
+      }, TRAIL_MS);
+    }, TRAIL_DELAY_MS);
+  }
+
+  // update the fragment positions whenever the track container resizes
+  // so that the selection indicator is always positioned correctly relative
+  // to the selectable elements
+  const resizeObserver = new ResizeObserver(() => {
+    refreshFragmentPositions();
+    if (selectedElement) {
+      const fragmentDetail = getIndicatorFragmentDetail(selectedElement);
+      if (fragmentDetail) {
+        currentIndicatorPositionTop = fragmentDetail.top + (fragmentDetail.height - currentIndicatorHeight) / 2;
+        forEachIndicatorFragment(selectedElement, (indicatorElement, frag) => {
+          place(indicatorElement, frag, currentIndicatorPositionTop, currentIndicatorHeight);
+        });
+      }
+    }
+  });
+  onMounted(() => {
+    if (trackEl.value) {
+      resizeObserver.observe(trackEl.value);
+    }
+  });
+  onUnmounted(() => {
+    resizeObserver.disconnect();
+  });
+
+  provide(SELECTION_TRACK_KEY, { register, unregister, select });
+</script>
+
+<template>
+  <div class="track" v-bind="$attrs" ref="trackEl">
+    <slot></slot>
+    <div
+      v-for="frag in indicatorFragments"
+      :key="frag.id"
+      class="clip-fragment"
+      :style="{
+        top: `${frag.top}px`,
+        left: `${frag.left}px`,
+        width: `${frag.width}px`,
+        height: `${frag.height}px`,
+      }"
+      aria-hidden="true"
+    >
+      <div :ref="getStableIndicatorFragmentRef(frag.id)" class="indicator"></div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+  .track {
+    position: relative;
+  }
+
+  .clip-fragment {
+    position: absolute;
+    overflow: hidden;
+    pointer-events: none;
+    z-index: 2;
+  }
+
+  .indicator {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 3px;
+    height: 0;
+    background-color: var(--wui-accent-default);
+    border-radius: var(--wui-control-corner-radius);
+    opacity: 0;
+    transition: opacity var(--wui-control-fast-duration) ease;
+  }
+</style>

--- a/frontend/lib/components/Navigation/AnimatedNavigationItemIndicator/SelectionTrack.vue
+++ b/frontend/lib/components/Navigation/AnimatedNavigationItemIndicator/SelectionTrack.vue
@@ -8,6 +8,15 @@
   import { type ComponentPublicInstance, onMounted, onUnmounted, provide, ref, useTemplateRef } from 'vue';
   import { SELECTION_TRACK_KEY } from './keys';
 
+  const { orientation = 'vertical' } = defineProps<{
+    /**
+     * The axis upon which the selectable items are positoned and on which the indicator
+     * travels. 'vertical' draws an accent bar on the leading (left) edge of the
+     * item; 'horizontal' draws an underline along its bottom edge.
+     */
+    orientation?: 'vertical' | 'horizontal';
+  }>();
+
   // The indicator moves in two phases so it appears to visually stretch toward its
   // destination. The leading edge jumps ahead quickly, and then the trailing edge
   // catches up slightly later.
@@ -17,6 +26,10 @@
   const TRAIL_MS = 200;
   const TRAIL_EASING = 'cubic-bezier(0.24, 1, 0.45, 1)';
   const TRAIL_DELAY_MS = 200;
+
+  const isHorizontal = orientation === 'horizontal';
+  const mainPositionProperty = isHorizontal ? 'left' : 'top';
+  const mainSizeProperty = isHorizontal ? 'width' : 'height';
 
   interface IndicatorFragmentDetail {
     el: HTMLElement;
@@ -45,10 +58,11 @@
   /** The currently-selected selectable element */
   let selectedElement: HTMLElement | null = null;
 
-  // current logical indicator geometry using coordinates relative to the track
-  // container, used for rendering the indicator fragment for each selectable element.
-  let currentIndicatorPositionTop = 0;
-  let currentIndicatorHeight = 0;
+  // current logical indicator geometry along the main axis, in coordinates
+  // relative to the track container, used for rendering the indicator fragment
+  // for each selectable element.
+  let currentIndicatorMainStart = 0;
+  let currentIndicatorMainSize = 0;
   let trailTimer: ReturnType<typeof setTimeout> | null = null;
   let isAnimating = false;
 
@@ -66,17 +80,28 @@
     };
   }
 
+  /** Gets the the main-axis start (top for vertical, left for horizontal) of a fragment. */
+  function getStartPos(fragmentDetail: IndicatorFragmentDetail) {
+    return isHorizontal ? fragmentDetail.left : fragmentDetail.top;
+  }
+
+  /** Gets the main-axis size (height for vertical, width for horizontal) of a fragment. */
+  function getFragmentSize(fragmentDetail: IndicatorFragmentDetail) {
+    return isHorizontal ? fragmentDetail.width : fragmentDetail.height;
+  }
+
   /**
-   * Position an indicator fragment, converting track coords to fragment-local.
+   * Position an indicator fragment along the main axis, converting track coords
+   * to fragment-local. The cross-axis placement (thickness/edge) is handled by CSS.
    **/
   function place(
     indicatorElement: HTMLElement,
     fragmentDetail: IndicatorFragmentDetail,
-    top: number,
-    height: number
+    start: number,
+    size: number
   ) {
-    indicatorElement.style.top = `${top - fragmentDetail.top}px`;
-    indicatorElement.style.height = `${height}px`;
+    indicatorElement.style.setProperty(mainPositionProperty, `${start - getStartPos(fragmentDetail)}px`);
+    indicatorElement.style.setProperty(mainSizeProperty, `${size}px`);
   }
 
   function refreshFragmentPositions() {
@@ -213,7 +238,7 @@
     }
 
     indicatorElement.style.transition = 'none';
-    place(indicatorElement, fragmentDetail, currentIndicatorPositionTop, currentIndicatorHeight);
+    place(indicatorElement, fragmentDetail, currentIndicatorMainStart, currentIndicatorMainSize);
     indicatorElement.getBoundingClientRect(); // force reflow
     indicatorElement.style.transition = '';
     indicatorElement.style.opacity = selectedElement === fragmentDetail.el ? '1' : '0';
@@ -224,8 +249,12 @@
    *
    * The element must be a registered selectable element that is a child
    * of the track container.
+   *
+   * `indicatorSize` is the length of the accent line along the main axis (its
+   * height when vertical and its width when horizontal). This defaults to the full
+   * main-axis size of the item.
    */
-  function select(el: HTMLElement | null, indicatorHeight?: number) {
+  function select(el: HTMLElement | null, indicatorSize?: number) {
     // cancel any in-progress trailing edge animation so we can start a new one
     if (trailTimer !== null) {
       clearTimeout(trailTimer);
@@ -256,44 +285,44 @@
       return;
     }
 
-    const lineHeight = indicatorHeight ?? fragmentDetail.height;
-    const nextTop = fragmentDetail.top + (fragmentDetail.height - lineHeight) / 2;
+    const lineSize = indicatorSize ?? getFragmentSize(fragmentDetail);
+    const nextStart = getStartPos(fragmentDetail) + (getFragmentSize(fragmentDetail) - lineSize) / 2;
 
     const fromElement = selectedElement;
-    const fromTop = currentIndicatorPositionTop;
-    const fromHeight = currentIndicatorHeight;
+    const fromStart = currentIndicatorMainStart;
+    const fromSize = currentIndicatorMainSize;
 
     selectedElement = el;
-    currentIndicatorPositionTop = nextTop;
-    currentIndicatorHeight = lineHeight;
+    currentIndicatorMainStart = nextStart;
+    currentIndicatorMainSize = lineSize;
 
     // if there is an animation already in progress, cancel that animation
     // and snap to the current position instead of changing the animation
     // (matches WinUI 3 behavior)
     if (isAnimating) {
-      snapTo(el, nextTop, lineHeight);
+      snapTo(el, nextStart, lineSize);
     }
 
     // if there is no previous selection, snap to the new position with no animation
     else if (!fromElement) {
-      snapTo(el, nextTop, lineHeight);
+      snapTo(el, nextStart, lineSize);
     }
 
     // if there is a previous selection, animate the indicator
     // from the previous position to the new position
     else {
-      stretchBetween(fromElement, el, fromTop, fromHeight, nextTop, lineHeight);
+      stretchBetween(fromElement, el, fromStart, fromSize, nextStart, lineSize);
     }
   }
 
   /**
    * Place the indicator on a single item with no animation (first selection).
    **/
-  function snapTo(el: HTMLElement, top: number, height: number) {
+  function snapTo(el: HTMLElement, start: number, size: number) {
     whitelistIndicatorFragmentsForSelectableElements(el);
     forEachIndicatorFragment(el, (indicatorElement, fragmentDetail) => {
       indicatorElement.style.transition = 'none';
-      place(indicatorElement, fragmentDetail, top, height);
+      place(indicatorElement, fragmentDetail, start, size);
       indicatorElement.getBoundingClientRect(); // force reflow
       indicatorElement.style.transition = '';
       indicatorElement.style.opacity = '1';
@@ -304,21 +333,21 @@
    * Animate the indicator from one item to another. The indicator only ever
    * renders within the start and end elements.
    *
-   * A tall bar is drawn spanning this distance between both elements, but
+   * A long bar is drawn spanning the distance between both elements, but
    * each element's indicator fragment reveals only its own portion, causing the middle
    * (gaps and any items in between) to stay empty.
    */
   function stretchBetween(
     fromElement: HTMLElement,
     toElement: HTMLElement,
-    fromTop: number,
-    fromHeight: number,
-    toTop: number,
-    toHeight: number
+    fromStart: number,
+    fromSize: number,
+    toStart: number,
+    toSize: number
   ) {
-    const movingDown = toTop > fromTop;
-    const fromBottom = fromTop + fromHeight;
-    const toBottom = toTop + toHeight;
+    const movingForward = toStart > fromStart;
+    const fromEnd = fromStart + fromSize;
+    const toEnd = toStart + toSize;
 
     if (!trackEl.value) {
       return;
@@ -333,8 +362,8 @@
       forEachIndicatorFragment(element, (indicatorElement, fragmentDetail) => {
         indicatorElement.style.transition = 'none';
         indicatorElement.style.opacity = '1';
-        place(indicatorElement, fragmentDetail, fromTop, fromHeight);
-        indicatorElement.getBoundingClientRect(); // force reflow so the reset tak1es effect
+        place(indicatorElement, fragmentDetail, fromStart, fromSize);
+        indicatorElement.getBoundingClientRect(); // force reflow so the reset takes effect
       });
     }
 
@@ -344,32 +373,32 @@
 
     isAnimating = true;
 
-    const leadTop = movingDown ? fromTop : toTop;
-    const leadHeight = movingDown ? toBottom - fromTop : fromBottom - toTop;
-    const leadTransition = movingDown
-      ? `height ${LEAD_MS}ms ${LEAD_EASING}`
-      : `top ${LEAD_MS}ms ${LEAD_EASING}, height ${LEAD_MS}ms ${LEAD_EASING}`;
+    const leadStart = movingForward ? fromStart : toStart;
+    const leadSize = movingForward ? toEnd - fromStart : fromEnd - toStart;
+    const leadTransition = movingForward
+      ? `${mainSizeProperty} ${LEAD_MS}ms ${LEAD_EASING}`
+      : `${mainPositionProperty} ${LEAD_MS}ms ${LEAD_EASING}, ${mainSizeProperty} ${LEAD_MS}ms ${LEAD_EASING}`;
 
     for (const element of [fromElement, toElement]) {
       forEachIndicatorFragment(element, (indicatorElement, fragmentDetail) => {
         indicatorElement.style.transition = leadTransition;
-        place(indicatorElement, fragmentDetail, leadTop, leadHeight);
+        place(indicatorElement, fragmentDetail, leadStart, leadSize);
       });
     }
 
     // Phase 2. The trailing edge catches up after a short delay, leaving
     // the indicator in its final position on the newly-selected element.
 
-    const trailTransition = movingDown
-      ? `top ${TRAIL_MS}ms ${TRAIL_EASING}, height ${TRAIL_MS}ms ${TRAIL_EASING}`
-      : `height ${TRAIL_MS}ms ${TRAIL_EASING}`;
+    const trailTransition = movingForward
+      ? `${mainPositionProperty} ${TRAIL_MS}ms ${TRAIL_EASING}, ${mainSizeProperty} ${TRAIL_MS}ms ${TRAIL_EASING}`
+      : `${mainSizeProperty} ${TRAIL_MS}ms ${TRAIL_EASING}`;
 
     trailTimer = setTimeout(() => {
       trailTimer = null;
       for (const element of [fromElement, toElement]) {
         forEachIndicatorFragment(element, (indicatorElement, fragmentDetail) => {
           indicatorElement.style.transition = trailTransition;
-          place(indicatorElement, fragmentDetail, toTop, toHeight);
+          place(indicatorElement, fragmentDetail, toStart, toSize);
         });
       }
 
@@ -387,9 +416,10 @@
     if (selectedElement) {
       const fragmentDetail = getIndicatorFragmentDetail(selectedElement);
       if (fragmentDetail) {
-        currentIndicatorPositionTop = fragmentDetail.top + (fragmentDetail.height - currentIndicatorHeight) / 2;
+        currentIndicatorMainStart =
+          getStartPos(fragmentDetail) + (getFragmentSize(fragmentDetail) - currentIndicatorMainSize) / 2;
         forEachIndicatorFragment(selectedElement, (indicatorElement, frag) => {
-          place(indicatorElement, frag, currentIndicatorPositionTop, currentIndicatorHeight);
+          place(indicatorElement, frag, currentIndicatorMainStart, currentIndicatorMainSize);
         });
       }
     }
@@ -407,7 +437,7 @@
 </script>
 
 <template>
-  <div class="track" v-bind="$attrs" ref="trackEl">
+  <div class="track" :class="{ horizontal: isHorizontal }" v-bind="$attrs" ref="trackEl">
     <slot></slot>
     <div
       v-for="frag in indicatorFragments"
@@ -448,5 +478,14 @@
     border-radius: var(--wui-control-corner-radius);
     opacity: 0;
     transition: opacity var(--wui-control-fast-duration) ease;
+  }
+
+  /* horizontal: the accent line becomes an underline along the bottom edge */
+  .track.horizontal .indicator {
+    top: auto;
+    bottom: 2px;
+    left: 0;
+    width: 0;
+    height: 3px;
   }
 </style>

--- a/frontend/lib/components/Navigation/AnimatedNavigationItemIndicator/SelectionTrack.vue
+++ b/frontend/lib/components/Navigation/AnimatedNavigationItemIndicator/SelectionTrack.vue
@@ -300,15 +300,18 @@
     currentIndicatorMainStart = nextStart;
     currentIndicatorMainSize = lineSize;
 
-    // if there is an animation already in progress, cancel that animation
-    // and snap to the current position instead of changing the animation
-    // (matches WinUI 3 behavior)
-    if (isAnimating) {
-      snapTo(el, nextStart, lineSize);
-    }
+    const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    const shouldSnap =
+      // do not animate if the user prefers reduced motion
+      prefersReducedMotion ||
+      // if there is an animation already in progress, cancel that animation
+      // and snap to the current position instead of changing the animation
+      // (matches WinUI 3 behavior)
+      isAnimating ||
+      // if there is no previous selection, snap to the new position with no animation
+      !fromElement;
 
-    // if there is no previous selection, snap to the new position with no animation
-    else if (!fromElement) {
+    if (shouldSnap) {
       snapTo(el, nextStart, lineSize);
     }
 

--- a/frontend/lib/components/Navigation/AnimatedNavigationItemIndicator/SelectionTrack.vue
+++ b/frontend/lib/components/Navigation/AnimatedNavigationItemIndicator/SelectionTrack.vue
@@ -27,6 +27,9 @@
   const TRAIL_EASING = 'cubic-bezier(0.24, 1, 0.45, 1)';
   const TRAIL_DELAY_MS = 200;
 
+  // for when the indicator is hidden from the track because there is no selected element
+  const FADE_TRANSITION = 'opacity var(--wui-control-fast-duration) ease';
+
   const isHorizontal = orientation === 'horizontal';
   const mainPositionProperty = isHorizontal ? 'left' : 'top';
   const mainSizeProperty = isHorizontal ? 'width' : 'height';
@@ -145,6 +148,7 @@
       if (keep.includes(fragmentDetail.el)) continue;
       const indicatorElement = selectableElements.get(fragmentDetail.id);
       if (indicatorElement) {
+        indicatorElement.style.transition = FADE_TRANSITION;
         indicatorElement.style.opacity = '0';
       }
     }
@@ -433,7 +437,19 @@
     resizeObserver.disconnect();
   });
 
-  provide(SELECTION_TRACK_KEY, { register, unregister, select });
+  /**
+   * Clears the selection, but only if the given element is still the selected
+   * one. A deselected item calls this so that when selection moves to another
+   * track the old indicator fades out, while a move between siblings in this
+   * track (which has already updated the selection) is left untouched.
+   */
+  function deselect(element: HTMLElement) {
+    if (selectedElement === element) {
+      select(null);
+    }
+  }
+
+  provide(SELECTION_TRACK_KEY, { register, unregister, select, deselect });
 </script>
 
 <template>
@@ -470,7 +486,8 @@
 
   .indicator {
     position: absolute;
-    left: 0;
+    /* cross-axis offset lets consumers indent the bar (e.g. nested tree items) */
+    left: var(--indicator-cross-offset, 0);
     top: 0;
     width: 3px;
     height: 0;

--- a/frontend/lib/components/Navigation/AnimatedNavigationItemIndicator/index.mjs
+++ b/frontend/lib/components/Navigation/AnimatedNavigationItemIndicator/index.mjs
@@ -1,6 +1,6 @@
 import Selectable from './Selectable.vue';
 import Track from './SelectionTrack.vue';
-import * as keys from './keys';
+import * as keys from './keys.ts';
 
 export const AnimatedNavigationItemIndicator = {
   ...keys,

--- a/frontend/lib/components/Navigation/AnimatedNavigationItemIndicator/index.ts
+++ b/frontend/lib/components/Navigation/AnimatedNavigationItemIndicator/index.ts
@@ -1,0 +1,9 @@
+import Selectable from './Selectable.vue';
+import Track from './SelectionTrack.vue';
+import * as keys from './keys';
+
+export const AnimatedNavigationItemIndicator = {
+  ...keys,
+  Track,
+  Selectable,
+};

--- a/frontend/lib/components/Navigation/AnimatedNavigationItemIndicator/keys.ts
+++ b/frontend/lib/components/Navigation/AnimatedNavigationItemIndicator/keys.ts
@@ -1,6 +1,6 @@
 import type { InjectionKey } from 'vue';
 
-interface TrackHandle {
+export interface TrackHandle {
   register: (el: HTMLElement) => void;
   unregister: (el: HTMLElement) => void;
   /**

--- a/frontend/lib/components/Navigation/AnimatedNavigationItemIndicator/keys.ts
+++ b/frontend/lib/components/Navigation/AnimatedNavigationItemIndicator/keys.ts
@@ -1,0 +1,22 @@
+import type { InjectionKey } from 'vue';
+
+interface TrackHandle {
+  register: (el: HTMLElement) => void;
+  unregister: (el: HTMLElement) => void;
+  select: (el: HTMLElement | null, indicatorHeight?: number) => void;
+}
+
+export const SELECTION_TRACK_KEY: InjectionKey<TrackHandle> = Symbol('selection-track');
+
+/**
+ * Provided by Selectable to its descendants so they can suppress their own
+ * active-state visuals (background, accent bar) in favor of the track indicator.
+ *
+ * @example Usage in a descendant component
+ * ```
+ * import { inject } from 'vue';
+ *
+ * const isInSelectionTrack = inject(IN_SELECTION_TRACK_KEY, false);
+ * ```
+ */
+export const IN_SELECTION_TRACK_KEY: InjectionKey<true> = Symbol('in-selection-track');

--- a/frontend/lib/components/Navigation/AnimatedNavigationItemIndicator/keys.ts
+++ b/frontend/lib/components/Navigation/AnimatedNavigationItemIndicator/keys.ts
@@ -8,6 +8,12 @@ interface TrackHandle {
    * axis (its height when vertical and its width when horizontal).
    */
   select: (el: HTMLElement | null, indicatorSize?: number) => void;
+  /**
+   * Clears the selection if (and only if) `el` is still the selected element.
+   * Used so an item can fade its indicator out when selection leaves this track
+   * without clobbering a sibling that has since become selected.
+   */
+  deselect: (el: HTMLElement) => void;
 }
 
 export const SELECTION_TRACK_KEY: InjectionKey<TrackHandle> = Symbol('selection-track');

--- a/frontend/lib/components/Navigation/AnimatedNavigationItemIndicator/keys.ts
+++ b/frontend/lib/components/Navigation/AnimatedNavigationItemIndicator/keys.ts
@@ -3,7 +3,11 @@ import type { InjectionKey } from 'vue';
 interface TrackHandle {
   register: (el: HTMLElement) => void;
   unregister: (el: HTMLElement) => void;
-  select: (el: HTMLElement | null, indicatorHeight?: number) => void;
+  /**
+   * `indicatorSize` is the length of the accent line along the track's main
+   * axis (its height when vertical and its width when horizontal).
+   */
+  select: (el: HTMLElement | null, indicatorSize?: number) => void;
 }
 
 export const SELECTION_TRACK_KEY: InjectionKey<TrackHandle> = Symbol('selection-track');

--- a/frontend/lib/components/Navigation/NavigationRail.vue
+++ b/frontend/lib/components/Navigation/NavigationRail.vue
@@ -8,7 +8,7 @@
   } from '$components';
   import RailButton from '$components/Navigation/RailButton.vue';
   import { BulkImportDialog, ManagedResourceCreateDiscoveryDialog, showConfirm } from '$dialogs';
-  import { useCoreDataStore } from '$stores';
+  import { useCoreDataStore, useNavigationRailStore } from '$stores';
   import {
     favoritesEnabled,
     openHelpPopup,
@@ -18,12 +18,21 @@
   } from '$utils';
   import { useTranslation } from 'i18next-vue';
   import { storeToRefs } from 'pinia';
+  import { onMounted, useTemplateRef } from 'vue';
   import { useRouter } from 'vue-router';
 
   const { docsUrl } = useCoreDataStore();
   const { authUser, needsSignInAgain, capabilities } = storeToRefs(useCoreDataStore());
   const { t } = useTranslation();
   const router = useRouter();
+
+  // publish this rail's track handle so App_Data/inject/index.js nav items
+  // can still register with it
+  const trackRef = useTemplateRef('track');
+  const navigationRailStore = useNavigationRailStore();
+  onMounted(() => {
+    navigationRailStore.trackHandle = trackRef.value;
+  });
 
   // TODO [Anchors]: Remove this when all major browsers support CSS Anchor Positioning
   const supportsAnchorPositions = CSS.supports('position-area', 'center center');
@@ -54,6 +63,7 @@
 
 <template>
   <AnimatedNavigationItemIndicator.Track
+    ref="track"
     class="nav-rail nav-rail-flex"
     :class="{ hidden }"
     :aria-hidden="hidden"

--- a/frontend/lib/components/Navigation/NavigationRail.vue
+++ b/frontend/lib/components/Navigation/NavigationRail.vue
@@ -59,7 +59,7 @@
         <!-- Favorites -->
         <li v-if="favoritesEnabled && supportsAnchorPositions">
           <RouterLink to="/favorites" custom v-slot="{ href, isActive, navigate }">
-            <AnimatedNavigationItemIndicator.Selectable :selected="isActive" :indicatorHeight="24">
+            <AnimatedNavigationItemIndicator.Selectable :selected="isActive" :indicatorSize="24">
               <RailButton :href="href" :active="isActive" @click="navigate">
                 <template v-slot:icon>
                   <svg
@@ -98,7 +98,7 @@
         <!-- Devices -->
         <li>
           <RouterLink to="/devices" custom v-slot="{ href, isActive, navigate }">
-            <AnimatedNavigationItemIndicator.Selectable :selected="isActive" :indicatorHeight="24">
+            <AnimatedNavigationItemIndicator.Selectable :selected="isActive" :indicatorSize="24">
               <RailButton :href="href" :active="isActive" @click="navigate">
                 <template v-slot:icon>
                   <svg
@@ -137,7 +137,7 @@
         <!-- Apps -->
         <li>
           <RouterLink to="/apps" custom v-slot="{ href, isActive, navigate }">
-            <AnimatedNavigationItemIndicator.Selectable :selected="isActive" :indicatorHeight="24">
+            <AnimatedNavigationItemIndicator.Selectable :selected="isActive" :indicatorSize="24">
               <RailButton :href="href" :active="isActive" @click="navigate">
                 <template v-slot:icon>
                   <svg
@@ -382,7 +382,7 @@
     <div class="bottom">
       <!-- Settings -->
       <RouterLink to="/settings" custom v-slot="{ href, isActive, navigate }">
-        <AnimatedNavigationItemIndicator.Selectable :selected="isActive" :indicatorHeight="24">
+        <AnimatedNavigationItemIndicator.Selectable :selected="isActive" :indicatorSize="24">
           <RailButton :href="href" :active="isActive" @click="navigate">
             <template v-slot:icon>
               <AnimatedIcon.Settings :filled="isActive" />

--- a/frontend/lib/components/Navigation/NavigationRail.vue
+++ b/frontend/lib/components/Navigation/NavigationRail.vue
@@ -1,6 +1,11 @@
 <script setup lang="ts">
-  import { AnimatedIcon, MenuFlyout, MenuFlyoutDivider, MenuFlyoutItem } from '$components';
-  import { AnimatedNavigationItemIndicator } from '$components/Navigation/AnimatedNavigationItemIndicator';
+  import {
+    AnimatedIcon,
+    AnimatedNavigationItemIndicator,
+    MenuFlyout,
+    MenuFlyoutDivider,
+    MenuFlyoutItem,
+  } from '$components';
   import RailButton from '$components/Navigation/RailButton.vue';
   import { BulkImportDialog, ManagedResourceCreateDiscoveryDialog, showConfirm } from '$dialogs';
   import { useCoreDataStore } from '$stores';
@@ -57,7 +62,7 @@
     <nav>
       <ul>
         <!-- Favorites -->
-        <li v-if="favoritesEnabled && supportsAnchorPositions">
+        <li v-if="favoritesEnabled && supportsAnchorPositions" data-id="favorites">
           <RouterLink to="/favorites" custom v-slot="{ href, isActive, navigate }">
             <AnimatedNavigationItemIndicator.Selectable :selected="isActive" :indicatorSize="24">
               <RailButton :href="href" :active="isActive" @click="navigate">
@@ -96,7 +101,7 @@
         </li>
 
         <!-- Devices -->
-        <li>
+        <li data-id="devices">
           <RouterLink to="/devices" custom v-slot="{ href, isActive, navigate }">
             <AnimatedNavigationItemIndicator.Selectable :selected="isActive" :indicatorSize="24">
               <RailButton :href="href" :active="isActive" @click="navigate">
@@ -135,7 +140,7 @@
         </li>
 
         <!-- Apps -->
-        <li>
+        <li data-id="apps">
           <RouterLink to="/apps" custom v-slot="{ href, isActive, navigate }">
             <AnimatedNavigationItemIndicator.Selectable :selected="isActive" :indicatorSize="24">
               <RailButton :href="href" :active="isActive" @click="navigate">
@@ -185,6 +190,7 @@
               ? 1
               : 0
           }; transition: opacity var(--wui-control-fast-duration) ease-in-out;`"
+          data-id="add"
         >
           <MenuFlyoutDivider style="margin-block: 0.25rem" />
           <li>
@@ -335,6 +341,7 @@
           :style="`opacity: ${
             router.currentRoute.value.name === 'webGuacd' ? 1 : 0
           }; transition: opacity var(--wui-control-fast-duration);`"
+          data-id="client"
         >
           <RailButton :active="true">
             <template v-slot:icon>
@@ -381,7 +388,7 @@
 
     <div class="bottom">
       <!-- Settings -->
-      <RouterLink to="/settings" custom v-slot="{ href, isActive, navigate }">
+      <RouterLink to="/settings" custom v-slot="{ href, isActive, navigate }" data-id="settings">
         <AnimatedNavigationItemIndicator.Selectable :selected="isActive" :indicatorSize="24">
           <RailButton :href="href" :active="isActive" @click="navigate">
             <template v-slot:icon>
@@ -393,7 +400,7 @@
       </RouterLink>
 
       <!-- Wiki (external link, not router) -->
-      <RailButton :href="docsUrl" target="_blank" @click.prevent="openHelpPopup(docsUrl)">
+      <RailButton :href="docsUrl" target="_blank" @click.prevent="openHelpPopup(docsUrl)" data-id="wiki">
         <template v-slot:icon>
           <svg width="24" height="24" fill="none" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
             <path

--- a/frontend/lib/components/Navigation/NavigationRail.vue
+++ b/frontend/lib/components/Navigation/NavigationRail.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
   import { AnimatedIcon, MenuFlyout, MenuFlyoutDivider, MenuFlyoutItem } from '$components';
+  import { AnimatedNavigationItemIndicator } from '$components/Navigation/AnimatedNavigationItemIndicator';
   import RailButton from '$components/Navigation/RailButton.vue';
   import { BulkImportDialog, ManagedResourceCreateDiscoveryDialog, showConfirm } from '$dialogs';
   import { useCoreDataStore } from '$stores';
@@ -47,81 +48,128 @@
 </script>
 
 <template>
-  <div class="nav-rail nav-rail-flex" :class="{ hidden }" :aria-hidden="hidden" :inert="hidden">
+  <AnimatedNavigationItemIndicator.Track
+    class="nav-rail nav-rail-flex"
+    :class="{ hidden }"
+    :aria-hidden="hidden"
+    :inert="hidden"
+  >
     <nav>
       <ul>
         <!-- Favorites -->
         <li v-if="favoritesEnabled && supportsAnchorPositions">
           <RouterLink to="/favorites" custom v-slot="{ href, isActive, navigate }">
-            <RailButton :href="href" :active="isActive" @click="navigate">
-              <template v-slot:icon>
-                <svg width="24" height="24" fill="none" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                  <path
-                    d="M10.788 3.103c.495-1.004 1.926-1.004 2.421 0l2.358 4.777 5.273.766c1.107.161 1.549 1.522.748 2.303l-3.816 3.72.901 5.25c.19 1.103-.968 1.944-1.959 1.424l-4.716-2.48-4.715 2.48c-.99.52-2.148-.32-1.96-1.424l.901-5.25-3.815-3.72c-.801-.78-.359-2.142.748-2.303L8.43 7.88l2.358-4.777Zm1.21.936L9.74 8.615a1.35 1.35 0 0 1-1.016.738l-5.05.734 3.654 3.562c.318.31.463.757.388 1.195l-.862 5.03 4.516-2.375a1.35 1.35 0 0 1 1.257 0l4.516 2.374-.862-5.029a1.35 1.35 0 0 1 .388-1.195l3.654-3.562-5.05-.734a1.35 1.35 0 0 1-1.016-.738l-2.259-4.576Z"
-                    fill="currentColor"
-                  />
-                </svg>
-              </template>
-              <template v-slot:icon-active>
-                <svg width="24" height="24" fill="none" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                  <path
-                    d="M10.788 3.103c.495-1.004 1.926-1.004 2.421 0l2.358 4.777 5.273.766c1.107.161 1.549 1.522.748 2.303l-3.816 3.72.901 5.25c.19 1.103-.968 1.944-1.959 1.424l-4.716-2.48-4.715 2.48c-.99.52-2.148-.32-1.96-1.424l.901-5.25-3.815-3.72c-.801-.78-.359-2.142.748-2.303L8.43 7.88l2.358-4.777Z"
-                    fill="currentColor"
-                  />
-                </svg>
-              </template>
-              {{ $t('favorites.title') }}
-            </RailButton>
+            <AnimatedNavigationItemIndicator.Selectable :selected="isActive" :indicatorHeight="24">
+              <RailButton :href="href" :active="isActive" @click="navigate">
+                <template v-slot:icon>
+                  <svg
+                    width="24"
+                    height="24"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M10.788 3.103c.495-1.004 1.926-1.004 2.421 0l2.358 4.777 5.273.766c1.107.161 1.549 1.522.748 2.303l-3.816 3.72.901 5.25c.19 1.103-.968 1.944-1.959 1.424l-4.716-2.48-4.715 2.48c-.99.52-2.148-.32-1.96-1.424l.901-5.25-3.815-3.72c-.801-.78-.359-2.142.748-2.303L8.43 7.88l2.358-4.777Zm1.21.936L9.74 8.615a1.35 1.35 0 0 1-1.016.738l-5.05.734 3.654 3.562c.318.31.463.757.388 1.195l-.862 5.03 4.516-2.375a1.35 1.35 0 0 1 1.257 0l4.516 2.374-.862-5.029a1.35 1.35 0 0 1 .388-1.195l3.654-3.562-5.05-.734a1.35 1.35 0 0 1-1.016-.738l-2.259-4.576Z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                </template>
+                <template v-slot:icon-active>
+                  <svg
+                    width="24"
+                    height="24"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M10.788 3.103c.495-1.004 1.926-1.004 2.421 0l2.358 4.777 5.273.766c1.107.161 1.549 1.522.748 2.303l-3.816 3.72.901 5.25c.19 1.103-.968 1.944-1.959 1.424l-4.716-2.48-4.715 2.48c-.99.52-2.148-.32-1.96-1.424l.901-5.25-3.815-3.72c-.801-.78-.359-2.142.748-2.303L8.43 7.88l2.358-4.777Z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                </template>
+                {{ $t('favorites.title') }}
+              </RailButton>
+            </AnimatedNavigationItemIndicator.Selectable>
           </RouterLink>
         </li>
 
         <!-- Devices -->
         <li>
           <RouterLink to="/devices" custom v-slot="{ href, isActive, navigate }">
-            <RailButton :href="href" :active="isActive" @click="navigate">
-              <template v-slot:icon>
-                <svg width="24" height="24" fill="none" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                  <path
-                    d="M6.75 22a.75.75 0 0 1-.102-1.493l.102-.007h1.749v-2.498H4.25a2.25 2.25 0 0 1-2.245-2.096L2 15.752V5.25a2.25 2.25 0 0 1 2.096-2.245L4.25 3h15.499a2.25 2.25 0 0 1 2.245 2.096l.005.154v10.502a2.25 2.25 0 0 1-2.096 2.245l-.154.005h-4.25V20.5h1.751a.75.75 0 0 1 .102 1.494L17.25 22H6.75Zm7.248-3.998h-4l.001 2.498h4l-.001-2.498ZM19.748 4.5H4.25a.75.75 0 0 0-.743.648L3.5 5.25v10.502c0 .38.282.694.648.743l.102.007h15.499a.75.75 0 0 0 .743-.648l.007-.102V5.25a.75.75 0 0 0-.648-.743l-.102-.007Z"
-                    fill="currentColor"
-                  />
-                </svg>
-              </template>
-              <template v-slot:icon-active>
-                <svg width="24" height="24" fill="none" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                  <path
-                    d="M6.75 22a.75.75 0 0 1-.102-1.493l.102-.007h1.749v-2.498H4.25a2.25 2.25 0 0 1-2.245-2.096L2 15.752V5.25a2.25 2.25 0 0 1 2.096-2.245L4.25 3h15.499a2.25 2.25 0 0 1 2.245 2.096l.005.154v10.502a2.25 2.25 0 0 1-2.096 2.245l-.154.005h-4.25V20.5h1.751a.75.75 0 0 1 .102 1.494L17.25 22H6.75Zm7.248-3.998h-4l.001 2.498h4l-.001-2.498Z"
-                    fill="currentColor"
-                  />
-                </svg>
-              </template>
-              {{ $t('devices.title') }}
-            </RailButton>
+            <AnimatedNavigationItemIndicator.Selectable :selected="isActive" :indicatorHeight="24">
+              <RailButton :href="href" :active="isActive" @click="navigate">
+                <template v-slot:icon>
+                  <svg
+                    width="24"
+                    height="24"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M6.75 22a.75.75 0 0 1-.102-1.493l.102-.007h1.749v-2.498H4.25a2.25 2.25 0 0 1-2.245-2.096L2 15.752V5.25a2.25 2.25 0 0 1 2.096-2.245L4.25 3h15.499a2.25 2.25 0 0 1 2.245 2.096l.005.154v10.502a2.25 2.25 0 0 1-2.096 2.245l-.154.005h-4.25V20.5h1.751a.75.75 0 0 1 .102 1.494L17.25 22H6.75Zm7.248-3.998h-4l.001 2.498h4l-.001-2.498ZM19.748 4.5H4.25a.75.75 0 0 0-.743.648L3.5 5.25v10.502c0 .38.282.694.648.743l.102.007h15.499a.75.75 0 0 0 .743-.648l.007-.102V5.25a.75.75 0 0 0-.648-.743l-.102-.007Z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                </template>
+                <template v-slot:icon-active>
+                  <svg
+                    width="24"
+                    height="24"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M6.75 22a.75.75 0 0 1-.102-1.493l.102-.007h1.749v-2.498H4.25a2.25 2.25 0 0 1-2.245-2.096L2 15.752V5.25a2.25 2.25 0 0 1 2.096-2.245L4.25 3h15.499a2.25 2.25 0 0 1 2.245 2.096l.005.154v10.502a2.25 2.25 0 0 1-2.096 2.245l-.154.005h-4.25V20.5h1.751a.75.75 0 0 1 .102 1.494L17.25 22H6.75Zm7.248-3.998h-4l.001 2.498h4l-.001-2.498Z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                </template>
+                {{ $t('devices.title') }}
+              </RailButton>
+            </AnimatedNavigationItemIndicator.Selectable>
           </RouterLink>
         </li>
 
         <!-- Apps -->
         <li>
           <RouterLink to="/apps" custom v-slot="{ href, isActive, navigate }">
-            <RailButton :href="href" :active="isActive" @click="navigate">
-              <template v-slot:icon>
-                <svg width="24" height="24" fill="none" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                  <path
-                    d="m18.492 2.33 3.179 3.179a2.25 2.25 0 0 1 0 3.182l-2.584 2.584A2.25 2.25 0 0 1 21 13.5v5.25A2.25 2.25 0 0 1 18.75 21H5.25A2.25 2.25 0 0 1 3 18.75V5.25A2.25 2.25 0 0 1 5.25 3h5.25a2.25 2.25 0 0 1 2.225 1.915L15.31 2.33a2.25 2.25 0 0 1 3.182 0ZM4.5 18.75c0 .414.336.75.75.75l5.999-.001.001-6.75H4.5v6Zm8.249.749h6.001a.75.75 0 0 0 .75-.75V13.5a.75.75 0 0 0-.75-.75h-6.001v6.75Zm-2.249-15H5.25a.75.75 0 0 0-.75.75v6h6.75v-6a.75.75 0 0 0-.75-.75Zm2.25 4.81v1.94h1.94l-1.94-1.94Zm3.62-5.918-3.178 3.178a.75.75 0 0 0 0 1.061l3.179 3.179a.75.75 0 0 0 1.06 0l3.18-3.179a.75.75 0 0 0 0-1.06l-3.18-3.18a.75.75 0 0 0-1.06 0Z"
-                    fill="currentColor"
-                  />
-                </svg>
-              </template>
-              <template v-slot:icon-active>
-                <svg width="24" height="24" fill="none" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                  <path
-                    d="m18.492 2.33 3.179 3.179a2.25 2.25 0 0 1 0 3.182l-2.423 2.422A2.501 2.501 0 0 1 21 13.5v5a2.5 2.5 0 0 1-2.5 2.5h-13A2.5 2.5 0 0 1 3 18.5v-13A2.5 2.5 0 0 1 5.5 3h5c1.121 0 2.07.737 2.387 1.754L15.31 2.33a2.25 2.25 0 0 1 3.182 0ZM11 13H5v5.5a.5.5 0 0 0 .5.5H11v-6Zm7.5 0H13v6h5.5a.5.5 0 0 0 .5-.5v-5a.5.5 0 0 0-.5-.5Zm-4.06-2.001L13 9.559v1.44h1.44Zm-3.94-6h-5a.5.5 0 0 0-.5.5V11h6V5.5a.5.5 0 0 0-.5-.5Z"
-                    fill="currentColor"
-                  />
-                </svg>
-              </template>
-              {{ $t('apps.title') }}
-            </RailButton>
+            <AnimatedNavigationItemIndicator.Selectable :selected="isActive" :indicatorHeight="24">
+              <RailButton :href="href" :active="isActive" @click="navigate">
+                <template v-slot:icon>
+                  <svg
+                    width="24"
+                    height="24"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="m18.492 2.33 3.179 3.179a2.25 2.25 0 0 1 0 3.182l-2.584 2.584A2.25 2.25 0 0 1 21 13.5v5.25A2.25 2.25 0 0 1 18.75 21H5.25A2.25 2.25 0 0 1 3 18.75V5.25A2.25 2.25 0 0 1 5.25 3h5.25a2.25 2.25 0 0 1 2.225 1.915L15.31 2.33a2.25 2.25 0 0 1 3.182 0ZM4.5 18.75c0 .414.336.75.75.75l5.999-.001.001-6.75H4.5v6Zm8.249.749h6.001a.75.75 0 0 0 .75-.75V13.5a.75.75 0 0 0-.75-.75h-6.001v6.75Zm-2.249-15H5.25a.75.75 0 0 0-.75.75v6h6.75v-6a.75.75 0 0 0-.75-.75Zm2.25 4.81v1.94h1.94l-1.94-1.94Zm3.62-5.918-3.178 3.178a.75.75 0 0 0 0 1.061l3.179 3.179a.75.75 0 0 0 1.06 0l3.18-3.179a.75.75 0 0 0 0-1.06l-3.18-3.18a.75.75 0 0 0-1.06 0Z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                </template>
+                <template v-slot:icon-active>
+                  <svg
+                    width="24"
+                    height="24"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="m18.492 2.33 3.179 3.179a2.25 2.25 0 0 1 0 3.182l-2.423 2.422A2.501 2.501 0 0 1 21 13.5v5a2.5 2.5 0 0 1-2.5 2.5h-13A2.5 2.5 0 0 1 3 18.5v-13A2.5 2.5 0 0 1 5.5 3h5c1.121 0 2.07.737 2.387 1.754L15.31 2.33a2.25 2.25 0 0 1 3.182 0ZM11 13H5v5.5a.5.5 0 0 0 .5.5H11v-6Zm7.5 0H13v6h5.5a.5.5 0 0 0 .5-.5v-5a.5.5 0 0 0-.5-.5Zm-4.06-2.001L13 9.559v1.44h1.44Zm-3.94-6h-5a.5.5 0 0 0-.5.5V11h6V5.5a.5.5 0 0 0-.5-.5Z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                </template>
+                {{ $t('apps.title') }}
+              </RailButton>
+            </AnimatedNavigationItemIndicator.Selectable>
           </RouterLink>
         </li>
 
@@ -334,12 +382,14 @@
     <div class="bottom">
       <!-- Settings -->
       <RouterLink to="/settings" custom v-slot="{ href, isActive, navigate }">
-        <RailButton :href="href" :active="isActive" @click="navigate">
-          <template v-slot:icon>
-            <AnimatedIcon.Settings :filled="isActive" />
-          </template>
-          {{ $t('settings.title') }}
-        </RailButton>
+        <AnimatedNavigationItemIndicator.Selectable :selected="isActive" :indicatorHeight="24">
+          <RailButton :href="href" :active="isActive" @click="navigate">
+            <template v-slot:icon>
+              <AnimatedIcon.Settings :filled="isActive" />
+            </template>
+            {{ $t('settings.title') }}
+          </RailButton>
+        </AnimatedNavigationItemIndicator.Selectable>
       </RouterLink>
 
       <!-- Wiki (external link, not router) -->
@@ -359,7 +409,7 @@
         {{ $t('wiki.title') }}
       </RailButton>
     </div>
-  </div>
+  </AnimatedNavigationItemIndicator.Track>
 </template>
 
 <style scoped>

--- a/frontend/lib/components/Navigation/RailButton.vue
+++ b/frontend/lib/components/Navigation/RailButton.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
   import { registerIconAnimationKey, type IconAnimationHandle } from '$components/AnimatedIcon/iconAnimation';
+  import { AnimatedNavigationItemIndicator } from '$components/Navigation/AnimatedNavigationItemIndicator/index.mjs';
   import TextBlock from '$components/TextBlock/TextBlock.vue';
   import { inject, provide, useTemplateRef } from 'vue';
-  import { AnimatedNavigationItemIndicator } from './AnimatedNavigationItemIndicator';
 
   const {
     active = false,

--- a/frontend/lib/components/Navigation/RailButton.vue
+++ b/frontend/lib/components/Navigation/RailButton.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
   import { registerIconAnimationKey, type IconAnimationHandle } from '$components/AnimatedIcon/iconAnimation';
   import TextBlock from '$components/TextBlock/TextBlock.vue';
-  import { provide, useTemplateRef } from 'vue';
+  import { inject, provide, useTemplateRef } from 'vue';
+  import { AnimatedNavigationItemIndicator } from './AnimatedNavigationItemIndicator';
 
   const {
     active = false,
@@ -20,6 +21,8 @@
   }>();
 
   const tag = href ? 'a' : 'button'; // use <a> if href is provided, otherwise use <button>
+
+  const inTrack = inject(AnimatedNavigationItemIndicator.IN_SELECTION_TRACK_KEY, false);
 
   const componentRef = useTemplateRef('componentRef');
   function handleKeydown(evt: KeyboardEvent) {
@@ -58,7 +61,7 @@
     :is="tag"
     :="restProps"
     class="button"
-    :class="{ active, disabled }"
+    :class="{ active, disabled, 'in-track': inTrack }"
     :href="active || disabled ? null : href"
     :target="active ? null : target"
     :disabled="active || disabled"
@@ -93,6 +96,8 @@
   .button {
     background-color: transparent;
     color: currentColor;
+    position: relative;
+    z-index: 1;
     inline-size: var(--button-size, 64px);
     block-size: calc(var(--button-size, 64px) / 1.1);
     position: relative;
@@ -146,11 +151,15 @@
     content: '';
     position: absolute;
     width: 3px;
-    height: 38%;
-    top: 31%;
+    height: calc(1.5rem - 2px);
     left: 0;
     background-color: var(--wui-accent-default);
     border-radius: var(--wui-control-corner-radius);
+  }
+
+  /* AnimatedNavigationItemIndicator.SelectionTrack renders its own indicator */
+  .button.in-track.active::after {
+    display: none;
   }
 
   .icon {

--- a/frontend/lib/components/Navigation/SettingsNavBar.vue
+++ b/frontend/lib/components/Navigation/SettingsNavBar.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
-  import { Button } from '$components';
-  import { AnimatedNavigationItemIndicator } from '$components/Navigation/AnimatedNavigationItemIndicator';
+  import { AnimatedNavigationItemIndicator, Button } from '$components';
   import { useCoreDataStore } from '$stores';
   import { useTranslation } from 'i18next-vue';
 

--- a/frontend/lib/components/Navigation/SettingsNavBar.vue
+++ b/frontend/lib/components/Navigation/SettingsNavBar.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
   import { Button } from '$components';
+  import { AnimatedNavigationItemIndicator } from '$components/Navigation/AnimatedNavigationItemIndicator';
   import { useCoreDataStore } from '$stores';
   import { useTranslation } from 'i18next-vue';
 
@@ -20,19 +21,26 @@
 
 <template>
   <!-- TODO: replace this with a selector bar -->
-  <div v-if="shouldShowNavBar" class="settings-nav" :class="{ hidden, simpleModeEnabled }">
+  <AnimatedNavigationItemIndicator.Track
+    v-if="shouldShowNavBar"
+    orientation="horizontal"
+    class="settings-nav"
+    :class="{ hidden, simpleModeEnabled }"
+  >
     <RouterLink to="/settings" custom v-slot="{ href, isExactActive, navigate }">
-      <Button :href :active="isExactActive" @click="navigate" :class="{ isExactActive }">
-        {{ t('settingsHub.nav.general') }}
-        <template v-slot:icon>
-          <svg width="24" height="24" fill="none" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-            <path
-              d="M12.012 2.25c.734.008 1.465.093 2.182.253a.75.75 0 0 1 .582.649l.17 1.527a1.384 1.384 0 0 0 1.927 1.116l1.401-.615a.75.75 0 0 1 .85.174 9.792 9.792 0 0 1 2.204 3.792.75.75 0 0 1-.271.825l-1.242.916a1.381 1.381 0 0 0 0 2.226l1.243.915a.75.75 0 0 1 .272.826 9.797 9.797 0 0 1-2.204 3.792.75.75 0 0 1-.848.175l-1.407-.617a1.38 1.38 0 0 0-1.926 1.114l-.169 1.526a.75.75 0 0 1-.572.647 9.518 9.518 0 0 1-4.406 0 .75.75 0 0 1-.572-.647l-.168-1.524a1.382 1.382 0 0 0-1.926-1.11l-1.406.616a.75.75 0 0 1-.849-.175 9.798 9.798 0 0 1-2.204-3.796.75.75 0 0 1 .272-.826l1.243-.916a1.38 1.38 0 0 0 0-2.226l-1.243-.914a.75.75 0 0 1-.271-.826 9.793 9.793 0 0 1 2.204-3.792.75.75 0 0 1 .85-.174l1.4.615a1.387 1.387 0 0 0 1.93-1.118l.17-1.526a.75.75 0 0 1 .583-.65c.717-.159 1.45-.243 2.201-.252Zm0 1.5a9.135 9.135 0 0 0-1.354.117l-.109.977A2.886 2.886 0 0 1 6.525 7.17l-.898-.394a8.293 8.293 0 0 0-1.348 2.317l.798.587a2.881 2.881 0 0 1 0 4.643l-.799.588c.32.842.776 1.626 1.348 2.322l.905-.397a2.882 2.882 0 0 1 4.017 2.318l.11.984c.889.15 1.798.15 2.687 0l.11-.984a2.881 2.881 0 0 1 4.018-2.322l.905.396a8.296 8.296 0 0 0 1.347-2.318l-.798-.588a2.881 2.881 0 0 1 0-4.643l.796-.587a8.293 8.293 0 0 0-1.348-2.317l-.896.393a2.884 2.884 0 0 1-4.023-2.324l-.11-.976a8.988 8.988 0 0 0-1.333-.117ZM12 8.25a3.75 3.75 0 1 1 0 7.5 3.75 3.75 0 0 1 0-7.5Zm0 1.5a2.25 2.25 0 1 0 0 4.5 2.25 2.25 0 0 0 0-4.5Z"
-              fill="currentColor"
-            />
-          </svg>
-        </template>
-      </Button>
+      <AnimatedNavigationItemIndicator.Selectable :selected="isExactActive" :indicatorSize="16">
+        <Button :href :active="isExactActive" @click="navigate" :class="{ isExactActive }">
+          {{ t('settingsHub.nav.general') }}
+          <template v-slot:icon>
+            <svg width="24" height="24" fill="none" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+              <path
+                d="M12.012 2.25c.734.008 1.465.093 2.182.253a.75.75 0 0 1 .582.649l.17 1.527a1.384 1.384 0 0 0 1.927 1.116l1.401-.615a.75.75 0 0 1 .85.174 9.792 9.792 0 0 1 2.204 3.792.75.75 0 0 1-.271.825l-1.242.916a1.381 1.381 0 0 0 0 2.226l1.243.915a.75.75 0 0 1 .272.826 9.797 9.797 0 0 1-2.204 3.792.75.75 0 0 1-.848.175l-1.407-.617a1.38 1.38 0 0 0-1.926 1.114l-.169 1.526a.75.75 0 0 1-.572.647 9.518 9.518 0 0 1-4.406 0 .75.75 0 0 1-.572-.647l-.168-1.524a1.382 1.382 0 0 0-1.926-1.11l-1.406.616a.75.75 0 0 1-.849-.175 9.798 9.798 0 0 1-2.204-3.796.75.75 0 0 1 .272-.826l1.243-.916a1.38 1.38 0 0 0 0-2.226l-1.243-.914a.75.75 0 0 1-.271-.826 9.793 9.793 0 0 1 2.204-3.792.75.75 0 0 1 .85-.174l1.4.615a1.387 1.387 0 0 0 1.93-1.118l.17-1.526a.75.75 0 0 1 .583-.65c.717-.159 1.45-.243 2.201-.252Zm0 1.5a9.135 9.135 0 0 0-1.354.117l-.109.977A2.886 2.886 0 0 1 6.525 7.17l-.898-.394a8.293 8.293 0 0 0-1.348 2.317l.798.587a2.881 2.881 0 0 1 0 4.643l-.799.588c.32.842.776 1.626 1.348 2.322l.905-.397a2.882 2.882 0 0 1 4.017 2.318l.11.984c.889.15 1.798.15 2.687 0l.11-.984a2.881 2.881 0 0 1 4.018-2.322l.905.396a8.296 8.296 0 0 0 1.347-2.318l-.798-.588a2.881 2.881 0 0 1 0-4.643l.796-.587a8.293 8.293 0 0 0-1.348-2.317l-.896.393a2.884 2.884 0 0 1-4.023-2.324l-.11-.976a8.988 8.988 0 0 0-1.333-.117ZM12 8.25a3.75 3.75 0 1 1 0 7.5 3.75 3.75 0 0 1 0-7.5Zm0 1.5a2.25 2.25 0 1 0 0 4.5 2.25 2.25 0 0 0 0-4.5Z"
+                fill="currentColor"
+              />
+            </svg>
+          </template>
+        </Button>
+      </AnimatedNavigationItemIndicator.Selectable>
     </RouterLink>
     <RouterLink
       v-if="canManagePolicies"
@@ -40,17 +48,19 @@
       custom
       v-slot="{ href, isExactActive, navigate }"
     >
-      <Button :href :active="isExactActive" @click="navigate" :class="{ isExactActive }">
-        {{ t('settingsHub.nav.policies') }}
-        <template v-slot:icon>
-          <svg width="24" height="24" fill="none" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-            <path
-              d="M12 1.999c5.487 0 9.942 4.419 10 9.892a6.064 6.064 0 0 1-1.525-.566 8.486 8.486 0 0 0-.21-1.326h-1.942a1.618 1.618 0 0 0-.648 0h-.769c.012.123.023.246.032.37a7.858 7.858 0 0 1-1.448.974c-.016-.46-.047-.908-.094-1.343H8.604a18.968 18.968 0 0 0 .135 5H12v1.5H9.06c.653 2.414 1.786 4.002 2.94 4.002.276 0 .551-.091.819-.263a6.938 6.938 0 0 0 1.197 1.56c-.652.133-1.326.203-2.016.203-5.524 0-10.002-4.478-10.002-10.001C1.998 6.477 6.476 1.998 12 1.998ZM7.508 16.501H4.785a8.532 8.532 0 0 0 4.095 3.41c-.523-.82-.954-1.846-1.27-3.015l-.102-.395ZM7.093 10H3.735l-.004.017a8.524 8.524 0 0 0-.233 1.984c0 1.056.193 2.067.545 3h3.173a20.301 20.301 0 0 1-.218-3c0-.684.033-1.354.095-2.001Zm1.788-5.91-.023.008A8.531 8.531 0 0 0 4.25 8.5h3.048c.313-1.752.86-3.278 1.583-4.41ZM12 3.499l-.116.005C10.618 3.62 9.396 5.622 8.828 8.5h6.343c-.566-2.87-1.784-4.869-3.045-4.995L12 3.5Zm3.12.59.106.175c.67 1.112 1.178 2.572 1.475 4.237h3.048a8.533 8.533 0 0 0-4.338-4.29l-.291-.121Zm7.38 8.888c-1.907-.172-3.434-1.287-4.115-1.87a.601.601 0 0 0-.77 0c-.682.583-2.21 1.698-4.116 1.87a.538.538 0 0 0-.5.523V17c0 4.223 4.094 5.716 4.873 5.962a.42.42 0 0 0 .255 0c.78-.246 4.872-1.74 4.872-5.962v-3.5a.538.538 0 0 0-.5-.523Z"
-              fill="currentColor"
-            />
-          </svg>
-        </template>
-      </Button>
+      <AnimatedNavigationItemIndicator.Selectable :selected="isExactActive" :indicatorSize="16">
+        <Button :href :active="isExactActive" @click="navigate" :class="{ isExactActive }">
+          {{ t('settingsHub.nav.policies') }}
+          <template v-slot:icon>
+            <svg width="24" height="24" fill="none" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+              <path
+                d="M12 1.999c5.487 0 9.942 4.419 10 9.892a6.064 6.064 0 0 1-1.525-.566 8.486 8.486 0 0 0-.21-1.326h-1.942a1.618 1.618 0 0 0-.648 0h-.769c.012.123.023.246.032.37a7.858 7.858 0 0 1-1.448.974c-.016-.46-.047-.908-.094-1.343H8.604a18.968 18.968 0 0 0 .135 5H12v1.5H9.06c.653 2.414 1.786 4.002 2.94 4.002.276 0 .551-.091.819-.263a6.938 6.938 0 0 0 1.197 1.56c-.652.133-1.326.203-2.016.203-5.524 0-10.002-4.478-10.002-10.001C1.998 6.477 6.476 1.998 12 1.998ZM7.508 16.501H4.785a8.532 8.532 0 0 0 4.095 3.41c-.523-.82-.954-1.846-1.27-3.015l-.102-.395ZM7.093 10H3.735l-.004.017a8.524 8.524 0 0 0-.233 1.984c0 1.056.193 2.067.545 3h3.173a20.301 20.301 0 0 1-.218-3c0-.684.033-1.354.095-2.001Zm1.788-5.91-.023.008A8.531 8.531 0 0 0 4.25 8.5h3.048c.313-1.752.86-3.278 1.583-4.41ZM12 3.499l-.116.005C10.618 3.62 9.396 5.622 8.828 8.5h6.343c-.566-2.87-1.784-4.869-3.045-4.995L12 3.5Zm3.12.59.106.175c.67 1.112 1.178 2.572 1.475 4.237h3.048a8.533 8.533 0 0 0-4.338-4.29l-.291-.121Zm7.38 8.888c-1.907-.172-3.434-1.287-4.115-1.87a.601.601 0 0 0-.77 0c-.682.583-2.21 1.698-4.116 1.87a.538.538 0 0 0-.5.523V17c0 4.223 4.094 5.716 4.873 5.962a.42.42 0 0 0 .255 0c.78-.246 4.872-1.74 4.872-5.962v-3.5a.538.538 0 0 0-.5-.523Z"
+                fill="currentColor"
+              />
+            </svg>
+          </template>
+        </Button>
+      </AnimatedNavigationItemIndicator.Selectable>
     </RouterLink>
     <RouterLink
       v-if="canManageResources"
@@ -58,19 +68,21 @@
       custom
       v-slot="{ href, isExactActive, navigate }"
     >
-      <Button :href :active="isExactActive" @click="navigate" :class="{ isExactActive }">
-        {{ t('settingsHub.nav.resources') }}
-        <template v-slot:icon>
-          <svg width="24" height="24" fill="none" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-            <path
-              d="M8.75 2A1.75 1.75 0 0 0 7 3.75v3a.25.25 0 0 1-.25.25h-3A1.75 1.75 0 0 0 2 8.75v3c0 .966.784 1.75 1.75 1.75h8a1.75 1.75 0 0 0 1.75-1.75v-3a.25.25 0 0 1 .25-.25h2.5A1.75 1.75 0 0 0 18 6.75v-3A1.75 1.75 0 0 0 16.25 2h-7.5Zm7.5 5H13.5V3.5h2.75a.25.25 0 0 1 .25.25v3a.25.25 0 0 1-.25.25ZM12 7H8.483c.011-.082.017-.165.017-.25v-3a.25.25 0 0 1 .25-.25H12V7ZM7 8.5V12H3.75a.25.25 0 0 1-.25-.25v-3a.25.25 0 0 1 .25-.25H7Zm1.5 0h3.518a1.762 1.762 0 0 0-.018.25v3a.25.25 0 0 1-.25.25H8.5V8.5Zm8.75 2a1.75 1.75 0 0 0-1.75 1.75v3a.25.25 0 0 1-.25.25h-8.5A1.75 1.75 0 0 0 5 17.25v3c0 .966.783 1.75 1.75 1.75h13.5A1.75 1.75 0 0 0 22 20.25v-8a1.75 1.75 0 0 0-1.75-1.75h-3ZM17 12.25a.25.25 0 0 1 .25-.25h3a.25.25 0 0 1 .25.25v3.25h-3.518c.012-.082.018-.165.018-.25v-3ZM17 17h3.5v3.25a.25.25 0 0 1-.25.25H17V17Zm-1.5-.018V20.5h-4V17h3.75c.085 0 .168-.006.25-.018ZM10 17v3.5H6.75a.25.25 0 0 1-.25-.25v-3a.25.25 0 0 1 .25-.25H10Z"
-              fill="currentColor"
-            />
-          </svg>
-        </template>
-      </Button>
+      <AnimatedNavigationItemIndicator.Selectable :selected="isExactActive" :indicatorSize="16">
+        <Button :href :active="isExactActive" @click="navigate" :class="{ isExactActive }">
+          {{ t('settingsHub.nav.resources') }}
+          <template v-slot:icon>
+            <svg width="24" height="24" fill="none" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+              <path
+                d="M8.75 2A1.75 1.75 0 0 0 7 3.75v3a.25.25 0 0 1-.25.25h-3A1.75 1.75 0 0 0 2 8.75v3c0 .966.784 1.75 1.75 1.75h8a1.75 1.75 0 0 0 1.75-1.75v-3a.25.25 0 0 1 .25-.25h2.5A1.75 1.75 0 0 0 18 6.75v-3A1.75 1.75 0 0 0 16.25 2h-7.5Zm7.5 5H13.5V3.5h2.75a.25.25 0 0 1 .25.25v3a.25.25 0 0 1-.25.25ZM12 7H8.483c.011-.082.017-.165.017-.25v-3a.25.25 0 0 1 .25-.25H12V7ZM7 8.5V12H3.75a.25.25 0 0 1-.25-.25v-3a.25.25 0 0 1 .25-.25H7Zm1.5 0h3.518a1.762 1.762 0 0 0-.018.25v3a.25.25 0 0 1-.25.25H8.5V8.5Zm8.75 2a1.75 1.75 0 0 0-1.75 1.75v3a.25.25 0 0 1-.25.25h-8.5A1.75 1.75 0 0 0 5 17.25v3c0 .966.783 1.75 1.75 1.75h13.5A1.75 1.75 0 0 0 22 20.25v-8a1.75 1.75 0 0 0-1.75-1.75h-3ZM17 12.25a.25.25 0 0 1 .25-.25h3a.25.25 0 0 1 .25.25v3.25h-3.518c.012-.082.018-.165.018-.25v-3ZM17 17h3.5v3.25a.25.25 0 0 1-.25.25H17V17Zm-1.5-.018V20.5h-4V17h3.75c.085 0 .168-.006.25-.018ZM10 17v3.5H6.75a.25.25 0 0 1-.25-.25v-3a.25.25 0 0 1 .25-.25H10Z"
+                fill="currentColor"
+              />
+            </svg>
+          </template>
+        </Button>
+      </AnimatedNavigationItemIndicator.Selectable>
     </RouterLink>
-  </div>
+  </AnimatedNavigationItemIndicator.Track>
 </template>
 
 <style scoped>
@@ -120,7 +132,7 @@
     background-color: transparent !important;
   }
 
-  .settings-nav :deep(.button::after) {
+  /* .settings-nav :deep(.button::after) {
     content: '';
     position: absolute;
     bottom: 2px;
@@ -132,7 +144,7 @@
   .settings-nav :deep(.button.isExactActive::after) {
     inline-size: 1rem;
     transition: width var(--wui-control-fast-duration) var(--wui-control-fast-out-slow-in-easing);
-  }
+  } */
 
   .settings-nav :deep(.button:not(.active) .icon) {
     transition: color var(--wui-control-normal-duration);

--- a/frontend/lib/components/NavigationView/NavigationPane.vue
+++ b/frontend/lib/components/NavigationView/NavigationPane.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
   import { AnimatedIcon, IconButton, ListItem, TreeView } from '$components';
-  import { ref } from 'vue';
+  import { provide, ref } from 'vue';
   import { useRouter } from 'vue-router';
   import { TreeItem } from './NavigationTypes.ts';
+  import { ANIMATE_TREE_SELECTION_KEY } from './treeSelection.ts';
 
   const {
     headerText = '',
@@ -27,6 +28,9 @@
     default: false,
   });
   const router = useRouter();
+
+  // opt descendant TreeViews into the animated (sliding) selection indicator
+  provide(ANIMATE_TREE_SELECTION_KEY, true);
 
   const previousPage = ref<string | null>(null);
   router.afterEach((to, from) => {

--- a/frontend/lib/components/NavigationView/TreeView.vue
+++ b/frontend/lib/components/NavigationView/TreeView.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
-  import { ListItem, MenuFlyout, TextBlock } from '$components';
-  import { AnimatedNavigationItemIndicator } from '$components/Navigation/AnimatedNavigationItemIndicator';
+  import { AnimatedNavigationItemIndicator, ListItem, MenuFlyout, TextBlock } from '$components';
   import { chevronDown } from '$icons';
   import { prefixUserNS, PreventableEvent, toKebabCase } from '$utils';
   import { isBrowser } from '$utils/environment.ts';

--- a/frontend/lib/components/NavigationView/TreeView.vue
+++ b/frontend/lib/components/NavigationView/TreeView.vue
@@ -274,36 +274,41 @@
                 <template v-if="type === 'expander' && __depth === 0">
                   <MenuFlyout placement="right" anchor="start">
                     <template #default="{ popoverId }">
-                      <ListItem
-                        :popovertarget="popoverId"
-                        :title="name"
-                        :compact
-                        :disabled
-                        :selected="!getIsExpanded(name, true) && hasSelectedChild(tree[index])"
+                      <component
+                        :is="animateSelection && unlabeled ? Selectable : Passthrough"
+                        v-bind="
+                          animateSelection
+                            ? {
+                                selected: !getIsExpanded(name, true) && hasSelectedChild(tree[index]),
+                                indicatorSize: INDICATOR_SIZE,
+                              }
+                            : {}
+                        "
                       >
-                        <template #icon>
-                          <img
-                            v-if="icon && typeof icon !== 'string'"
-                            :src="icon.href"
-                            alt=""
-                            width="24"
-                            height="24"
-                            style="margin-right: 8px"
-                          />
-                          <span v-else style="display: contents" v-html="icon"></span>
-                        </template>
-                      </ListItem>
+                        <ListItem
+                          :popovertarget="popoverId"
+                          :title="name"
+                          :compact
+                          :disabled
+                          :selected="!getIsExpanded(name, true) && hasSelectedChild(tree[index])"
+                        >
+                          <template #icon>
+                            <img
+                              v-if="icon && typeof icon !== 'string'"
+                              :src="icon.href"
+                              alt=""
+                              width="24"
+                              height="24"
+                              style="margin-right: 8px"
+                            />
+                            <span v-else style="display: contents" v-html="icon"></span>
+                          </template>
+                        </ListItem>
+                      </component>
                     </template>
                     <template #menu>
                       <TextBlock class="category-header" variant="bodyStrong">{{ name }}</TextBlock>
-                      <TreeView
-                        :__depth
-                        :tree="children"
-                        :compact
-                        :stateId
-                        :="restProps"
-                        :blockAnimatedIndicatorDetection="true"
-                      />
+                      <TreeView :__depth="0.0000000000001" :tree="children" :compact :stateId :="restProps" />
                     </template>
                   </MenuFlyout>
                 </template>
@@ -312,7 +317,7 @@
               <!-- labeled state -->
               <div class="labeled-subtree-button" :inert="unlabeled">
                 <component
-                  :is="animateSelection ? Selectable : Passthrough"
+                  :is="animateSelection && !unlabeled ? Selectable : Passthrough"
                   v-bind="
                     animateSelection
                       ? {

--- a/frontend/lib/components/NavigationView/TreeView.vue
+++ b/frontend/lib/components/NavigationView/TreeView.vue
@@ -1,12 +1,32 @@
 <script setup lang="ts">
   import { ListItem, MenuFlyout, TextBlock } from '$components';
+  import { AnimatedNavigationItemIndicator } from '$components/Navigation/AnimatedNavigationItemIndicator';
   import { chevronDown } from '$icons';
   import { prefixUserNS, PreventableEvent, toKebabCase } from '$utils';
   import { isBrowser } from '$utils/environment.ts';
   import { collapseUp, expandDown } from '$utils/transitions';
-  import { computed, onMounted, ref, useAttrs, useTemplateRef, watch } from 'vue';
+  import {
+    computed,
+    type FunctionalComponent,
+    inject,
+    onMounted,
+    provide,
+    ref,
+    useAttrs,
+    useTemplateRef,
+    watch,
+  } from 'vue';
   import { useRouter } from 'vue-router';
   import type { TreeItem } from './NavigationTypes';
+  import { ANIMATE_TREE_SELECTION_KEY, PROVIDED_TRACK_DEPTH_KEY } from './treeSelection.ts';
+
+  const Track = AnimatedNavigationItemIndicator.Track;
+  const Selectable = AnimatedNavigationItemIndicator.Selectable;
+
+  // Renders its slotted content with no wrapper element, used as the "off" state
+  // for the conditional Track/Selectable wrappers below so that TreeViews outside
+  // a NavigationPane keep their original markup and each ListItem's static bar.
+  const Passthrough: FunctionalComponent = (_props, { slots }) => slots.default?.() ?? null;
 
   const {
     tree: unfilteredTree = [],
@@ -15,6 +35,7 @@
     collapsed = false,
     unlabeled = false,
     stateId,
+    blockAnimatedIndicatorDetection = false,
   } = defineProps<{
     tree?: TreeItem[];
     __depth?: number;
@@ -22,9 +43,27 @@
     collapsed?: boolean;
     unlabeled?: boolean;
     stateId?: string;
+    blockAnimatedIndicatorDetection?: boolean;
   }>();
   const restProps = useAttrs();
   const router = useRouter();
+
+  // when inside a NavigationPane, wrap this level's items in a selection track so
+  // the accent bar slides between direct siblings; each TreeView provides its own
+  // track, so selection moving across levels lands in a different track (and only
+  // animates within a level). The indicator is indented to match this depth.
+  const animateSelection = !blockAnimatedIndicatorDetection && inject(ANIMATE_TREE_SELECTION_KEY, false);
+
+  // Only create a track when there isn't already one at this depth.
+  // Top-level categories recurse at the same __depth and reuse the ancestor track,
+  // so every __depth === 0 item (leaves and subtree buttons) shares one indicator.
+  // Each deeper subtree makes its own track and animates only among its direct siblings.
+  const injectedTrackDepth = inject(PROVIDED_TRACK_DEPTH_KEY, -1);
+  const createsOwnTrack = animateSelection && __depth > injectedTrackDepth;
+  provide(PROVIDED_TRACK_DEPTH_KEY, createsOwnTrack ? __depth : injectedTrackDepth);
+
+  const indicatorCrossOffset = computed(() => `--indicator-cross-offset: ${__depth * 32}px`);
+  const INDICATOR_SIZE = 16;
 
   const treeViewState = ref<Record<string, boolean> | undefined>(undefined);
   const delayedTreeViewState = ref<Record<string, boolean> | undefined>(undefined);
@@ -204,154 +243,200 @@
     :inert="collapsed && collapsedStateIsResolved"
   >
     <div class="tree-view-content" ref="treeViewContent">
-      <template v-for="({ name, href, type, children, icon, onClick, selected, disabled }, index) in tree">
-        <hr v-if="name === 'hr'" />
+      <component
+        :is="createsOwnTrack ? Track : Passthrough"
+        v-bind="createsOwnTrack ? { class: 'selection-track', style: indicatorCrossOffset } : {}"
+      >
+        <template v-for="({ name, href, type, children, icon, onClick, selected, disabled }, index) in tree">
+          <hr v-if="name === 'hr'" />
 
-        <!-- top-level categories -->
-        <template v-else-if="__depth === 0 && type === 'category'">
-          <TextBlock :class="['category-header', unlabeled ? 'hidden' : '']" variant="bodyStrong">{{
-            name
-          }}</TextBlock>
-          <TreeView :__depth="__depth" :tree="children" :compact :collapsed :unlabeled :stateId :="restProps" />
-        </template>
-
-        <!-- branch (subtree) -->
-        <template v-else-if="(__depth > 0 && type === 'category') || type === 'expander'">
-          <div class="subtree-buttons">
-            <!-- unlabeled state -->
-            <div class="unlabeled-subtree-button" :inert="!unlabeled">
-              <!-- show icons with menus for top-level expanders (hide otherwise) -->
-              <template v-if="type === 'expander' && __depth === 0">
-                <MenuFlyout placement="right" anchor="start">
-                  <template #default="{ popoverId }">
-                    <ListItem
-                      :popovertarget="popoverId"
-                      :title="name"
-                      :compact
-                      :disabled
-                      :selected="!getIsExpanded(name, true) && hasSelectedChild(tree[index])"
-                    >
-                      <template #icon>
-                        <img
-                          v-if="icon && typeof icon !== 'string'"
-                          :src="icon.href"
-                          alt=""
-                          width="24"
-                          height="24"
-                          style="margin-right: 8px"
-                        />
-                        <span v-else style="display: contents" v-html="icon"></span>
-                      </template>
-                    </ListItem>
-                  </template>
-                  <template #menu>
-                    <TextBlock class="category-header" variant="bodyStrong">{{ name }}</TextBlock>
-                    <TreeView :__depth :tree="children" :compact :stateId :="restProps" />
-                  </template>
-                </MenuFlyout>
-              </template>
-            </div>
-
-            <!-- labeled state -->
-            <div class="labeled-subtree-button" :inert="unlabeled">
-              <ListItem
-                @click="
-                  ($event: MouseEvent) => {
-                    const preventableEvent = new PreventableEvent($event);
-                    onClick?.(preventableEvent);
-
-                    if (!preventableEvent.defaultPrevented) {
-                      toggleExpansion($event, name);
-                    }
-                  }
-                "
-                @keypress="
-                  ($event: KeyboardEvent) => {
-                    if ($event.key === 'Enter') {
-                      const preventableEvent = new PreventableEvent($event);
-                      onClick?.(preventableEvent);
-
-                      if (!preventableEvent.defaultPrevented) {
-                        toggleExpansion($event, name);
-                      }
-                    }
-                  }
-                "
-                :disabled
-                type="navigation"
-                :style="`--depth: ${__depth}`"
-                :compact
-                :class="`${collapsed ? 'collapsed' : ''}`"
-                :selected="!getIsExpanded(name, true) && hasSelectedChild(tree[index])"
-              >
-                <template #icon>
-                  <img
-                    v-if="icon && typeof icon !== 'string'"
-                    :src="icon.href"
-                    alt=""
-                    width="24"
-                    height="24"
-                    style="margin-right: 8px"
-                  />
-                  <span v-else style="display: contents" v-html="icon"></span>
-                </template>
-                {{ name }}
-                <template #icon-end>
-                  <span
-                    :class="['chevron', getIsExpanded(name, true) ? 'expanded' : '']"
-                    v-html="chevronDown"
-                  ></span>
-                </template>
-              </ListItem>
-            </div>
-          </div>
-
-          <!-- subtree from expander -->
-          <div class="subtree-items" v-if="treeViewState !== undefined">
+          <!-- top-level categories -->
+          <template v-else-if="__depth === 0 && type === 'category'">
+            <TextBlock :class="['category-header', unlabeled ? 'hidden' : '']" variant="bodyStrong">{{
+              name
+            }}</TextBlock>
             <TreeView
-              :__depth="__depth + 1"
+              :__depth="__depth"
               :tree="children"
               :compact
-              :collapsed="collapsed || !getIsExpanded(name)"
+              :collapsed
               :unlabeled
               :stateId
               :="restProps"
             />
-          </div>
-        </template>
-
-        <!-- leaf -->
-        <ListItem
-          v-else
-          @click="handleLeafClick($event, onClick, href)"
-          @keypress="
-            if ($event.key === 'Enter' || $event.key === ' ') {
-              handleLeafClick($event, onClick, href);
-            }
-          "
-          :disabled
-          type="navigation"
-          :selected="!collapsed && collapsedStateIsResolved && isItemSelected(tree[index])"
-          :href="href ? (base.endsWith('/') ? base.slice(0, -1) : base) + href.replace('!/', '/') : undefined"
-          :style="`--depth: ${__depth}`"
-          :compact
-          :class="`tree-leaf ${collapsed ? 'collapsed' : ''}`"
-          :title="collapsed ? name : undefined"
-        >
-          <template v-if="icon" #icon>
-            <img
-              v-if="icon && typeof icon !== 'string'"
-              :src="icon.href"
-              alt=""
-              width="24"
-              height="24"
-              style="margin-right: 8px"
-            />
-            <span v-else style="display: contents" v-html="icon"></span>
           </template>
-          {{ name }}
-        </ListItem>
-      </template>
+
+          <!-- branch (subtree) -->
+          <template v-else-if="(__depth > 0 && type === 'category') || type === 'expander'">
+            <div class="subtree-buttons">
+              <!-- unlabeled state -->
+              <div class="unlabeled-subtree-button" :inert="!unlabeled">
+                <!-- show icons with menus for top-level expanders (hide otherwise) -->
+                <template v-if="type === 'expander' && __depth === 0">
+                  <MenuFlyout placement="right" anchor="start">
+                    <template #default="{ popoverId }">
+                      <ListItem
+                        :popovertarget="popoverId"
+                        :title="name"
+                        :compact
+                        :disabled
+                        :selected="!getIsExpanded(name, true) && hasSelectedChild(tree[index])"
+                      >
+                        <template #icon>
+                          <img
+                            v-if="icon && typeof icon !== 'string'"
+                            :src="icon.href"
+                            alt=""
+                            width="24"
+                            height="24"
+                            style="margin-right: 8px"
+                          />
+                          <span v-else style="display: contents" v-html="icon"></span>
+                        </template>
+                      </ListItem>
+                    </template>
+                    <template #menu>
+                      <TextBlock class="category-header" variant="bodyStrong">{{ name }}</TextBlock>
+                      <TreeView
+                        :__depth
+                        :tree="children"
+                        :compact
+                        :stateId
+                        :="restProps"
+                        :blockAnimatedIndicatorDetection="true"
+                      />
+                    </template>
+                  </MenuFlyout>
+                </template>
+              </div>
+
+              <!-- labeled state -->
+              <div class="labeled-subtree-button" :inert="unlabeled">
+                <component
+                  :is="animateSelection ? Selectable : Passthrough"
+                  v-bind="
+                    animateSelection
+                      ? {
+                          selected: !getIsExpanded(name, true) && hasSelectedChild(tree[index]),
+                          indicatorSize: INDICATOR_SIZE,
+                        }
+                      : {}
+                  "
+                >
+                  <ListItem
+                    @click="
+                      ($event: MouseEvent) => {
+                        const preventableEvent = new PreventableEvent($event);
+                        onClick?.(preventableEvent);
+
+                        if (!preventableEvent.defaultPrevented) {
+                          toggleExpansion($event, name);
+                        }
+                      }
+                    "
+                    @keypress="
+                      ($event: KeyboardEvent) => {
+                        if ($event.key === 'Enter') {
+                          const preventableEvent = new PreventableEvent($event);
+                          onClick?.(preventableEvent);
+
+                          if (!preventableEvent.defaultPrevented) {
+                            toggleExpansion($event, name);
+                          }
+                        }
+                      }
+                    "
+                    :disabled
+                    type="navigation"
+                    :style="`--depth: ${__depth}`"
+                    :compact
+                    :class="`${collapsed ? 'collapsed' : ''}`"
+                    :selected="!getIsExpanded(name, true) && hasSelectedChild(tree[index])"
+                  >
+                    <template #icon>
+                      <img
+                        v-if="icon && typeof icon !== 'string'"
+                        :src="icon.href"
+                        alt=""
+                        width="24"
+                        height="24"
+                        style="margin-right: 8px"
+                      />
+                      <span v-else style="display: contents" v-html="icon"></span>
+                    </template>
+                    {{ name }}
+                    <template #icon-end>
+                      <span
+                        :class="['chevron', getIsExpanded(name, true) ? 'expanded' : '']"
+                        v-html="chevronDown"
+                      ></span>
+                    </template>
+                  </ListItem>
+                </component>
+              </div>
+            </div>
+
+            <!-- subtree from expander -->
+            <div class="subtree-items" v-if="treeViewState !== undefined">
+              <TreeView
+                :__depth="__depth + 1"
+                :tree="children"
+                :compact
+                :collapsed="collapsed || !getIsExpanded(name)"
+                :unlabeled
+                :stateId
+                :="restProps"
+              />
+            </div>
+          </template>
+
+          <!-- leaf -->
+          <component
+            v-else
+            :is="animateSelection ? Selectable : Passthrough"
+            v-bind="
+              animateSelection
+                ? {
+                    selected: !collapsed && collapsedStateIsResolved && isItemSelected(tree[index]),
+                    indicatorSize: INDICATOR_SIZE,
+                  }
+                : {}
+            "
+          >
+            <ListItem
+              @click="handleLeafClick($event, onClick, href)"
+              @keypress="
+                if ($event.key === 'Enter' || $event.key === ' ') {
+                  handleLeafClick($event, onClick, href);
+                }
+              "
+              :disabled
+              type="navigation"
+              :selected="!collapsed && collapsedStateIsResolved && isItemSelected(tree[index])"
+              :href="
+                href ? (base.endsWith('/') ? base.slice(0, -1) : base) + href.replace('!/', '/') : undefined
+              "
+              :style="`--depth: ${__depth}`"
+              :compact
+              :class="`tree-leaf ${collapsed ? 'collapsed' : ''}`"
+              :title="collapsed ? name : undefined"
+            >
+              <template v-if="icon" #icon>
+                <img
+                  v-if="icon && typeof icon !== 'string'"
+                  :src="icon.href"
+                  alt=""
+                  width="24"
+                  height="24"
+                  style="margin-right: 8px"
+                />
+                <span v-else style="display: contents" v-html="icon"></span>
+              </template>
+              {{ name }}
+            </ListItem>
+          </component>
+        </template>
+      </component>
     </div>
   </div>
 
@@ -386,8 +471,11 @@
     opacity: 1;
     transition: all 130ms cubic-bezier(0.16, 1, 0.3, 1);
   }
-  .tree-view.unlabeled > .tree-view-content > :deep(.list-item .text-block) {
-    opacity: 0;
+
+  /* the selection track wraps this level's items but must not change their layout */
+  .tree-view-content > .selection-track {
+    display: flex;
+    flex-direction: column;
   }
 
   /* hide scrollbar on collapsed trees */
@@ -432,6 +520,7 @@
   .tree-view-content {
     display: flex;
     flex-direction: column;
+    max-height: fit-content;
   }
 
   /* prevent deeply nested trees from having internal expansion or collapses (with scroll bars) */

--- a/frontend/lib/components/NavigationView/treeSelection.ts
+++ b/frontend/lib/components/NavigationView/treeSelection.ts
@@ -1,0 +1,19 @@
+import type { InjectionKey } from 'vue';
+
+/**
+ * Provided by NavigationPane so that descendant TreeViews render the animated
+ * AnimatedNavigationItemIndicator selection indicator (a sliding accent bar)
+ * instead of each ListItem's static accent bar. TreeViews used outside of a
+ * NavigationPane do not inject a value and keep the static indicator.
+ */
+export const ANIMATE_TREE_SELECTION_KEY: InjectionKey<boolean> = Symbol('animate-tree-selection');
+
+/**
+ * The __depth of the nearest ancestor TreeView that created a selection track.
+ * A TreeView only creates its own track when its depth is greater than this, so
+ * same-depth recursion (top-level categories) shares one track.
+ * Functionally, this lets the indicator span every __depth === 0 item
+ * while each deeper subtree gets its own track and animates only among its direct
+ * siblings.
+ */
+export const PROVIDED_TRACK_DEPTH_KEY: InjectionKey<number> = Symbol('provided-track-depth');

--- a/frontend/lib/components/index.mjs
+++ b/frontend/lib/components/index.mjs
@@ -15,6 +15,7 @@ import { default as HeaderActions } from './Layout/HeaderActions.vue';
 import { default as ResourceGrid } from './Layout/ResourceGrid.vue';
 import { default as ListItem } from './ListItem/ListItem.vue';
 import { MenuFlyout, MenuFlyoutDivider, MenuFlyoutItem } from './MenuFlyout/index.mjs';
+import { AnimatedNavigationItemIndicator } from './Navigation/AnimatedNavigationItemIndicator/index.mjs';
 import { default as NavigationRail } from './Navigation/NavigationRail.vue';
 import { default as RailButton } from './Navigation/RailButton.vue';
 import { default as SettingsNavBar } from './Navigation/SettingsNavBar.vue';
@@ -34,6 +35,7 @@ import { default as ToggleSwitch } from './ToggleSwitch/ToggleSwitch.vue';
 
 export {
   AnimatedIcon,
+  AnimatedNavigationItemIndicator,
   Button,
   CheckBox,
   CodeBlock,

--- a/frontend/lib/stores/index.mjs
+++ b/frontend/lib/stores/index.mjs
@@ -1,2 +1,3 @@
 export { useCoreDataStore } from './coreDataStore.ts';
+export { useNavigationRailStore } from './navigationRailStore.ts';
 export { usePopupWindow } from './windowStore.ts';

--- a/frontend/lib/stores/navigationRailStore.ts
+++ b/frontend/lib/stores/navigationRailStore.ts
@@ -1,0 +1,15 @@
+import type { TrackHandle } from '$components/Navigation/AnimatedNavigationItemIndicator/keys';
+import { defineStore } from 'pinia';
+
+/**
+ * Exposes the NavigationRail's selection indicator track handle outside of
+ * Vue's provide/inject.
+ *
+ * **You should only use this when registering nav rail items from
+ * `App_Data/inject/index.js`.**
+ */
+export const useNavigationRailStore = defineStore('navigationRail', {
+  state: () => ({
+    trackHandle: null as TrackHandle | null,
+  }),
+});


### PR DESCRIPTION
This PR adds an animated indicator for navigation menus that follows the style of WinUI 3. This is best explained via a video snippet:


https://github.com/user-attachments/assets/a5c0dc43-b21e-4c4e-96f6-0c486faf5e26

As demonstrated in the video, this change upgrades the vertical navigation rail in the main app, the horizontal navigation pane in the RDP file properties editor, and the horizontal navigation menu in the web app settings.

This change also upgrades the navigation pane in the wiki. To see what this looks like, you can visit https://raweb.app/deploy-preview/pr-302/docs/.

When a user has requested reduced motion, the menus will not animate.
