### PR TITLE
ci: sign generated `.exe` and `.ps1` files

### DIFF
--- a/.github/actions/sign-exe/action.yaml
+++ b/.github/actions/sign-exe/action.yaml
@@ -1,0 +1,75 @@
+name: "Sign Windows executables"
+description: "Signs one or more .exe files with an Authenticode code-signing certificate using signtool.exe. Skips silently if no certificate is available (e.g. fork pull requests)."
+author: jackbuehner
+branding:
+  icon: "shield"
+  color: "green"
+
+inputs:
+  files:
+    description: "Newline-separated list of file paths or globs to sign"
+    required: true
+  certificate-base64:
+    description: "Base64-encoded .pfx certificate. If empty, signing is skipped."
+    required: false
+    default: ""
+  certificate-password:
+    description: "Password for the .pfx certificate"
+    required: false
+    default: ""
+  timestamp-url:
+    description: "RFC 3161 timestamp server URL"
+    required: false
+    default: "http://timestamp.digicert.com"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Sign files
+      if: ${{ inputs.certificate-base64 != '' }}
+      shell: pwsh
+      run: |
+        $certPath = Join-Path $env:RUNNER_TEMP "code-signing-cert-$([Guid]::NewGuid().ToString('N')).pfx"
+        [IO.File]::WriteAllBytes($certPath, [Convert]::FromBase64String("${{ inputs.certificate-base64 }}"))
+
+        try {
+          $signtool = Get-ChildItem -Path "${env:ProgramFiles(x86)}\Windows Kits\10\bin" -Recurse -Filter "signtool.exe" -ErrorAction Stop |
+            Where-Object { $_.FullName -match '\\x64\\' } |
+            Sort-Object FullName -Descending |
+            Select-Object -First 1 -ExpandProperty FullName
+
+          if (-not $signtool) {
+            throw "Could not locate signtool.exe under the Windows SDK installation."
+          }
+
+          $patterns = @"
+        ${{ inputs.files }}
+        "@ -split "`r?`n" | Where-Object { $_.Trim() -ne '' }
+
+          $resolved = @()
+          foreach ($pattern in $patterns) {
+            $matches = Get-ChildItem -Path $pattern.Trim() -File -ErrorAction SilentlyContinue
+            if (-not $matches) {
+              throw "No files matched pattern: $pattern"
+            }
+            $resolved += $matches
+          }
+
+          foreach ($file in $resolved) {
+            Write-Host "Signing $($file.FullName)"
+            & $signtool sign /f $certPath /p $env:CODE_SIGNING_CERT_PASSWORD /fd sha256 /tr "${{ inputs.timestamp-url }}" /td sha256 "$($file.FullName)"
+            if ($LASTEXITCODE -ne 0) {
+              throw "signtool failed to sign $($file.FullName)"
+            }
+          }
+        }
+        finally {
+          Remove-Item -Path $certPath -Force -ErrorAction SilentlyContinue
+        }
+      env:
+        CODE_SIGNING_CERT_PASSWORD: ${{ inputs.certificate-password }}
+
+    - name: Skip signing (no certificate configured)
+      if: ${{ inputs.certificate-base64 == '' }}
+      shell: pwsh
+      run: Write-Host "::notice::Skipping code signing. CODE_SIGNING_CERTIFICATE secret is not available in this context."

--- a/.github/actions/sign-exe/action.yaml
+++ b/.github/actions/sign-exe/action.yaml
@@ -1,5 +1,5 @@
-name: "Sign Windows executables"
-description: "Signs one or more .exe files with an Authenticode code-signing certificate using signtool.exe. Skips silently if no certificate is available (e.g. fork pull requests)."
+name: "Sign Windows executables and scripts"
+description: "Signs one or more .exe/.ps1 files with an Authenticode code-signing certificate using signtool.exe, then verifies the resulting signatures. Skips silently if no certificate is available (e.g. fork pull requests)."
 author: jackbuehner
 branding:
   icon: "shield"
@@ -31,6 +31,8 @@ runs:
       run: |
         $certPath = Join-Path $env:RUNNER_TEMP "code-signing-cert-$([Guid]::NewGuid().ToString('N')).pfx"
         [IO.File]::WriteAllBytes($certPath, [Convert]::FromBase64String("${{ inputs.certificate-base64 }}"))
+        $securePassword = ConvertTo-SecureString -String $env:CODE_SIGNING_CERT_PASSWORD -AsPlainText -Force
+        $importedCert = $null
 
         try {
           $signtool = Get-ChildItem -Path "${env:ProgramFiles(x86)}\Windows Kits\10\bin" -Recurse -Filter "signtool.exe" -ErrorAction Stop |
@@ -62,9 +64,25 @@ runs:
               throw "signtool failed to sign $($file.FullName)"
             }
           }
+
+          # trust the signing certificate as a root CA for this run only, so that
+          # chain validation below succeeds even when the certificate is self-signed
+          $importedCert = Import-PfxCertificate -FilePath $certPath -CertStoreLocation Cert:\LocalMachine\Root -Password $securePassword
+
+          Write-Host "Verifying signatures..."
+          foreach ($file in $resolved) {
+            $sig = Get-AuthenticodeSignature -FilePath $file.FullName
+            if ($sig.Status -ne 'Valid') {
+              throw "Signature verification failed for $($file.FullName): $($sig.Status) - $($sig.StatusMessage)"
+            }
+            Write-Host "Verified: $($file.FullName) (signed by $($sig.SignerCertificate.Subject))"
+          }
         }
         finally {
           Remove-Item -Path $certPath -Force -ErrorAction SilentlyContinue
+          if ($importedCert) {
+            Remove-Item -Path "Cert:\LocalMachine\Root\$($importedCert.Thumbprint)" -Force -ErrorAction SilentlyContinue
+          }
         }
       env:
         CODE_SIGNING_CERT_PASSWORD: ${{ inputs.certificate-password }}

--- a/.github/workflows/public.yaml
+++ b/.github/workflows/public.yaml
@@ -496,6 +496,13 @@ jobs:
             exit 1
           fi
 
+      - name: Sign server executables
+        uses: ./.github/actions/sign-exe
+        with:
+          files: dotnet/RAWeb.Server/dist/*.exe
+          certificate-base64: ${{ secrets.CODE_SIGNING_CERTIFICATE }}
+          certificate-password: ${{ secrets.CODE_SIGNING_CERTIFICATE_PASSWORD }}
+
       - name: Move repository setup.ps1 to dotnet/RAWeb.Server/dist so it is included in the release archive
         shell: bash
         run: |
@@ -602,6 +609,13 @@ jobs:
             exit 1
           }
           "path=$($installer.FullName)" >> $env:GITHUB_OUTPUT
+
+      - name: Sign installer executable
+        uses: ./.github/actions/sign-exe
+        with:
+          files: ${{ steps.find-installer.outputs.path }}
+          certificate-base64: ${{ secrets.CODE_SIGNING_CERTIFICATE }}
+          certificate-password: ${{ secrets.CODE_SIGNING_CERTIFICATE_PASSWORD }}
 
       - name: Upload installer
         uses: actions/upload-artifact@v7

--- a/.github/workflows/public.yaml
+++ b/.github/workflows/public.yaml
@@ -117,6 +117,7 @@ jobs:
             ${{ github.event_name == 'pull_request_target'
               && format('refs/pull/{0}/merge', github.event.pull_request.number)
               || github.ref }}
+          allow-unsafe-pr-checkout: ${{ github.event_name == 'pull_request_target' }}
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/public.yaml
+++ b/.github/workflows/public.yaml
@@ -519,6 +519,13 @@ jobs:
 
           sed -i "s|$find|$replace|g" "$file"
 
+      - name: Sign setup.ps1
+        uses: ./.github/actions/sign-exe
+        with:
+          files: dotnet/RAWeb.Server/dist/setup.ps1
+          certificate-base64: ${{ secrets.CODE_SIGNING_CERTIFICATE }}
+          certificate-password: ${{ secrets.CODE_SIGNING_CERTIFICATE_PASSWORD }}
+
       - name: Generate archive
         uses: thedoctor0/zip-release@0.7.5
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -202,6 +202,13 @@ jobs:
       - name: Build .NET solution (no embedded docs)
         run: dotnet publish RAWeb.Server.slnf --configuration Release --no-restore
 
+      - name: Sign server executables (no embedded docs)
+        uses: ./.github/actions/sign-exe
+        with:
+          files: dotnet/RAWeb.Server/dist/*.exe
+          certificate-base64: ${{ secrets.CODE_SIGNING_CERTIFICATE }}
+          certificate-password: ${{ secrets.CODE_SIGNING_CERTIFICATE_PASSWORD }}
+
       - name: Move repository setup.ps1 to dotnet/RAWeb.Server/dist so it is included in the release archive
         shell: bash
         run: |
@@ -253,6 +260,13 @@ jobs:
 
       - name: Build .NET solution
         run: dotnet publish RAWeb.Server.slnf --configuration Release --no-restore
+
+      - name: Sign server executables
+        uses: ./.github/actions/sign-exe
+        with:
+          files: dotnet/RAWeb.Server/dist/*.exe
+          certificate-base64: ${{ secrets.CODE_SIGNING_CERTIFICATE }}
+          certificate-password: ${{ secrets.CODE_SIGNING_CERTIFICATE_PASSWORD }}
 
       - name: Generate archive
         uses: thedoctor0/zip-release@0.7.5

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -225,6 +225,13 @@ jobs:
 
           sed -i "s|$find|$replace|g" "$file"
 
+      - name: Sign setup.ps1
+        uses: ./.github/actions/sign-exe
+        with:
+          files: dotnet/RAWeb.Server/dist/setup.ps1
+          certificate-base64: ${{ secrets.CODE_SIGNING_CERTIFICATE }}
+          certificate-password: ${{ secrets.CODE_SIGNING_CERTIFICATE_PASSWORD }}
+
       - name: Generate archive (no web connect) (no embedded docs)
         uses: thedoctor0/zip-release@0.7.5
         with:
@@ -456,6 +463,13 @@ jobs:
 
           Invoke-Expression "& { . ([ScriptBlock]::Create([System.Text.Encoding]::Unicode.GetString([System.Convert]::FromBase64String('${encodedScriptContent}')))) \$paramString }"
           EOF
+
+      - name: Sign install.ps1
+        uses: ./.github/actions/sign-exe
+        with:
+          files: install.ps1
+          certificate-base64: ${{ secrets.CODE_SIGNING_CERTIFICATE }}
+          certificate-password: ${{ secrets.CODE_SIGNING_CERTIFICATE_PASSWORD }}
 
       - name: Create draft release
         uses: ncipollo/release-action@v1

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.local.*
+cert.pfx
+cert.base64.txt

--- a/frontend/docs/(development)/code-signing/index.md
+++ b/frontend/docs/(development)/code-signing/index.md
@@ -1,0 +1,92 @@
+---
+title: Signing generated executables
+nav_title: Code signing
+---
+
+RAWeb's GitHub Actions workflows (`public.yaml` and `release.yaml`) automatically sign every `.exe` file produced by `dotnet publish` – `raweb.exe`, `rawebmgmtsvc.exe`, and the DesktopApp installer – using the [`sign-exe`](https://github.com/kimmknight/raweb/tree/master/.github/actions/sign-exe) composite action. Signing uses `signtool.exe` from the Windows SDK (already present on `windows-latest` runners) with a PFX certificate stored as a repository secret.
+
+<InfoBar title="Requires a maintainer with repo admin access" severity="caution">
+  Adding or changing the signing certificate requires access to the repository's Actions secrets. Only repository owners and constributors can do this.
+</InfoBar>
+
+## How it works
+
+Each publish step is followed by a step that calls the `sign-exe` action, passing it a glob of the `.exe` files to sign and the certificate secrets:
+
+```yaml
+- name: Sign server executables
+  uses: ./.github/actions/sign-exe
+  with:
+    files: dotnet/RAWeb.Server/dist/*.exe
+    certificate-base64: ${{ secrets.CODE_SIGNING_CERTIFICATE }}
+    certificate-password: ${{ secrets.CODE_SIGNING_CERTIFICATE_PASSWORD }}
+```
+
+The action decodes the base64 certificate to a temporary `.pfx` file, locates `signtool.exe` under the Windows Kits installation, signs each matching file with `signtool.exe`, and then deletes the temporary certificate file.
+
+If `CODE_SIGNING_CERTIFICATE` is not available, the action skips signing and logs a notice instead of failing the build. Pull requests from forks do not have access to secrets, so signing is skipped for those runs.
+
+## Required repository secrets
+
+| Secret                              | Description                                            |
+| ----------------------------------- | ------------------------------------------------------ |
+| `CODE_SIGNING_CERTIFICATE`          | The signing certificate's `.pfx` file, base64-encoded. |
+| `CODE_SIGNING_CERTIFICATE_PASSWORD` | The password used to export/protect the `.pfx` file.   |
+
+## Generating a code signing certificate
+
+Run the following script on a Windows machine with the Windows SDK installed (it ships with Visual Studio, or can be installed standalone). It uses `makecert.exe` and `pvk2pfx.exe` from the SDK to create a self-signed code signing certificate, and `certutil` to base64-encode the resulting `.pfx` for pasting into a GitHub secret.
+
+```powershell
+# Run this script on a Windows machine with the Windows SDK installed.
+# It will create a code-signing certificate.
+# This certificate is used in the GitHub Actions workflow to sign the Windows installer.
+
+# remove existing cert files
+Remove-Item -Path 'cert.pfx', 'cert.base64.txt' -ErrorAction SilentlyContinue
+
+$password = Read-Host -AsSecureString -Prompt "Enter certificate password"
+
+$cert = New-SelfSignedCertificate `
+  -Type CodeSigningCert `
+  -Subject "CN=Jack Buehner" `
+  -KeyExportPolicy Exportable `
+  -KeyLength 2048 `
+  -NotAfter (Get-Date "12/31/2099") `
+  -CertStoreLocation Cert:\CurrentUser\My
+
+Export-PfxCertificate `
+  -Cert $cert `
+  -FilePath "cert.pfx" `
+  -Password $password
+
+& certutil -encode cert.pfx cert.base64.txt
+```
+
+Replace `CN=Jack Buehner` with the publisher name you want to appear on the signature. `makecert.exe` will prompt you to set (and re-enter) a password to protect the private key.
+
+This produces four files: `cert.cer` (public certificate), `cert.pvk` (private key), `cert.pfx` (the combined certificate + key used for signing), and `cert.base64.txt` (the base64-encoded `.pfx`, ready to paste into `CODE_SIGNING_CERTIFICATE`).
+
+<InfoBar title="Keep the .pfx and its password safe" severity="warning">
+  Anyone with the .pfx file and its password can sign executables as RAWeb. Never commit `cert.pfx`, `cert.pvk`, or `cert.base64.txt` to the repository, and only share the certificate through the GitHub secrets UI described below. Delete these files once the secrets are saved.
+</InfoBar>
+
+## Adding the certificate to GitHub
+
+1. Copy the base64-encoded certificate to your clipboard. The `sign-exe` action expects plain base64 with no headers, so use `Convert`'s output directly rather than `cert.base64.txt` (which `certutil -encode` wraps in `-----BEGIN CERTIFICATE-----` / `-----END CERTIFICATE-----` lines):
+   ```powershell
+   [Convert]::ToBase64String([IO.File]::ReadAllBytes("cert.pfx")) | Set-Clipboard
+   ```
+2. In the repository, go to **Settings > Secrets and variables > Actions**.
+3. Click **New repository secret**, name it `CODE_SIGNING_CERTIFICATE`, and paste the base64 value from your clipboard.
+4. Click **New repository secret** again, name it `CODE_SIGNING_CERTIFICATE_PASSWORD`, and enter the password you set for `cert.pvk` when running `makecert.exe`.
+5. Delete the local `cert.pvk`, `cert.pfx`, `cert.cer`, and `cert.base64.txt` files and clear your clipboard once both secrets are saved.
+
+The next workflow run that publishes an `.exe` file will sign it automatically.
+
+## Replacing the certificate
+
+Certificates expire or may need to be reissued. To rotate:
+
+1. Obtain the new certificate and export it to a `.pfx` file as described above.
+2. Update the `CODE_SIGNING_CERTIFICATE` and `CODE_SIGNING_CERTIFICATE_PASSWORD` secrets with the new values.

--- a/frontend/docs/(development)/code-signing/index.md
+++ b/frontend/docs/(development)/code-signing/index.md
@@ -1,9 +1,9 @@
 ---
-title: Signing generated executables
+title: Signing generated executables and scripts
 nav_title: Code signing
 ---
 
-RAWeb's GitHub Actions workflows (`public.yaml` and `release.yaml`) automatically sign every `.exe` file produced by `dotnet publish` – `raweb.exe`, `rawebmgmtsvc.exe`, and the DesktopApp installer – using the [`sign-exe`](https://github.com/kimmknight/raweb/tree/master/.github/actions/sign-exe) composite action. Signing uses `signtool.exe` from the Windows SDK (already present on `windows-latest` runners) with a PFX certificate stored as a repository secret.
+RAWeb's GitHub Actions workflows (`public.yaml` and `release.yaml`) automatically sign every `.exe` and `.ps1` file they produce or ship – `raweb.exe`, `rawebmgmtsvc.exe`, the DesktopApp installer, `setup.ps1`, and the generated `install.ps1` bootstrap script – using the [`sign-exe`](https://github.com/kimmknight/raweb/tree/master/.github/actions/sign-exe) composite action. Signing uses `signtool.exe` from the Windows SDK (already present on `windows-latest` runners) with a PFX certificate stored as a repository secret.
 
 <InfoBar title="Requires a maintainer with repo admin access" severity="caution">
   Adding or changing the signing certificate requires access to the repository's Actions secrets. Only repository owners and constributors can do this.
@@ -11,7 +11,7 @@ RAWeb's GitHub Actions workflows (`public.yaml` and `release.yaml`) automaticall
 
 ## How it works
 
-Each publish step is followed by a step that calls the `sign-exe` action, passing it a glob of the `.exe` files to sign and the certificate secrets:
+Each publish step is followed by a step that calls the `sign-exe` action, passing it a glob (or list) of the files to sign and the certificate secrets:
 
 ```yaml
 - name: Sign server executables
@@ -22,7 +22,9 @@ Each publish step is followed by a step that calls the `sign-exe` action, passin
     certificate-password: ${{ secrets.CODE_SIGNING_CERTIFICATE_PASSWORD }}
 ```
 
-The action decodes the base64 certificate to a temporary `.pfx` file, locates `signtool.exe` under the Windows Kits installation, signs each matching file with `signtool.exe`, and then deletes the temporary certificate file.
+The action decodes the base64 certificate to a temporary `.pfx` file, locates `signtool.exe` under the Windows Kits installation, and signs each matching file with `signtool.exe`.
+
+After signing, the action imports the certificate into the runner's local `Cert:\LocalMachine\Root` store (removed again in a `finally` block) and re-checks every signed file with `Get-AuthenticodeSignature`, failing the step if any file's signature status isn't `Valid`. This catches a bad or expired certificate, a `signtool` failure that didn't surface as a non-zero exit code, or a file type `signtool` silently failed to sign.
 
 If `CODE_SIGNING_CERTIFICATE` is not available, the action skips signing and logs a notice instead of failing the build. Pull requests from forks do not have access to secrets, so signing is skipped for those runs.
 
@@ -68,7 +70,7 @@ Replace `CN=Jack Buehner` with the publisher name you want to appear on the sign
 This produces four files: `cert.cer` (public certificate), `cert.pvk` (private key), `cert.pfx` (the combined certificate + key used for signing), and `cert.base64.txt` (the base64-encoded `.pfx`, ready to paste into `CODE_SIGNING_CERTIFICATE`).
 
 <InfoBar title="Keep the .pfx and its password safe" severity="warning">
-  Anyone with the .pfx file and its password can sign executables as RAWeb. Never commit `cert.pfx`, `cert.pvk`, or `cert.base64.txt` to the repository, and only share the certificate through the GitHub secrets UI described below. Delete these files once the secrets are saved.
+  Anyone with the .pfx file and its password can sign executables and scripts as RAWeb. Never commit `cert.pfx`, `cert.pvk`, or `cert.base64.txt` to the repository, and only share the certificate through the GitHub secrets UI described below. Delete these files once the secrets are saved.
 </InfoBar>
 
 ## Adding the certificate to GitHub
@@ -82,7 +84,7 @@ This produces four files: `cert.cer` (public certificate), `cert.pvk` (private k
 4. Click **New repository secret** again, name it `CODE_SIGNING_CERTIFICATE_PASSWORD`, and enter the password you set for `cert.pvk` when running `makecert.exe`.
 5. Delete the local `cert.pvk`, `cert.pfx`, `cert.cer`, and `cert.base64.txt` files and clear your clipboard once both secrets are saved.
 
-The next workflow run that publishes an `.exe` file will sign it automatically.
+The next workflow run that publishes an `.exe` or `.ps1` file will sign it automatically.
 
 ## Replacing the certificate
 


### PR DESCRIPTION
Currently, generated exe and ps1 files are unsigned. Some antivirus tools flag any exe file that is unsigned.

This PR signs the generated and edited exe and ps1 files (raweb.exe, rawebmgmtsvc.exe, install.ps1, and setup.ps1).

Since code signing certificates are quite expensive, and I do not want to pay a recurring cost for them, we are using a self-signed certificate stored in the repository's secrets. Only owners and collaborators (users who can directly push, merge, etc.) can see the secrets.

At some point in the future, we might be eligible for [signpath.org](https://signpath.org/) instead of being forced to use a self-signed certificate.

Closes #306.