### PR TITLE
fix: load the lazy-loaded menu and associated actions on click or focus within a desktop card

### DIFF
--- a/frontend/lib/components/ItemCard/DesktopCard.vue
+++ b/frontend/lib/components/ItemCard/DesktopCard.vue
@@ -47,6 +47,13 @@
     emit('requestWorkspaceRefresh');
   }
 
+  // The card's menu button lazily mounts its dialogs (see GenericResourceCardMenuButton.vue).
+  // It only mounts them when the user shows intent to open the menu, but we also need to
+  // activate the menu when the user reigh clicks the card.
+  function activateMenu() {
+    raw(_menu.value)?.activateMenu();
+  }
+
   const emit = defineEmits<{
     (e: 'requestWorkspaceRefresh'): void;
   }>();
@@ -58,6 +65,8 @@
       `--wallpaper-light: ${wallpaper?.light}; --wallpaper-dark: ${wallpaper?.dark};`,
       width ? `--width: ${width};` : '',
     ]"
+    @pointerdown="activateMenu"
+    @focusin="activateMenu"
   >
     <div class="content">
       <div class="labels">
@@ -74,6 +83,7 @@
           hide-default-connect
           ref="menu"
           class="actual-menu-button"
+          tabindex="0"
           @request-workspace-refresh="requestWorkspaceRefresh"
         />
       </div>

--- a/frontend/lib/components/ItemCard/GenericResourceCardMenuButton.vue
+++ b/frontend/lib/components/ItemCard/GenericResourceCardMenuButton.vue
@@ -30,11 +30,13 @@
     class: className,
     placement,
     hideDefaultConnect = false,
+    tabindex = -1,
   } = defineProps<{
     resource: Resource;
     class?: string;
     placement: 'top' | 'bottom';
     hideDefaultConnect?: boolean;
+    tabindex?: number;
   }>();
 
   // mounting the menu items and their related dialogs is very
@@ -124,7 +126,7 @@
         @keydown.stop
         @pointerdown="activateMenu"
         @focus="activateMenu"
-        tabIndex="-1"
+        :tabindex
         :class="className"
       >
         <svg width="24" height="24" fill="none" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
The latest version of RAWeb improves performance by not loading the menu button contents until the user has started to interact with the menu button. However, in an oversight, I did not consider hovering or clicking on the connect button as an interaction that loads the menu. As a result, the connect action is not available.

This PR adds event listeners to the desktop card that triggers loading of the menu button contents whenever the desktop card is clicked or receives any focus within the card.

Fixes #304