### PR TITLE
Improve performance of available system apps discovery

### DIFF
--- a/dotnet/RAWeb.Server.Management/src/InstalledApps.cs
+++ b/dotnet/RAWeb.Server.Management/src/InstalledApps.cs
@@ -33,12 +33,18 @@ public class InstalledApp(string path, string displayName, string displayFolder,
   /// <param name="shortcutFilePath"></param>
   /// <param name="programsPath"></param>
   /// <returns></returns>
-  public static InstalledApp? FromShortcut(string shortcutFilePath, string programsPath) {
+  public static InstalledApp? FromShortcut(string shortcutFilePath, string programsPath, Dictionary<string, string>? displayNameCache = null) {
 
     // extract the shortcut name, which may be different than the .lnk file name
     string? shortcutName = null;
     try {
-      shortcutName = GetFileOrFolderDisplayName(shortcutFilePath);
+      if (displayNameCache is not null && displayNameCache.TryGetValue(shortcutFilePath, out var cachedDisplayName)) {
+        shortcutName = cachedDisplayName;
+      }
+      else {
+        shortcutName = GetFileOrFolderDisplayName(shortcutFilePath);
+        displayNameCache?[shortcutFilePath] = shortcutName ?? "";
+      }
     }
     catch { }
     shortcutName ??= System.IO.Path.GetFileNameWithoutExtension(shortcutFilePath);
@@ -49,9 +55,15 @@ public class InstalledApp(string path, string displayName, string displayFolder,
     var folderName = folderParts.LastOrDefault() ?? "";
     if (folderPath is not null && !string.IsNullOrWhiteSpace(folderPath) && folderPath != programsPath) {
       try {
-        var resolvedFolderName = GetFileOrFolderDisplayName(folderPath);
-        if (!string.IsNullOrWhiteSpace(resolvedFolderName)) {
-          folderName = resolvedFolderName;
+        if (displayNameCache is not null && displayNameCache.TryGetValue(folderPath, out var cachedFolderDisplayName)) {
+          folderName = cachedFolderDisplayName;
+        }
+        else {
+          var resolvedFolderName = GetFileOrFolderDisplayName(folderPath);
+          if (!string.IsNullOrWhiteSpace(resolvedFolderName)) {
+            folderName = resolvedFolderName;
+            displayNameCache?[folderPath] = folderName;
+          }
         }
       }
       catch { }
@@ -275,14 +287,14 @@ public class InstalledApps : System.Collections.ObjectModel.Collection<Installed
   /// </summary>
   /// <param name="folderPath"></param>
   /// <returns></returns>
-  private static InstalledApps FromShortcutsInFolder(string folderPath) {
+  private static InstalledApps FromShortcutsInFolder(string folderPath, Dictionary<string, string>? displayNameCache = null) {
     var foundApps = new InstalledApps();
 
     var shortcutFiles = Directory.GetFiles(folderPath, "*.lnk", SearchOption.AllDirectories);
     var seen = new HashSet<string>();
     foreach (var shortcutFilePath in shortcutFiles) {
       try {
-        var installedApp = InstalledApp.FromShortcut(shortcutFilePath, folderPath);
+        var installedApp = InstalledApp.FromShortcut(shortcutFilePath, folderPath, displayNameCache);
 
         if (installedApp is null) {
           continue;
@@ -330,10 +342,11 @@ public class InstalledApps : System.Collections.ObjectModel.Collection<Installed
   /// <see cref="FromStartMenu(SecurityIdentifier)"/>.
   /// </summary>
   /// <returns></returns>
-  public static InstalledApps FromStartMenu() {
+  public static InstalledApps FromStartMenu(Dictionary<string, string>? displayNameCache = null) {
     // get the applications from the common Start Menu
     var programsPath = Environment.GetFolderPath(Environment.SpecialFolder.CommonStartMenu) + @"\Programs";
-    var programs = FromShortcutsInFolder(programsPath);
+    displayNameCache ??= new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+    var programs = FromShortcutsInFolder(programsPath, displayNameCache);
 
     FlattenSingleItemFolders(programs);
 
@@ -351,7 +364,7 @@ public class InstalledApps : System.Collections.ObjectModel.Collection<Installed
   /// </summary>
   /// <param name="userSid"></param>
   /// <returns></returns>
-  public static InstalledApps FromStartMenu(SecurityIdentifier userSid, SystemUserProfile? userProfile = null) {
+  public static InstalledApps FromStartMenu(SecurityIdentifier userSid, SystemUserProfile? userProfile = null, Dictionary<string, string>? displayNameCache = null) {
     ElevatedPrivileges.Require();
 
     if (userProfile is null) {
@@ -365,7 +378,8 @@ public class InstalledApps : System.Collections.ObjectModel.Collection<Installed
 
     // get the applications from the user's Start Menu
     var startMenuPath = Path.Combine(userProfile.ProfilePath, @"AppData\Roaming\Microsoft\Windows\Start Menu\Programs");
-    var programs = FromShortcutsInFolder(startMenuPath);
+    displayNameCache ??= new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+    var programs = FromShortcutsInFolder(startMenuPath, displayNameCache);
     FlattenSingleItemFolders(programs);
     return programs;
   }

--- a/dotnet/RAWeb.Server.Management/src/InstalledApps.cs
+++ b/dotnet/RAWeb.Server.Management/src/InstalledApps.cs
@@ -474,57 +474,57 @@ public class InstalledApps : System.Collections.ObjectModel.Collection<Installed
           }
         }
       }
+    }
 
-      // scan for system apps
-      var systemAppsPath = @"C:\Windows\SystemApps";
-      var systemAppsAppxManifests = Directory.GetFiles(systemAppsPath, "AppxManifest.xml", SearchOption.AllDirectories);
-      foreach (var manifestFilePath in systemAppsAppxManifests) {
-        var result = LoadPackageOrBundleManifestXml(manifestFilePath);
-        if (result is not null) {
-          var (manifestXml, type, folder) = result.Value;
-          if (type != PackageOrBundleType.Package) {
-            continue;
-          }
-
-          var packageBaseName = Path.GetFileName(folder).Split('_').FirstOrDefault();
-          if (string.IsNullOrWhiteSpace(packageBaseName) || seenPackages.Contains(packageBaseName)) {
-            continue;
-          }
-
-          var publisherHash = Path.GetFileName(folder).Split('_').LastOrDefault() ?? "";
-          if (string.IsNullOrWhiteSpace(publisherHash)) {
-            continue;
-          }
-
-          yield return (manifestXml, folder, new PublisherHash(publisherHash));
-          seenPackages.Add(packageBaseName ?? "");
+    // scan for system apps
+    var systemAppsPath = @"C:\Windows\SystemApps";
+    var systemAppsAppxManifests = Directory.GetFiles(systemAppsPath, "AppxManifest.xml", SearchOption.AllDirectories);
+    foreach (var manifestFilePath in systemAppsAppxManifests) {
+      var result = LoadPackageOrBundleManifestXml(manifestFilePath);
+      if (result is not null) {
+        var (manifestXml, type, folder) = result.Value;
+        if (type != PackageOrBundleType.Package) {
+          continue;
         }
+
+        var packageBaseName = Path.GetFileName(folder).Split('_').FirstOrDefault();
+        if (string.IsNullOrWhiteSpace(packageBaseName) || seenPackages.Contains(packageBaseName)) {
+          continue;
+        }
+
+        var publisherHash = Path.GetFileName(folder).Split('_').LastOrDefault() ?? "";
+        if (string.IsNullOrWhiteSpace(publisherHash)) {
+          continue;
+        }
+
+        yield return (manifestXml, folder, new PublisherHash(publisherHash));
+        seenPackages.Add(packageBaseName ?? "");
       }
+    }
 
-      // scan for all other apps in WindowsApps
-      var windowsAppsPath = @"C:\Program Files\WindowsApps";
-      var windowsAppsAppxManifests = Directory.GetFiles(windowsAppsPath, "AppxManifest.xml", SearchOption.AllDirectories);
-      foreach (var manifestFilePath in windowsAppsAppxManifests) {
-        var result = LoadPackageOrBundleManifestXml(manifestFilePath);
-        if (result is not null) {
-          var (manifestXml, type, folder) = result.Value;
-          if (type != PackageOrBundleType.Package) {
-            continue;
-          }
-
-          var packageBaseName = Path.GetFileName(folder).Split('_').FirstOrDefault();
-          if (string.IsNullOrWhiteSpace(packageBaseName) || seenPackages.Contains(packageBaseName)) {
-            continue;
-          }
-
-          var publisherHash = Path.GetFileName(folder).Split('_').LastOrDefault() ?? "";
-          if (string.IsNullOrWhiteSpace(publisherHash)) {
-            continue;
-          }
-
-          yield return (manifestXml, folder, new PublisherHash(publisherHash));
-          seenPackages.Add(packageBaseName ?? "");
+    // scan for all other apps in WindowsApps
+    var windowsAppsPath = @"C:\Program Files\WindowsApps";
+    var windowsAppsAppxManifests = Directory.GetFiles(windowsAppsPath, "AppxManifest.xml", SearchOption.AllDirectories);
+    foreach (var manifestFilePath in windowsAppsAppxManifests) {
+      var result = LoadPackageOrBundleManifestXml(manifestFilePath);
+      if (result is not null) {
+        var (manifestXml, type, folder) = result.Value;
+        if (type != PackageOrBundleType.Package) {
+          continue;
         }
+
+        var packageBaseName = Path.GetFileName(folder).Split('_').FirstOrDefault();
+        if (string.IsNullOrWhiteSpace(packageBaseName) || seenPackages.Contains(packageBaseName)) {
+          continue;
+        }
+
+        var publisherHash = Path.GetFileName(folder).Split('_').LastOrDefault() ?? "";
+        if (string.IsNullOrWhiteSpace(publisherHash)) {
+          continue;
+        }
+
+        yield return (manifestXml, folder, new PublisherHash(publisherHash));
+        seenPackages.Add(packageBaseName ?? "");
       }
     }
   }

--- a/dotnet/RAWeb.Server.Management/src/InstalledApps.cs
+++ b/dotnet/RAWeb.Server.Management/src/InstalledApps.cs
@@ -335,6 +335,46 @@ public class InstalledApps : System.Collections.ObjectModel.Collection<Installed
     var programsPath = Environment.GetFolderPath(Environment.SpecialFolder.CommonStartMenu) + @"\Programs";
     var programs = FromShortcutsInFolder(programsPath);
 
+    FlattenSingleItemFolders(programs);
+
+    return programs;
+  }
+
+  /// <summary>
+  /// Gets a collection of installed applications for a specific user based on their
+  /// Start Menu entries and installed AppX/MSIX packages.
+  /// <br /><br />
+  /// If a user profile cannot be found for the specified SID, an empty collection is returned.
+  /// <br /><br />
+  /// To get installed applications for the system, use
+  /// <see cref="FromStartMenu()"/>.
+  /// </summary>
+  /// <param name="userSid"></param>
+  /// <returns></returns>
+  public static InstalledApps FromStartMenu(SecurityIdentifier userSid, SystemUserProfile? userProfile = null) {
+    ElevatedPrivileges.Require();
+
+    if (userProfile is null) {
+      // verify that the user profile exists
+      var userProfiles = new SystemUserProfiles();
+      userProfile = userProfiles.FirstOrDefault(up => up.Sid.Equals(userSid));
+    }
+    if (userProfile is null) {
+      return [];
+    }
+
+    // get the applications from the user's Start Menu
+    var startMenuPath = Path.Combine(userProfile.ProfilePath, @"AppData\Roaming\Microsoft\Windows\Start Menu\Programs");
+    var programs = FromShortcutsInFolder(startMenuPath);
+    FlattenSingleItemFolders(programs);
+    return programs;
+  }
+
+  /// <summary>
+  /// Promotes apps out of any DisplayFolder that contains only a single app and no
+  /// nested folders with other apps.
+  /// </summary>
+  private static void FlattenSingleItemFolders(InstalledApps programs) {
     bool changed;
     do {
       changed = false;
@@ -372,36 +412,6 @@ public class InstalledApps : System.Collections.ObjectModel.Collection<Installed
 
       }
     } while (changed); // Repeat until no more single-item folders can be flattened
-
-    return programs;
-  }
-
-  /// <summary>
-  /// Gets a collection of installed applications for a specific user based on their
-  /// Start Menu entries and installed AppX/MSIX packages.
-  /// <br /><br />
-  /// If a user profile cannot be found for the specified SID, an empty collection is returned.
-  /// <br /><br />
-  /// To get installed applications for the system, use
-  /// <see cref="FromStartMenu()"/>.
-  /// </summary>
-  /// <param name="userSid"></param>
-  /// <returns></returns>
-  public static InstalledApps FromStartMenu(SecurityIdentifier userSid, SystemUserProfile? userProfile = null) {
-    ElevatedPrivileges.Require();
-
-    if (userProfile is null) {
-      // verify that the user profile exists
-      var userProfiles = new SystemUserProfiles();
-      userProfile = userProfiles.FirstOrDefault(up => up.Sid.Equals(userSid));
-    }
-    if (userProfile is null) {
-      return [];
-    }
-
-    // get the applications from the user's Start Menu
-    var startMenuPath = Path.Combine(userProfile.ProfilePath, @"AppData\Roaming\Microsoft\Windows\Start Menu\Programs");
-    return FromShortcutsInFolder(startMenuPath);
   }
 
   enum PackageOrBundleType {

--- a/dotnet/RAWeb.Server.Management/src/InstalledApps.cs
+++ b/dotnet/RAWeb.Server.Management/src/InstalledApps.cs
@@ -478,7 +478,10 @@ public class InstalledApps : System.Collections.ObjectModel.Collection<Installed
 
     // scan for system apps
     var systemAppsPath = @"C:\Windows\SystemApps";
-    var systemAppsAppxManifests = Directory.GetFiles(systemAppsPath, "AppxManifest.xml", SearchOption.AllDirectories);
+    var systemAppsAppxManifests = Directory
+      .GetDirectories(systemAppsPath)
+      .SelectMany(childDir => Directory.GetFiles(childDir, "AppxManifest.xml", SearchOption.TopDirectoryOnly))
+      .ToArray();
     foreach (var manifestFilePath in systemAppsAppxManifests) {
       var result = LoadPackageOrBundleManifestXml(manifestFilePath);
       if (result is not null) {
@@ -504,7 +507,10 @@ public class InstalledApps : System.Collections.ObjectModel.Collection<Installed
 
     // scan for all other apps in WindowsApps
     var windowsAppsPath = @"C:\Program Files\WindowsApps";
-    var windowsAppsAppxManifests = Directory.GetFiles(windowsAppsPath, "AppxManifest.xml", SearchOption.AllDirectories);
+    var windowsAppsAppxManifests = Directory
+      .GetDirectories(windowsAppsPath)
+      .SelectMany(childDir => Directory.GetFiles(childDir, "AppxManifest.xml", SearchOption.TopDirectoryOnly))
+      .ToArray();
     foreach (var manifestFilePath in windowsAppsAppxManifests) {
       var result = LoadPackageOrBundleManifestXml(manifestFilePath);
       if (result is not null) {
@@ -600,6 +606,72 @@ public class InstalledApps : System.Collections.ObjectModel.Collection<Installed
   }
 
   /// <summary>
+  /// Resolves the best icon path from a directory and a relative icon path.
+  /// <br /><br />
+  /// The best icon path is determined by finding the largest scale version of the icon in the directory.
+  /// <br /><br />
+  /// If the relative icon path does not exist in the specified directory, this method
+  /// will search for the folder structure somewhere in the package directory until it
+  /// finds an icon or runs out of folders to search.
+  /// </summary>
+  private static string? ResolveBestIconPath(string? packageDir, string relativeIconPath, Dictionary<string, string[]> directoryListingCache) {
+    if (packageDir is null || !Path.Exists(packageDir)) {
+      return null;
+    }
+
+    var relativeIconDir = Path.GetDirectoryName(relativeIconPath) ?? "";
+    var rootedIconDir = Path.GetFullPath(Path.Combine(packageDir, relativeIconDir));
+
+    if (Path.Exists(rootedIconDir)) {
+      // list the directory once and reuse it for every icon/logo lookup that
+      // shares the same folder (a package's app icon and its file-type-association
+      // logos are usually all in the same Assets folder)
+      if (!directoryListingCache.TryGetValue(rootedIconDir, out var filesInDir)) {
+        filesInDir = Directory.GetFiles(rootedIconDir, "*", SearchOption.TopDirectoryOnly);
+        directoryListingCache[rootedIconDir] = filesInDir;
+      }
+
+      // find all matching icon files
+      var iconStem = Path.GetFileNameWithoutExtension(relativeIconPath);
+      var iconExtension = Path.GetExtension(relativeIconPath);
+      var matches = filesInDir.Where(path => {
+        var fileName = Path.GetFileName(path);
+        return fileName.StartsWith(iconStem, StringComparison.OrdinalIgnoreCase)
+          && fileName.EndsWith(iconExtension, StringComparison.OrdinalIgnoreCase);
+      });
+
+      // get the largest scale version of the icon
+      var bestMatch = matches
+        .Select(path => new {
+          Path = path,
+          Scale = InterpretAssetScale(path)
+        })
+        .OrderByDescending(x => x.Scale)
+        .FirstOrDefault()?.Path;
+
+      return bestMatch;
+    }
+
+    // when the manifest specifies a relative path that does not exist,
+    // we must search for the folder structure somewhere in the package
+    // directory until we find an icon or run out of folders to search
+    foreach (var potentialMatch in Directory.EnumerateDirectories(packageDir, relativeIconDir, SearchOption.AllDirectories)) {
+
+      var correctedRelativeIconDir = Path.GetRelativePath(packageDir, potentialMatch);
+      var correctedRelativeIconPath = Path.Combine(correctedRelativeIconDir, Path.GetFileName(relativeIconPath));
+
+      var iconPath = ResolveBestIconPath(potentialMatch, Path.GetFileName(relativeIconPath), directoryListingCache);
+      if (iconPath is not null) {
+        return iconPath;
+      }
+    }
+
+    // we could not find a matching icon file in the package directory
+    return null;
+
+  }
+
+  /// <summary>
   /// Gets a collection of installed app packages based on the Registry entries
   /// in AppxAllUserStore and the packages discovered in the WindowsApps and SystemApps folders.
   /// </summary>
@@ -609,6 +681,9 @@ public class InstalledApps : System.Collections.ObjectModel.Collection<Installed
     var installedApps = new InstalledApps();
 
     foreach (var (manifestXml, packageDir, publisherHash) in GetAppPackageManifests()) {
+      // a cache for directory file listings so we do not need to ever scan a directory more than once for icon lookups
+      var directoryListingCache = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase);
+
       // ensure the Package element exists
       if (manifestXml.Root is null || manifestXml.Root.Name.LocalName != "Package") {
         continue;
@@ -703,22 +778,7 @@ public class InstalledApps : System.Collections.ObjectModel.Collection<Installed
         // attempt to find the largest scale version of the icon in the package folder
         string? iconPath = null;
         if (!string.IsNullOrWhiteSpace(relativeIconPath)) {
-
-          // find all matching icon files 
-          var matches = Directory.GetFiles(packageDir, $"{Path.GetFileNameWithoutExtension(relativeIconPath)}*{Path.GetExtension(relativeIconPath)}", SearchOption.AllDirectories);
-
-          // get the largest scale version of the icon
-          var bestMatch = matches
-            .Select(path => new {
-              Path = path,
-              Scale = InterpretAssetScale(path)
-            })
-            .OrderByDescending(x => x.Scale)
-            .FirstOrDefault()?.Path;
-
-          if (bestMatch is not null) {
-            iconPath = bestMatch;
-          }
+          iconPath = ResolveBestIconPath(packageDir, relativeIconPath, directoryListingCache);
         }
 
         // search for file type associations
@@ -733,22 +793,7 @@ public class InstalledApps : System.Collections.ObjectModel.Collection<Installed
           var relativeLogoPath = element.Elements().Where(elem => elem.Name.LocalName == "Logo").FirstOrDefault()?.Value;
           string? logoPath = null;
           if (!string.IsNullOrWhiteSpace(relativeLogoPath)) {
-
-            // find all matching icon files 
-            var matches = Directory.GetFiles(packageDir, $"{Path.GetFileNameWithoutExtension(relativeLogoPath)}*{Path.GetExtension(relativeLogoPath)}", SearchOption.AllDirectories);
-
-            // get the largest scale version of the icon
-            var bestMatch = matches
-              .Select(path => new {
-                Path = path,
-                Scale = InterpretAssetScale(path)
-              })
-              .OrderByDescending(x => x.Scale)
-              .FirstOrDefault()?.Path;
-
-            if (bestMatch is not null) {
-              logoPath = bestMatch;
-            }
+            logoPath = ResolveBestIconPath(packageDir, relativeLogoPath, directoryListingCache);
           }
 
           // list the supported file types (.ext1, .ext2, etc.)


### PR DESCRIPTION
RAWeb provides a GET endpoint at `/api/management/resources/available` that returns a list of all packaged apps on the system combined with a list of apps included in the Start Menu. Before this PR, RAWeb scanned more directories than necessary and also performed duplicate operations.

With this change, performance is significantly improved (now less than 1 second for 100 apps). The endpoint is now 10x faster for first loads (down to 0.75s from 7.5s on my machine) and 3.5x faster for subsequent loads (down from 2.3s to 0.65s on my machine). Performance improvements will stand out more on systems with more apps. RAWeb reports 106 available apps on my test machine.

<!-- DEPLOY-PREVIEW-COMMENT -->
<!-- DO NOT EDIT THIS HTML CONTENT -->
<div width="100%">
<table width="100%">
  <thead>
    <tr>
      <th colspan="3" align="left" valign="middle">Deployment status</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td valign="middle">RAWeb<br/><i>server</i></td>
      <td valign="middle"><!--STATUS:SERVER-->✅ Success<!--/STATUS:SERVER--></td>
      <td align="right" valign="middle">
        <!--BUTTON:SERVER--><a href="https://install.raweb.app/preview/jackbuehner/available-apps-scan-optimization" rel="nofollow"><picture><source media="(prefers-color-scheme: dark)" srcset="https://install.raweb.app/buttons/install-this-developer-build-primary-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://install.raweb.app/buttons/install-this-developer-build-primary-light.svg"><img src="https://install.raweb.app/buttons/install-this-developer-build-primary-light.svg" alt="install-this-developer-build-primary" height="32"></picture></a><!--/BUTTON:SERVER-->
        <!--LOGS:SERVER--><a href="https://github.com/kimmknight/raweb/actions/runs/33987571542" rel="nofollow"><picture><source media="(prefers-color-scheme: dark)" srcset="https://install.raweb.app/buttons/view-logs-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://install.raweb.app/buttons/view-logs-light.svg"><img src="https://install.raweb.app/buttons/view-logs-light.svg" alt="view-logs" height="32"></picture></a><!--/LOGS:SERVER-->
      </td>
    </tr>
    <tr>
      <td valign="middle">RemoteApps &amp; Devices<br/><i>web app</i></td>
      <td valign="middle"><!--STATUS:WEBAPP-->🟡 Waiting for runner<!--/STATUS:WEBAPP--></td>
      <td align="right" valign="middle">
        <!--BUTTON:WEBAPP--><!--/BUTTON:WEBAPP-->
        <!--LOGS:WEBAPP--><!--/LOGS:WEBAPP-->
      </td>
    </tr>
    <tr>
      <td valign="middle">RemoteApps &amp; Devices<br/><i>desktop app</i></td>
      <td valign="middle"><!--STATUS:DESKTOP-->✅ Success<!--/STATUS:DESKTOP--></td>
      <td align="right" valign="middle">
        <!--BUTTON:DESKTOP--><a href="https://github.com/kimmknight/raweb/actions/runs/33987571542/artifacts/9975699930" rel="nofollow"><picture><source media="(prefers-color-scheme: dark)" srcset="https://install.raweb.app/buttons/install-this-developer-build-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://install.raweb.app/buttons/install-this-developer-build-light.svg"><img src="https://install.raweb.app/buttons/install-this-developer-build-light.svg" alt="install-this-developer-build" height="32"></picture></a><!--/BUTTON:DESKTOP-->
        <!--LOGS:DESKTOP--><a href="https://github.com/kimmknight/raweb/actions/runs/33987571542" rel="nofollow"><picture><source media="(prefers-color-scheme: dark)" srcset="https://install.raweb.app/buttons/view-logs-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://install.raweb.app/buttons/view-logs-light.svg"><img src="https://install.raweb.app/buttons/view-logs-light.svg" alt="view-logs" height="32"></picture></a><!--/LOGS:DESKTOP-->
      </td>
    </tr>
  </tbody>
</table>
</div>
<!-- /DEPLOY-PREVIEW-COMMENT -->